### PR TITLE
Add function to access ΛEnumTypes from generated code.

### DIFF
--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -1393,10 +1393,6 @@ func generateEnumMap(enumValues map[string]map[int64]ygot.EnumDefinition) (strin
 // types that can correspond to the schema path. The map generated allows a
 // schemapath to be mapped into the reflect.Type representing the enum value.
 func generateEnumTypeMap(enumTypeMap map[string][]string) (string, error) {
-	if len(enumTypeMap) == 0 {
-		return "", nil
-	}
-
 	var buf bytes.Buffer
 	if err := goTemplates["enumTypeMap"].Execute(&buf, enumTypeMap); err != nil {
 		return "", err

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -563,7 +563,7 @@ var ΛEnumTypes = map[string][]reflect.Type{
 }
 `
 
-	// goEnumTypeMapAccessTemplate provides a teplate to output an accessor
+	// goEnumTypeMapAccessTemplate provides a template to output an accessor
 	// function with a generated struct as receiver, it returns the enum type
 	// map associated with the generated code.
 	goEnumTypeMapAccessTemplate = `

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -27,10 +27,10 @@ import (
 
 // generateUnifiedDiff takes two strings and generates a diff that can be
 // shown to the user in a test error message.
-func generateUnifiedDiff(want, got string) (string, error) {
+func generateUnifiedDiff(got, want string) (string, error) {
 	diffl := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(want),
-		B:        difflib.SplitLines(got),
+		A:        difflib.SplitLines(got),
+		B:        difflib.SplitLines(want),
 		FromFile: "got",
 		ToFile:   "want",
 		Context:  3,
@@ -132,6 +132,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 		wantUncompressed: wantGoStructOut{
@@ -155,6 +159,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 	}, {
@@ -206,6 +214,10 @@ func (s *InputStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *InputStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 			interfaces: `
 // InputStruct_U1_Union is an interface that is implemented by valid types for the union
@@ -269,6 +281,10 @@ func (s *InputStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *InputStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 			interfaces: `
 // Module_InputStruct_U1_Union is an interface that is implemented by valid types for the union
@@ -356,6 +372,10 @@ func (s *InputStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *InputStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 		wantUncompressed: wantGoStructOut{
@@ -378,6 +398,10 @@ func (s *InputStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *InputStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 	}, {
@@ -483,6 +507,10 @@ func (s *QStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *QStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 		wantUncompressed: wantGoStructOut{
@@ -505,6 +533,10 @@ func (s *QStruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *QStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 	}, {
@@ -603,6 +635,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 		wantUncompressed: wantGoStructOut{
@@ -652,6 +688,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 	}, {
@@ -833,6 +873,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 		wantUncompressed: wantGoStructOut{
@@ -893,6 +937,10 @@ func (s *Tstruct) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 `,
 		},
 	}}
@@ -924,7 +972,8 @@ func (s *Tstruct) Validate() error {
 			}
 
 			if diff := pretty.Compare(want.structs, got.structDef); diff != "" {
-				if diffl, err := generateUnifiedDiff(want.structs, got.structDef); err == nil {
+				if diffl, err := generateUnifiedDiff(got.structDef, want.methods); err == nil {
+
 					diff = diffl
 				}
 				t.Errorf("%s writeGoStruct(CompressOCPaths: %v, targetStruct: %v): struct generated code was not correct, diff (-got,+want):\n%s",
@@ -932,7 +981,7 @@ func (s *Tstruct) Validate() error {
 			}
 
 			if diff := pretty.Compare(want.keys, got.listKeys); diff != "" {
-				if diffl, err := generateUnifiedDiff(want.keys, got.listKeys); err == nil {
+				if diffl, err := generateUnifiedDiff(got.listKeys, want.keys); err == nil {
 					diff = diffl
 				}
 				t.Errorf("%s writeGoStruct(CompressOCPaths: %v, targetStruct: %v): structs generated as list keys incorrect, diff (-got,+want):\n%s",
@@ -940,15 +989,15 @@ func (s *Tstruct) Validate() error {
 			}
 
 			if diff := pretty.Compare(want.methods, got.methods); diff != "" {
-				if diffl, err := generateUnifiedDiff(want.methods, got.methods); err == nil {
+				if diffl, err := generateUnifiedDiff(got.methods, want.methods); err == nil {
 					diff = diffl
 				}
-				t.Errorf("%s writeGoStruct(CompressOCPaths: %v, targetStruct: %v): methods generated corresponding to lists incorrect, diff (-got,+want):\n%s",
+				t.Errorf("%s writeGoStruct(CompressOCPaths: %v, targetStruct: %v): generated methods incorrect, diff (-got,+want):\n%s",
 					tt.name, compressed, tt.inStructToMap, diff)
 			}
 
 			if diff := pretty.Compare(want.interfaces, got.interfaces); diff != "" {
-				if diffl, err := generateUnifiedDiff(want.interfaces, got.interfaces); err == nil {
+				if diffl, err := generateUnifiedDiff(got.interfaces, want.interfaces); err == nil {
 					diff = diffl
 				}
 				t.Errorf("%s: writeGoStruct(CompressOCPaths: %v, targetStruct: %v): interfaces generated for struct incorrect, diff (-got,+want):\n%s",
@@ -1131,7 +1180,7 @@ const (
 
 		if diff := pretty.Compare(tt.want, got); diff != "" {
 			fmt.Println(diff)
-			if diffl, err := generateUnifiedDiff(tt.want.constDef, got.constDef); err == nil {
+			if diffl, err := generateUnifiedDiff(got.constDef, tt.want.constDef); err == nil {
 				diff = diffl
 			}
 			t.Errorf("%s: writeGoEnum(%v): got incorrect output, diff(-got,+want):\n%s",
@@ -1362,7 +1411,7 @@ var ΛEnum = map[string]map[int64]ygot.EnumDefinition{
 
 		if tt.wantMap != got {
 			diff := fmt.Sprintf("got: %s, want %s", got, tt.wantMap)
-			if diffl, err := generateUnifiedDiff(tt.wantMap, got); err == nil {
+			if diffl, err := generateUnifiedDiff(got, tt.wantMap); err == nil {
 				diff = "diff (-got, +want):\n" + diffl
 			}
 			t.Errorf("%s: did not get expected generated enum, %s", tt.name, diff)

--- a/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
@@ -100,6 +100,10 @@ func (s *Bgp) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Bgp) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // Bgp_Neighbor represents the /openconfig-options/bgp/neighbors/neighbor YANG schema element.
 type Bgp_Neighbor struct {
 	EnabledAddressFamily	[]Bgp_Neighbor_EnabledAddressFamily_Union	`path:"state/enabled-address-family" module:"openconfig-options"`
@@ -131,6 +135,10 @@ func (s *Bgp_Neighbor) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Bgp_Neighbor) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // Bgp_Neighbor_EnabledAddressFamily_Union is an interface that is implemented by valid types for the union
 // for the leaf /openconfig-options/bgp/neighbors/neighbor/state/enabled-address-family within the YANG schema.
@@ -189,6 +197,10 @@ func (s *Device) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Device) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // E_OpenconfigOptions_AFI is a derived int64 type which is used to represent
 // the enumerated node OpenconfigOptions_AFI. An additional value named

--- a/ygen/testdata/schema/openconfig-options-compress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress.formatted-txt
@@ -100,6 +100,10 @@ func (s *Bgp) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Bgp) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // Bgp_Neighbor represents the /openconfig-options/bgp/neighbors/neighbor YANG schema element.
 type Bgp_Neighbor struct {
 	EnabledAddressFamily	[]Bgp_Neighbor_EnabledAddressFamily_Union	`path:"state/enabled-address-family" module:"openconfig-options"`
@@ -131,6 +135,10 @@ func (s *Bgp_Neighbor) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Bgp_Neighbor) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // Bgp_Neighbor_EnabledAddressFamily_Union is an interface that is implemented by valid types for the union
 // for the leaf /openconfig-options/bgp/neighbors/neighbor/state/enabled-address-family within the YANG schema.

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -74,6 +74,10 @@ func (s *Fakeroot) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Fakeroot) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // Parent represents the /openconfig-simple/parent YANG schema element.
 type Parent struct {
 	Child	*Parent_Child	`path:"/parent/child" module:"openconfig-simple"`
@@ -91,6 +95,10 @@ func (s *Parent) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Parent) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // Parent_Child represents the /openconfig-simple/parent/child YANG schema element.
 type Parent_Child struct {
@@ -113,6 +121,10 @@ func (s *Parent_Child) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Parent_Child) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // RemoteContainer represents the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainer struct {
 	ALeaf	*string	`path:"/remote-container/config/a-leaf" module:"openconfig-simple"`
@@ -130,6 +142,10 @@ func (s *RemoteContainer) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *RemoteContainer) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // E_OpenconfigSimple_Child_Three is a derived int64 type which is used to represent
 // the enumerated node OpenconfigSimple_Child_Three. An additional value named

--- a/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
@@ -73,6 +73,10 @@ func (s *Device) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *Device) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp represents the /openconfig-options/bgp YANG schema element.
 type OpenconfigOptions_Bgp struct {
 	Neighbors	*OpenconfigOptions_Bgp_Neighbors	`path:"/bgp/neighbors" module:"openconfig-options"`
@@ -90,6 +94,10 @@ func (s *OpenconfigOptions_Bgp) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // OpenconfigOptions_Bgp_Neighbors represents the /openconfig-options/bgp/neighbors YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors struct {
@@ -136,6 +144,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp_Neighbors_Neighbor represents the /openconfig-options/bgp/neighbors/neighbor YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor struct {
 	Config	*OpenconfigOptions_Bgp_Neighbors_Neighbor_Config	`path:"config" module:"openconfig-options"`
@@ -167,6 +179,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_Config represents the /openconfig-options/bgp/neighbors/neighbor/config YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor_Config struct {
 	HoldTime	*uint32	`path:"hold-time" module:"openconfig-options"`
@@ -185,6 +201,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor_Config) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor_Config) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_State represents the /openconfig-options/bgp/neighbors/neighbor/state YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor_State struct {
@@ -206,6 +226,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor_State) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor_State) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_State_EnabledAddressFamily_Union is an interface that is implemented by valid types for the union
 // for the leaf /openconfig-options/bgp/neighbors/neighbor/state/enabled-address-family within the YANG schema.

--- a/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
@@ -73,6 +73,10 @@ func (s *OpenconfigOptions_Bgp) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp_Neighbors represents the /openconfig-options/bgp/neighbors YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors struct {
 	Neighbor	map[string]*OpenconfigOptions_Bgp_Neighbors_Neighbor	`path:"neighbor" module:"openconfig-options"`
@@ -118,6 +122,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp_Neighbors_Neighbor represents the /openconfig-options/bgp/neighbors/neighbor YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor struct {
 	Config	*OpenconfigOptions_Bgp_Neighbors_Neighbor_Config	`path:"config" module:"openconfig-options"`
@@ -149,6 +157,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor) Validate() error {
 	return nil
 }
 
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
+
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_Config represents the /openconfig-options/bgp/neighbors/neighbor/config YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor_Config struct {
 	HoldTime	*uint32	`path:"hold-time" module:"openconfig-options"`
@@ -167,6 +179,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor_Config) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor_Config) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_State represents the /openconfig-options/bgp/neighbors/neighbor/state YANG schema element.
 type OpenconfigOptions_Bgp_Neighbors_Neighbor_State struct {
@@ -188,6 +204,10 @@ func (s *OpenconfigOptions_Bgp_Neighbors_Neighbor_State) Validate() error {
 	}
 	return nil
 }
+
+// ΛEnumTypeMap returns a map, keyed by YANG schema path, of the enumerated types
+// that are included in the generated code.
+func (t *OpenconfigOptions_Bgp_Neighbors_Neighbor_State) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes }
 
 // OpenconfigOptions_Bgp_Neighbors_Neighbor_State_EnabledAddressFamily_Union is an interface that is implemented by valid types for the union
 // for the leaf /openconfig-options/bgp/neighbors/neighbor/state/enabled-address-family within the YANG schema.

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -203,6 +203,8 @@ func (*mapStructTestOne) Validate() error {
 	return nil
 }
 
+func (*mapStructTestOne) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
+
 // mapStructTestOne_Child is a child structure of the mapStructTestOne test
 // case.
 type mapStructTestOneChild struct {
@@ -220,6 +222,8 @@ func (*mapStructTestOneChild) Validate() error {
 	return nil
 }
 
+func (*mapStructTestOneChild) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
+
 // mapStructTestFour is the top-level container used for the
 // schema-with-list test.
 type mapStructTestFour struct {
@@ -232,6 +236,8 @@ func (*mapStructTestFour) IsYANGGoStruct() {}
 func (*mapStructTestFour) Validate() error {
 	return nil
 }
+
+func (*mapStructTestFour) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // mapStructTestFourC is the "c" container used for the schema-with-list
 // test.
@@ -247,6 +253,8 @@ func (*mapStructTestFourC) IsYANGGoStruct() {}
 func (*mapStructTestFourC) Validate() error {
 	return nil
 }
+
+func (*mapStructTestFourC) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // mapStructTestFourCACLSet is the struct which represents each entry in
 // the ACLSet list in the schema-with-list test.
@@ -264,6 +272,8 @@ func (*mapStructTestFourCACLSet) Validate() error {
 	return nil
 }
 
+func (*mapStructTestFourCACLSet) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
+
 // mapStructTestFourOtherSet is a map entry with a
 type mapStructTestFourCOtherSet struct {
 	Name ECTest `path:"config/name|name"`
@@ -275,6 +285,8 @@ func (*mapStructTestFourCOtherSet) IsYANGGoStruct() {}
 func (*mapStructTestFourCOtherSet) Validate() error {
 	return nil
 }
+
+func (*mapStructTestFourCOtherSet) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // ECTest is a synthesised derived type which is used to represent
 // an enumeration in the YANG schema.
@@ -315,6 +327,8 @@ func (*mapStructInvalid) Validate() error {
 	return fmt.Errorf("invalid")
 }
 
+func (*mapStructInvalid) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
+
 // mapStructNoPaths is a valid GoStruct who does not implement path tags.
 type mapStructNoPaths struct {
 	Name *string
@@ -324,7 +338,8 @@ type mapStructNoPaths struct {
 func (*mapStructNoPaths) IsYANGGoStruct() {}
 
 // Validate implements the ValidatedGoStruct interface.
-func (*mapStructNoPaths) Validate() error { return nil }
+func (*mapStructNoPaths) Validate() error                         { return nil }
+func (*mapStructNoPaths) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // TestEmitJSON validates that the EmitJSON function outputs the expected JSON
 // for a set of input structs and schema definitions.

--- a/ygot/types.go
+++ b/ygot/types.go
@@ -14,6 +14,8 @@
 
 package ygot
 
+import "reflect"
+
 // GoStruct is an interface which can be implemented by Go structs that are
 // generated to represent a YANG container or list member. It simply allows
 // handling code to ensure that it is interacting with a struct that will meet
@@ -37,6 +39,9 @@ type ValidatedGoStruct interface {
 	// the YANG schema, and returns an error if the struct's contents
 	// are not valid, or nil if the struct complies with the schema.
 	Validate() error
+	// ΛEnumTypeMap returns the set of enumerated types that are contained
+	// in the generated code.
+	ΛEnumTypeMap() map[string][]reflect.Type
 }
 
 // KeyHelperGoStruct is an interface which can be implemented by Go structs


### PR DESCRIPTION
This CL adds the ability to call ΛEnumTypeMap() on a generated struct to retrieve the set of types that are associated with enums within the generated code file.