### PR TITLE
Fix bug with serialisation of enumeration values in unions.

### DIFF
--- a/demo/device/devicedemo.go
+++ b/demo/device/devicedemo.go
@@ -72,6 +72,13 @@ func CreateDemoDeviceInstance() (*oc.Device, error) {
 		return nil, err
 	}
 
+	// Add a component.
+	c, err := d.NewComponent("os")
+	if err != nil {
+		return nil, err
+	}
+	c.Type = &oc.Component_Type_Union_E_OpenconfigPlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT{oc.OpenconfigPlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT_OPERATING_SYSTEM}
+
 	return d, nil
 }
 

--- a/demo/device/devicedemo_test.go
+++ b/demo/device/devicedemo_test.go
@@ -32,8 +32,8 @@ const (
 // shown to the user in a test error message.
 func generateUnifiedDiff(want, got string) (string, error) {
 	diffl := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(got),
-		B:        difflib.SplitLines(want),
+		A:        difflib.SplitLines(want),
+		B:        difflib.SplitLines(got),
 		FromFile: "got",
 		ToFile:   "want",
 		Context:  3,

--- a/demo/device/testdata/device-ietf.json
+++ b/demo/device/testdata/device-ietf.json
@@ -40,6 +40,19 @@
          }
       ]
    },
+   "openconfig-platform:components": {
+      "component": [
+         {
+            "config": {
+               "name": "os"
+            },
+            "name": "os",
+            "state": {
+               "type": "openconfig-platform-types:OPERATING_SYSTEM"
+            }
+         }
+      ]
+   },
    "openconfig-system:system": {
       "config": {
          "hostname": "rtr02.pop44"

--- a/demo/device/testdata/device.json
+++ b/demo/device/testdata/device.json
@@ -1,4 +1,17 @@
 {
+   "components": {
+      "component": {
+         "os": {
+            "config": {
+               "name": "os"
+            },
+            "name": "os",
+            "state": {
+               "type": "OPERATING_SYSTEM"
+            }
+         }
+      }
+   },
    "interfaces": {
       "interface": {
          "eth0": {

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -237,12 +237,15 @@ func (EnumTest) ΛMap() map[string]map[int64]EnumDefinition {
 }
 
 const (
-	// C_TestVALONE is used to represent VAL_ONE of the /c/test
+	// EnumTestVALONE is used to represent VAL_ONE of the /c/test
 	// enumerated leaf in the schema-with-list test.
 	EnumTestVALONE EnumTest = 1
-	// C_TestVALTWO is used to represent VAL_TWO of the /c/test
+	// EnumTestVALTWO is used to represent VAL_TWO of the /c/test
 	// enumerated leaf in the schema-with-list test.
 	EnumTestVALTWO EnumTest = 2
+	// EnumTestVALTHREE is an an enum value that does not have
+	// a corresponding string mapping.
+	EnumTestVALTHREE = 3
 )
 
 func TestTogNMINotifications(t *testing.T) {
@@ -274,6 +277,11 @@ func TestTogNMINotifications(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name:        "no path tags on struct",
+		inTimestamp: 42,
+		inStruct:    &invalidGoStructEntity{NoPath: String("foo")},
+		wantErr:     true,
+	}, {
 		name:        "struct with invalid pointer",
 		inTimestamp: 42,
 		inStruct: &renderExample{
@@ -304,6 +312,11 @@ func TestTogNMINotifications(t *testing.T) {
 				Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"}},
 			}},
 		}},
+	}, {
+		name:        "struct with invalid enum",
+		inTimestamp: 42,
+		inStruct:    &renderExample{EnumField: EnumTestVALTHREE},
+		wantErr:     true,
 	}, {
 		name:        "struct with leaflist",
 		inTimestamp: 42,
@@ -1304,6 +1317,10 @@ func TestUnionInterfaceValue(t *testing.T) {
 		UField: &uFieldE{EnumTestVALONE},
 	}
 
+	testSeven := &unionTestOne{
+		UField: &uFieldE{EnumTestVALTHREE},
+	}
+
 	tests := []struct {
 		name        string
 		in          reflect.Value
@@ -1343,6 +1360,10 @@ func TestUnionInterfaceValue(t *testing.T) {
 		in:          reflect.ValueOf(testSix).Elem().Field(0),
 		inAppendMod: true,
 		want:        "foo:VAL_ONE",
+	}, {
+		name:    "enum without a string mapping",
+		in:      reflect.ValueOf(testSeven).Elem().Field(0),
+		wantErr: true,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When a union was serialised to JSON then if an enumerated value existed within that union it was printed as a string rather than as the string value. This CL corrects this serialisation.