### PR TITLE
Make error message for mismatched list keys clearer.

### DIFF
--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -122,7 +122,7 @@ func checkBasicKeyValue(structElems reflect.Value, keyFieldSchemaName string, ke
 		elementKeyValue = structElems.FieldByName(keyFieldName).Interface()
 	}
 	if elementKeyValue != keyValue.Interface() {
-		errors = appendErr(errors, fmt.Errorf("key field %s: element key %v != map key %v",
+		errors = appendErr(errors, fmt.Errorf("key value for field %s in list member (%v) is not equal to the key used in the map (%v)",
 			keyFieldName, elementKeyValue, keyValue))
 	}
 


### PR DESCRIPTION
```
  * (M) ytypes/list.go
    - When the key used within a map was not equal to the YANG list's
      field that specified the key, the error message was slightly
      cryptic. Fix this based on user bug.
```