### PR TITLE
Add missing validation handling for enum types in union.

### DIFF
--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -196,20 +196,26 @@ type Union1 interface {
 	IsUnion1()
 }
 
-type Union1Leaf1 struct {
-	Leaf1 *string
+type Union1_String struct {
+	String *string
 }
 
-func (Union1Leaf1) IsUnion1() {}
+func (Union1_String) IsUnion1() {}
 
-type Union1Leaf2 struct {
-	Leaf2 *int16
+type Union1_Int16 struct {
+	Int16 *int16
 }
 
-func (Union1Leaf2) IsUnion1() {}
+func (Union1_Int16) IsUnion1() {}
+
+type Union1_EnumType struct {
+	EnumType EnumType
+}
+
+func (Union1_EnumType) IsUnion1() {}
 
 type Union1BadLeaf struct {
-	Leaf3 *float32
+	BadLeaf *float32
 }
 
 func (Union1BadLeaf) IsUnion1() {}
@@ -229,16 +235,21 @@ func TestValidateLeafUnion(t *testing.T) {
 				Name: "union1",
 				Kind: yang.LeafEntry,
 				Type: &yang.YangType{
+					Name: "union1-type",
 					Kind: yang.Yunion,
 					Type: []*yang.YangType{
 						{
-							Name:    "leaf1",
+							Name:    "string",
 							Kind:    yang.Ystring,
 							Pattern: []string{"a+"},
 						},
 						{
-							Name: "leaf2",
+							Name: "int16",
 							Kind: yang.Yint16,
+						},
+						{
+							Name: "enum",
+							Kind: yang.Yenum,
 						},
 					},
 				},
@@ -259,12 +270,12 @@ func TestValidateLeafUnion(t *testing.T) {
 					Kind: yang.Yunion,
 					Type: []*yang.YangType{
 						{
-							Name:    "leaf1",
+							Name:    "string",
 							Kind:    yang.Ystring,
 							Pattern: []string{"a+"},
 						},
 						{
-							Name:    "leaf2",
+							Name:    "int16",
 							Kind:    yang.Ystring,
 							Pattern: []string{"b+"},
 						},
@@ -285,21 +296,21 @@ func TestValidateLeafUnion(t *testing.T) {
 					Kind: yang.Yunion,
 					Type: []*yang.YangType{
 						{
-							Name:    "leaf1",
+							Name:    "string",
 							Kind:    yang.Ystring,
 							Pattern: []string{"a+"},
 						},
 						{
-							Name:    "leaf2",
+							Name:    "int16",
 							Kind:    yang.Ystring,
 							Pattern: []string{"b+"},
 						},
 						{
-							Name: "leaf3",
+							Name: "bad-leaf",
 							Kind: yang.Yunion,
 							Type: []*yang.YangType{
 								{
-									Name:    "leaf3",
+									Name:    "bad-leaf",
 									Kind:    yang.Ystring,
 									Pattern: []string{"c+"},
 								},
@@ -318,39 +329,44 @@ func TestValidateLeafUnion(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			desc:   "success leaf1",
+			desc:   "success string",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &Union1Leaf1{Leaf1: ygot.String("aaa")}},
+			val:    &UnionContainer{UnionField: &Union1_String{String: ygot.String("aaa")}},
 		},
 		{
-			desc:   "success leaf2",
+			desc:   "success int16",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &Union1Leaf2{Leaf2: ygot.Int16(1)}},
+			val:    &UnionContainer{UnionField: &Union1_Int16{Int16: ygot.Int16(1)}},
+		},
+		{
+			desc:   "success enum",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: &Union1_EnumType{EnumType: 42}},
 		},
 		{
 			desc:    "bad regex",
 			schema:  unionContainerSchema,
-			val:     &UnionContainer{UnionField: &Union1Leaf1{Leaf1: ygot.String("bbb")}},
+			val:     &UnionContainer{UnionField: &Union1_String{String: ygot.String("bbb")}},
 			wantErr: true,
 		},
 		{
 			desc:    "bad type",
 			schema:  unionContainerSchema,
-			val:     &UnionContainer{UnionField: &Union1BadLeaf{Leaf3: ygot.Float32(0)}},
+			val:     &UnionContainer{UnionField: &Union1BadLeaf{BadLeaf: ygot.Float32(0)}},
 			wantErr: true,
 		},
 		{
-			desc:   "success no wrapping struct leaf1",
+			desc:   "success no wrapping struct string",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("aaa")},
 		},
 		{
-			desc:   "success no wrapping struct leaf2",
+			desc:   "success no wrapping struct int16",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("bbb")},
 		},
 		{
-			desc:   "success no wrapping struct leaf1",
+			desc:   "success no wrapping struct string",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("aaa")},
 		},

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -171,6 +171,31 @@ func TestValidateSystemDns(t *testing.T) {
 	}
 }
 
+func TestValidateSystemAaa(t *testing.T) {
+	dev := &oc.Device{
+		System: &oc.System{
+			Aaa: &oc.System_Aaa{
+				Authentication: &oc.System_Aaa_Authentication{
+					AuthenticationMethod: []oc.System_Aaa_Authentication_AuthenticationMethod_Union{
+						&oc.System_Aaa_Authentication_AuthenticationMethod_Union_E_OpenconfigAaaTypes_AAA_METHOD_TYPE{
+							E_OpenconfigAaaTypes_AAA_METHOD_TYPE: oc.OpenconfigAaaTypes_AAA_METHOD_TYPE_LOCAL,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Validate the fake root device.
+	if err := dev.Validate(); err != nil {
+		t.Errorf("root success: got %s, want nil", err)
+	}
+	// Validate an element in the device subtree.
+	if err := dev.System.Validate(); err != nil {
+		t.Errorf("system success: got %s, want nil", err)
+	}
+}
+
 func TestValidateLLDP(t *testing.T) {
 	dev := &oc.Device{
 		Lldp: &oc.Lldp{

--- a/ytypes/util_reflect.go
+++ b/ytypes/util_reflect.go
@@ -368,6 +368,11 @@ func IsNilOrInvalidValue(v reflect.Value) bool {
 	return !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) || isNil(v.Interface())
 }
 
+// IsValuePtr reports whether v is a ptr type.
+func IsValuePtr(v reflect.Value) bool {
+	return v.Kind() == reflect.Ptr
+}
+
 // IsValueStruct reports whether v is a struct type.
 func IsValueStruct(v reflect.Value) bool {
 	return v.Kind() == reflect.Struct
@@ -386,6 +391,11 @@ func IsValueMap(v reflect.Value) bool {
 // IsValueSlice reports whether v is a slice type.
 func IsValueSlice(v reflect.Value) bool {
 	return v.Kind() == reflect.Slice
+}
+
+// IsValueInterface reports whether v is an interface type.
+func IsValueInterface(v reflect.Value) bool {
+	return v.Kind() == reflect.Interface
 }
 
 // IsValueScalar reports whether v is a scalar type.

--- a/ytypes/util_types.go
+++ b/ytypes/util_types.go
@@ -99,6 +99,8 @@ func yangBuiltinTypeToGoType(t yang.TypeKind) interface{} {
 		return float64(0)
 	case yang.Ybinary:
 		return []byte(nil)
+	case yang.Yenum, yang.Yidentityref:
+		return int64(0)		
 	default:
 		// TODO(mostrowski): handle bitset.
 		log.Errorf("unexpected type %v in yangBuiltinTypeToGoPtrType", t)


### PR DESCRIPTION
Enum types in unions were not handled. Usually enums are checked by compiler but in the case of union, there may be other types possible, hence enum must be added to the set of possible types to check against (although the actual value need not be checked because the compiler will do this).