### PR TITLE
Add ability to unmarshal into individual list element structs.

### DIFF
--- a/ytypes/common.go
+++ b/ytypes/common.go
@@ -768,7 +768,7 @@ func enumStringToIntValue(parent interface{}, fieldName, value string) (int64, e
 	}
 	ft := field.Type()
 	// leaf-list case
-	if ft.Kind() == reflect.Slice{
+	if ft.Kind() == reflect.Slice {
 		ft = ft.Elem()
 	}
 

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -124,8 +124,8 @@ func TestUnmarshalLeafList(t *testing.T) {
 		},
 	}
 	type ContainerStruct struct {
-		Int32LeafList []*int32 `path:"int32-leaf-list"`
-		EnumLeafList []EnumType `path:"enum-leaf-list"`
+		Int32LeafList []*int32   `path:"int32-leaf-list"`
+		EnumLeafList  []EnumType `path:"enum-leaf-list"`
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Using SchemaTree sometimes leads to surprising results for users due to how the OC schema is laid out. Specifically, schemas that might be expected to be structs are lists since a list schema is also a container for the list element e.g. 
oc.SchemaTree["Device_Components_Component"] is actually a list, not a list element.
But it seems reasonable that the user may want to unmarshal into what they believe to be a struct in the schema.
This change addresses that case by checking the format of the incoming schema: if it's a struct ptr, we attempt the unmarshal is into a list element as well as a list. This is safe because the struct type must still be correct wrt the JSON being unmarshaled. 