### PR TITLE
Add additional test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@
 #
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-all:
+test:
 	go test ./...
 generate:
 	cd ${ROOT_DIR}/demo/getting_started && go generate
-
+clean:
+	rm -f ${ROOT_DIR}/demo/getting_started/pkg/ocdemo/oc.go
+all:
+	clean generate test

--- a/demo/getting_started/interfaces_test.go
+++ b/demo/getting_started/interfaces_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+
+	"github.com/openconfig/ygot/ygen"
+)
+
+// Simple test case that ensures that the end-to-end ygot pipeline works
+// correctly. This is a smoke-test for the ygot package.
+
+// The path to this directory within the test package.
+var TestRoot string
+
+func TestGenerateCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		inConfig *ygen.GeneratorConfig
+		inFiles  []string
+		inPaths  []string
+	}{{
+		name: "openconfig interfaces",
+		inConfig: &ygen.GeneratorConfig{
+			CompressOCPaths:    true,
+			ExcludeModules:     []string{"ietf-interfaces"},
+			GenerateFakeRoot:   true,
+			GenerateJSONSchema: true,
+		},
+		inFiles: []string{
+			filepath.Join(TestRoot, "yang", "openconfig-interfaces.yang"),
+			filepath.Join(TestRoot, "yang", "openconfig-if-ip.yang"),
+		},
+		inPaths: []string{filepath.Join(TestRoot, "yang")},
+	}, {
+		name: "openconfig interfaces with no compression",
+		inConfig: &ygen.GeneratorConfig{
+			CompressOCPaths:    false,
+			ExcludeModules:     []string{"ietf-interfaces"},
+			GenerateFakeRoot:   true,
+			GenerateJSONSchema: true,
+		},
+		inFiles: []string{
+			filepath.Join(TestRoot, "yang", "openconfig-interfaces.yang"),
+			filepath.Join(TestRoot, "yang", "openconfig-if-ip.yang"),
+		},
+		inPaths: []string{filepath.Join(TestRoot, "yang")},
+	}}
+
+	for _, tt := range tests {
+		cg := ygen.NewYANGCodeGenerator(tt.inConfig)
+		got, err := cg.GenerateGoCode(tt.inFiles, tt.inPaths)
+		if err != nil {
+			t.Errorf("%s: GenerateGoCode(%v, %v): Config: %v, got unexpected error: %v", tt.name, tt.inFiles, tt.inPaths, tt.inConfig, err)
+			continue
+		}
+
+		var b bytes.Buffer
+		fmt.Fprintf(&b, got.Header)
+		for _, s := range got.Structs {
+			fmt.Fprintf(&b, s)
+		}
+
+		for _, e := range got.Enums {
+			fmt.Fprintf(&b, e)
+		}
+
+		fmt.Fprintf(&b, got.EnumMap)
+		fmt.Fprintf(&b, got.JSONSchemaCode)
+
+		// Parse the generated code using the Go parser and check whether any errors
+		// are returned.
+		fset := token.NewFileSet()
+		if _, err := parser.ParseFile(fset, "", b.String(), parser.AllErrors); err != nil {
+			t.Errorf("%s: could not parse generated Go code: %v\n\n%s", tt.name, err, b.String())
+		}
+	}
+}

--- a/ygen/commongen.go
+++ b/ygen/commongen.go
@@ -52,6 +52,11 @@ func buildCommonHeader(packageName, caller string, compressPaths bool, yangFiles
 		currentCodeFile = "codegen"
 	}
 
+	// Handle the case of a null package name which produces invalid Go.
+	if packageName == "" {
+		packageName = "ocstructs"
+	}
+
 	return &commonCodeHeaderParams{
 		PackageName:      packageName,
 		YANGFiles:        yangFiles,


### PR DESCRIPTION
This change adds support for a smoke test for ygot that ensures the end-to-end generation pipeline is creating parsable code.

```
 * (M) Makefile
   - Make sure that go generate is called for make all, add make
     clean.
 * (M) demo/getting_started/interfaces_test.go
   - Add a smoke test for OpenConfig model generation using the Go
     parser.
```