### PR TITLE
Fix govet issues in the generated code.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -50,22 +50,22 @@ var (
 // The output includes a package header which is generated.
 func writeGoCode(w io.Writer, goCode *ygen.GeneratedGoCode) error {
 	// Write the package header to the supplier writer.
-	fmt.Fprintf(w, goCode.Header)
+	fmt.Fprint(w, goCode.Header)
 
 	// Write the returned Go code out. First the Structs - which is the struct
 	// definitions for the generated YANG entity, followed by the enumerations.
 	for _, codeSnippets := range [][]string{goCode.Structs, goCode.Enums} {
 		for _, snippet := range codeSnippets {
-			fmt.Fprintf(w, "%s\n", snippet)
+			fmt.Fprintln(w, snippet)
 		}
 	}
 
 	// Write the generated enumeration map out.
-	fmt.Fprintf(w, "%s\n", goCode.EnumMap)
+	fmt.Fprintln(w, goCode.EnumMap)
 
 	// Write the schema out if it was received.
 	if len(goCode.JSONSchemaCode) > 0 {
-		fmt.Fprintf(w, "%s\n", goCode.JSONSchemaCode)
+		fmt.Fprintln(w, goCode.JSONSchemaCode)
 	}
 
 	return nil

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -524,19 +524,19 @@ func TestSimpleStructs(t *testing.T) {
 		var gotCode bytes.Buffer
 		fmt.Fprint(&gotCode, gotGeneratedCode.Header)
 		for _, gotStruct := range gotGeneratedCode.Structs {
-			fmt.Fprintf(&gotCode, gotStruct)
+			fmt.Fprint(&gotCode, gotStruct)
 		}
 
 		for _, gotEnum := range gotGeneratedCode.Enums {
-			fmt.Fprintf(&gotCode, gotEnum)
+			fmt.Fprint(&gotCode, gotEnum)
 		}
 
 		// Write generated enumeration map out.
-		fmt.Fprintf(&gotCode, gotGeneratedCode.EnumMap)
+		fmt.Fprint(&gotCode, gotGeneratedCode.EnumMap)
 
 		if tt.inConfig.GenerateJSONSchema {
 			// Write the schema byte array out.
-			fmt.Fprintf(&gotCode, gotGeneratedCode.JSONSchemaCode)
+			fmt.Fprint(&gotCode, gotGeneratedCode.JSONSchemaCode)
 
 			wantSchema, rferr := ioutil.ReadFile(tt.wantSchemaFile)
 			if rferr != nil {

--- a/ygen/goelements_test.go
+++ b/ygen/goelements_test.go
@@ -320,7 +320,7 @@ func TestCamelCase(t *testing.T) {
 		}
 
 		if got := makeNameUnique(entryCamelCaseName(tt.inEntry), ctx); got != tt.wantName {
-			t.Errorf("%s: did not get expected name for %s (after defining %v): %s",
+			t.Errorf("%s: did not get expected name for %v (after defining %v): %s",
 				tt.name, tt.inEntry, tt.inPrevNames, got)
 		}
 	}

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -295,7 +295,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
@@ -457,7 +457,7 @@ func (t *{{ .Receiver }}) New{{ .ListName }}(
 	// list. Keyed YANG lists do not allow duplicate keys to
 	// be created.
 	if _, ok := t.{{ .ListName }}[key]; ok {
-		return nil, fmt.Errorf("duplicate key %%v for list {{ .ListName }}", key)
+		return nil, fmt.Errorf("duplicate key %v for list {{ .ListName }}", key)
 	}
 
 	t.{{ .ListName }}[key] = &{{ .ListType }}{
@@ -547,7 +547,7 @@ func (t *{{ .ParentReceiver }}) To_{{ .Name }}(i interface{}) ({{ .Name }}, erro
 		return &{{ $intfName }}_{{ $typeName }}{v}, nil
 	{{ end -}}
 	default:
-		return nil, fmt.Errorf("cannot convert %%v to {{ .Name }}, unknown union type, got: %%T, want any of [
+		return nil, fmt.Errorf("cannot convert %v to {{ .Name }}, unknown union type, got: %T, want any of [
 		{{- $length := len .TypeNames -}}
 		{{- range $i, $type := .TypeNames -}}
 			{{ $type }}

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -244,7 +244,7 @@ func (t *InputStruct) To_InputStruct_U1_Union(i interface{}) (InputStruct_U1_Uni
 	case string:
 		return &InputStruct_U1_Union_String{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %%v to InputStruct_U1_Union, unknown union type, got: %%T, want any of [int8, string]", i, i)
+		return nil, fmt.Errorf("cannot convert %v to InputStruct_U1_Union, unknown union type, got: %T, want any of [int8, string]", i, i)
 	}
 }
 `,
@@ -307,7 +307,7 @@ func (t *InputStruct) To_Module_InputStruct_U1_Union(i interface{}) (Module_Inpu
 	case string:
 		return &Module_InputStruct_U1_Union_String{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %%v to Module_InputStruct_U1_Union, unknown union type, got: %%T, want any of [int8, string]", i, i)
+		return nil, fmt.Errorf("cannot convert %v to Module_InputStruct_U1_Union, unknown union type, got: %T, want any of [int8, string]", i, i)
 	}
 }
 `,
@@ -581,7 +581,7 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 	// list. Keyed YANG lists do not allow duplicate keys to
 	// be created.
 	if _, ok := t.ListWithKey[key]; ok {
-		return nil, fmt.Errorf("duplicate key %%v for list ListWithKey", key)
+		return nil, fmt.Errorf("duplicate key %v for list ListWithKey", key)
 	}
 
 	t.ListWithKey[key] = &ListWithKey{
@@ -630,7 +630,7 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 	// list. Keyed YANG lists do not allow duplicate keys to
 	// be created.
 	if _, ok := t.ListWithKey[key]; ok {
-		return nil, fmt.Errorf("duplicate key %%v for list ListWithKey", key)
+		return nil, fmt.Errorf("duplicate key %v for list ListWithKey", key)
 	}
 
 	t.ListWithKey[key] = &ListWithKey{
@@ -737,7 +737,7 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 	// list. Keyed YANG lists do not allow duplicate keys to
 	// be created.
 	if _, ok := t.ListWithKey[key]; ok {
-		return nil, fmt.Errorf("duplicate key %%v for list ListWithKey", key)
+		return nil, fmt.Errorf("duplicate key %v for list ListWithKey", key)
 	}
 
 	t.ListWithKey[key] = &ListWithKey{
@@ -797,7 +797,7 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 	// list. Keyed YANG lists do not allow duplicate keys to
 	// be created.
 	if _, ok := t.ListWithKey[key]; ok {
-		return nil, fmt.Errorf("duplicate key %%v for list ListWithKey", key)
+		return nil, fmt.Errorf("duplicate key %v for list ListWithKey", key)
 	}
 
 	t.ListWithKey[key] = &ListWithKey{

--- a/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {

--- a/ygen/testdata/schema/openconfig-options-compress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress.formatted-txt
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {

--- a/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {

--- a/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
@@ -45,7 +45,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
-		return fmt.Errorf("could not find schema for type %%s", tn )
+		return fmt.Errorf("could not find schema for type %s", tn )
 	}
 	var jsonTree interface{}
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {


### PR DESCRIPTION
```
  * (M) exampleoc/oc.go
    - Update generated code, fixes go vet issues.
  * (M) generator/generator.go
  * (M) ygen/codegen_test.go
    - Change to fmt.Fprintln or fmt.Fprint rather than Fprintf which was
      causing %(MISSING)v output.
  * (M) ygen/gogen.go
    - Fix template that inserted %%.
  * (M) ygen/gogen_test.go
  * (M) ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
  * (M) ygen/testdata/schema/openconfig-options-compress.formatted-txt
  * (M) ygen/testdata/schema/openconfig-options-explicit.formatted-txt
  * (M) ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
  * (M) ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
    - Fix tests that expected %%.
```