### PR TITLE
Add handling for unmarshalling unions with enums.

### DIFF
--- a/util/reflect.go
+++ b/util/reflect.go
@@ -41,6 +41,11 @@ func IsTypeInterface(t reflect.Type) bool {
 	return t.Kind() == reflect.Interface
 }
 
+// IsTypeSliceOfInterface reports whether v is a slice of interface.
+func IsTypeSliceOfInterface(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Interface
+}
+
 // IsNilOrInvalidValue reports whether v is nil or reflect.Zero.
 func IsNilOrInvalidValue(v reflect.Value) bool {
 	return !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) || IsValueNil(v.Interface())

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -844,7 +844,7 @@ func writeGoStruct(targetStruct *yangDirectory, goStructElements map[string]*yan
 			// This is done to allow checks against nil.
 			scalarField := true
 			fType := mtype.nativeType
-			schemapath := EntrySchemaPath(field)
+			schemapath := entrySchemaPath(field)
 
 			if len(mtype.unionTypes) > 1 {
 				// If this is a union that has more than one subtype, then we need

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -844,7 +844,7 @@ func writeGoStruct(targetStruct *yangDirectory, goStructElements map[string]*yan
 			// This is done to allow checks against nil.
 			scalarField := true
 			fType := mtype.nativeType
-			schemapath := entrySchemaPath(field)
+			schemapath := EntrySchemaPath(field)
 
 			if len(mtype.unionTypes) > 1 {
 				// If this is a union that has more than one subtype, then we need

--- a/ygen/yang_helpers.go
+++ b/ygen/yang_helpers.go
@@ -311,8 +311,8 @@ func listKeyFieldsMap(e *yang.Entry) map[string]bool {
 	return r
 }
 
-// EntrySchemaPath takes an input yang.Entry, and returns its YANG schema
+// entrySchemaPath takes an input yang.Entry, and returns its YANG schema
 // path.
-func EntrySchemaPath(e *yang.Entry) string {
+func entrySchemaPath(e *yang.Entry) string {
 	return slicePathToString(append([]string{""}, traverseElementSchemaPath(e)[1:]...))
 }

--- a/ygen/yang_helpers.go
+++ b/ygen/yang_helpers.go
@@ -311,8 +311,8 @@ func listKeyFieldsMap(e *yang.Entry) map[string]bool {
 	return r
 }
 
-// goyangPathToSchemaPath takes an input yang.Entry, and returns its YANG schema
+// EntrySchemaPath takes an input yang.Entry, and returns its YANG schema
 // path.
-func entrySchemaPath(e *yang.Entry) string {
+func EntrySchemaPath(e *yang.Entry) string {
 	return slicePathToString(append([]string{""}, traverseElementSchemaPath(e)[1:]...))
 }

--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -32,10 +32,11 @@ var (
 	globalEnumMap = map[string]map[int64]ygot.EnumDefinition{
 		"EnumType": map[int64]ygot.EnumDefinition{
 			42: {Name: "E_VALUE_FORTY_TWO"},
-		}
+		},
 		"EnumType2": map[int64]ygot.EnumDefinition{
 			43: {Name: "E_VALUE_FORTY_THREE"},
-		}
+		},
+	}
 )
 
 // EnumType is used as an enum type in various tests in the ytypes package.

--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -29,18 +29,27 @@ var (
 	// testErrOutput controls whether expect error test cases log the error
 	// values.
 	testErrOutput = false
+	globalEnumMap = map[string]map[int64]ygot.EnumDefinition{
+		"EnumType": map[int64]ygot.EnumDefinition{
+			42: {Name: "E_VALUE_FORTY_TWO"},
+		}
+		"EnumType2": map[int64]ygot.EnumDefinition{
+			43: {Name: "E_VALUE_FORTY_THREE"},
+		}
 )
 
 // EnumType is used as an enum type in various tests in the ytypes package.
 type EnumType int64
 
 func (EnumType) ΛMap() map[string]map[int64]ygot.EnumDefinition {
-	m := map[string]map[int64]ygot.EnumDefinition{
-		"EnumType": map[int64]ygot.EnumDefinition{
-			42: {Name: "E_VALUE_FORTY_TWO"},
-		},
-	}
-	return m
+	return globalEnumMap
+}
+
+// EnumType2 is used as an enum type in various tests in the ytypes package.
+type EnumType2 int64
+
+func (EnumType2) ΛMap() map[string]map[int64]ygot.EnumDefinition {
+	return globalEnumMap
 }
 
 // populateParentField recurses through schema and populates each Parent field

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -129,7 +129,7 @@ func unmarshalContainer(schema *yang.Entry, parent interface{}, jsonTree interfa
 }
 
 // unmarshalStruct unmarshals a JSON tree into a struct.
-//   schema is the YANG schema of the node corresponding to the struct being 
+//   schema is the YANG schema of the node corresponding to the struct being
 //     unmarshalled into.
 //   parent is the parent struct, which must be a struct ptr.
 //   jsonTree is a JSON data tree which must be a map[string]interface{}.

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -25,7 +25,6 @@ import (
 	log "github.com/golang/glog"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
-	"github.com/openconfig/ygot/ygen"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -705,7 +704,7 @@ func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, erro
 		return nil, fmt.Errorf("%s ΛEnumTypes function returned wrong type %T, want map[string][]reflect.Type", t, ei)
 	}
 
-	util.DbgPrint("path is %s for schema %s", ygen.EntrySchemaPath(schema), schema.Name)
+	util.DbgPrint("path is %s for schema %s", absoluteSchemaDataPath(schema), schema.Name)
 
 	return enumTypesMap[absoluteSchemaDataPath(schema)], nil
 }

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -620,8 +620,8 @@ func setFieldWithTypedValue(parentT reflect.Type, destV reflect.Value, destElemT
 	return nil
 }
 
-// getUnionKindsAndTypes returns the YANG kinds of basic types and and 
-// reflect.Types of enum types that are possible for values for the union with 
+// getUnionKindsAndTypes returns the YANG kinds of basic types and and
+// reflect.Types of enum types that are possible for values for the union with
 // the given schema and type.
 func getUnionKindsAndTypes(schema *yang.Entry, parentT reflect.Type) ([]yang.TypeKind, []reflect.Type, error) {
 	uks, err := getUnionKindsNotEnums(schema)
@@ -654,7 +654,7 @@ func getUnionKindsNotEnums(schema *yang.Entry) ([]yang.TypeKind, error) {
 	return uks, nil
 }
 
-// getUnionTypesNotEnums returns all the non-enum YANG types under the given schema 
+// getUnionTypesNotEnums returns all the non-enum YANG types under the given schema
 // node, dereferencing any refs.
 func getUnionTypesNotEnums(schema *yang.Entry, yt *yang.YangType) ([]*yang.YangType, error) {
 	var uts []*yang.YangType
@@ -687,7 +687,8 @@ func getUnionTypesNotEnums(schema *yang.Entry, yt *yang.YangType) ([]*yang.YangT
 }
 
 // schemaToEnumTypes returns the actual enum types (rather than the interface
-// type) for a given schema, which must be for an enum type.
+// type) for a given schema, which must be for an enum type. t is the type of
+// the containing parent struct.
 func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, error) {
 	enumTypesMethod := reflect.New(t).Elem().MethodByName("ΛEnumTypeMap")
 	if !enumTypesMethod.IsValid() {
@@ -705,7 +706,12 @@ func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, erro
 	}
 	util.DbgPrint("path is %s for schema %s", ygen.EntrySchemaPath(schema), schema.Name)
 
-	return enumTypesMap[ygen.EntrySchemaPath(schema)], nil
+	p := ygen.EntrySchemaPath(schema)
+	m, ok := enumTypesMap[p]
+	if !ok {
+		return fmt.Errorf("schema %s with path %s does not have an entry in ΛEnumTypesMap", schema.Name, p)
+	}
+	return m, nil
 }
 
 // unmarshalScalar unmarshals value, which is the Go type from json.Unmarshal,

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -704,14 +704,10 @@ func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, erro
 	if !ok {
 		return nil, fmt.Errorf("%s ΛEnumTypes function returned wrong type %T, want map[string][]reflect.Type", t, ei)
 	}
+
 	util.DbgPrint("path is %s for schema %s", ygen.EntrySchemaPath(schema), schema.Name)
 
-	p := ygen.EntrySchemaPath(schema)
-	m, ok := enumTypesMap[p]
-	if !ok {
-		return nil, fmt.Errorf("schema %s with path %s does not have an entry in ΛEnumTypesMap", schema.Name, p)
-	}
-	return m, nil
+	return enumTypesMap[absoluteSchemaDataPath(schema)], nil
 }
 
 // unmarshalScalar unmarshals value, which is the Go type from json.Unmarshal,

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygen"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -511,43 +512,41 @@ with field String set to "forty-two".
 
 func unmarshalUnion(schema *yang.Entry, parent interface{}, fieldName string, value interface{}) error {
 	util.DbgPrint("unmarshalUnion value %v, type %T, into parent type %T field name %s, schema name %s", util.ValueStr(value), value, parent, fieldName, schema.Name)
-	v, t := reflect.ValueOf(parent), reflect.TypeOf(parent)
-	if !util.IsTypeStructPtr(t) {
+	parentV, parentT := reflect.ValueOf(parent), reflect.TypeOf(parent)
+	if !util.IsTypeStructPtr(parentT) {
 		return fmt.Errorf("%T is not a struct ptr in unmarshalUnion", parent)
 	}
 
-	vf := v.Elem().FieldByName(fieldName)
-	if !vf.IsValid() {
+	// Get the value and type of the field to set, which may have slice or
+	// interface types for leaf-list and union cases.
+	destUnionFieldV := parentV.Elem().FieldByName(fieldName)
+	if !destUnionFieldV.IsValid() {
 		return fmt.Errorf("%s is not a valid field name in %T", fieldName, parent)
 	}
-	ft, err := getFieldElemType(parent, fieldName)
+	dft, _ := parentT.Elem().FieldByName(fieldName)
+	destUnionFieldElemT := dft.Type
+
+	// Separately get the YANG kinds and reflect Types. The latter represent
+	// possible enum types.
+	uks, uts, err := getUnionKindsAndTypes(schema, parentT)
 	if err != nil {
 		return err
 	}
+	util.DbgPrint("possible union types are scalars %v or enums %v", uks, uts)
 
-	yks, yss, err := getUnionKindsAndEntries(schema, schema.Type)
-	if err != nil {
-		return err
-	}
-	var ss []yang.TypeKind
-	for _, e := range yss {
-		ss = append(ss, e.Type.Kind)
-	}
-	util.DbgPrint("possible union types are scalars %v or enums with paths %v", yks, ss)
-
-	// This can either be a interface, where multiple types are involved, of
-	// just the type itself, if the alternatives span only one type.
-	if !util.IsTypeInterface(ft) {
+	// Special case. If all possible union types map to a single go type, the
+	// GoStruct field is that type rather than a union Interface type.
+	if !util.IsTypeInterface(destUnionFieldElemT) && !util.IsTypeSliceOfInterface(destUnionFieldElemT) {
 		// Is not an interface, we must have exactly one type in the union.
-		if len(yks) != 1 {
-			return fmt.Errorf("got %v types for union schema %s for type %T, expect just one type", yks, fieldName, parent)
+		if len(uks) != 1 {
+			return fmt.Errorf("got %v types for union schema %s for type %T, expect just one type", uks, fieldName, parent)
 		}
-		yk := yks[0]
+		yk := uks[0]
 		goValue, err := unmarshalScalar(parent, yangKindToLeafEntry(yk), fieldName, value)
 		if err != nil {
 			return fmt.Errorf("could not unmarshal %v into type %s", value, yk)
 		}
-		vf.Set(reflect.ValueOf(ygot.ToPtr(goValue)))
+		destUnionFieldV.Set(reflect.ValueOf(ygot.ToPtr(goValue)))
 		return nil
 	}
 
@@ -556,120 +555,157 @@ func unmarshalUnion(schema *yang.Entry, parent interface{}, fieldName string, va
 	// Note that values can resolve into more than one struct type depending on
 	// the value and its range. In this case, no attempt is made to find the
 	// most restrictive type.
-
-	// Try to unmarshal in to enum types first, since the case of union of
-	// string and enum could unmarshal into either.
-	for _, ys := range yss {
-		valueStr, ok := value.(string)
-		if !ok {
-			// Only string values could be enum types.
-			continue
+	// Try to unmarshal to enum types first, since the case of union of string
+	// and enum could unmarshal into either. Only string values can be enum
+	// types.
+	valueStr, ok := value.(string)
+	if ok {
+		for _, ut := range uts {
+			util.DbgPrint("try to unmarshal into enum type %s", ut)
+			ev, err := castToEnumValue(ut, valueStr)
+			if err != nil {
+				return err
+			}
+			if ev != nil {
+				return setFieldWithTypedValue(parentT, destUnionFieldV, destUnionFieldElemT, ev)
+			}
+			util.DbgPrint("could not unmarshal %v into enum type: %s", value, err)
 		}
-		goValue, err := enumStringToUnionStructValue(schema, parent, fieldName, valueStr)
-		if err != nil {
-			util.DbgPrint("could not unmarshal %v into enum type %s: %s", value, ys.Type.Kind, err)
-			continue
-		}
-
-		vf.Set(reflect.ValueOf(goValue))
-		return nil
 	}
 
-	// Value does not match any enum type, so call the To_ function which will
-	// return a mapping of value to field type, if one matches.
-	// The "to union" conversion method is called To_<field type name>
-	mn := "To_" + ft.Name()
-	mapMethod := reflect.New(t).Elem().MethodByName(mn)
-	if !mapMethod.IsValid() {
-		return fmt.Errorf("%s in %T does not have a %s function", fieldName, parent, mn)
-	}
-
-	for _, yk := range yks {
-		goValue, err := unmarshalScalar(parent, yangKindToLeafEntry(yk), fieldName, value)
-		if err != nil {
-			util.DbgPrint("could not unmarshal %v into type %s: %s", value, yk, err)
-			continue
+	for _, yk := range uks {
+		util.DbgPrint("try to unmarshal into type %s", yk)
+		gv, err := unmarshalScalar(parent, yangKindToLeafEntry(yk), fieldName, value)
+		if err == nil {
+			return setFieldWithTypedValue(parentT, destUnionFieldV, destUnionFieldElemT, gv)
 		}
-
-		ec := mapMethod.Call([]reflect.Value{reflect.ValueOf(goValue)})
-		if len(ec) != 2 {
-			return fmt.Errorf("%s in %T %s function returns %d params", fieldName, parent, mn, len(ec))
-		}
-		ei := ec[0].Interface()
-		ee := ec[1].Interface()
-		if ee != nil {
-			util.DbgPrint("unmarshaled %v type %T does not have a union type", goValue, goValue)
-			continue
-		}
-
-		util.DbgPrint("unmarshaling %v into type %s", value, yk)
-		vf.Set(reflect.ValueOf(ei))
-		return nil
+		util.DbgPrint("could not unmarshal %v into type %s: %s", value, yk, err)
 	}
 
 	return fmt.Errorf("could not find suitable union type to unmarshal value %v type %T into parent struct type %T field %s", value, value, parent, fieldName)
 }
 
-func getUnionKindsAndEntries(schema *yang.Entry, t *yang.YangType) ([]yang.TypeKind, []*yang.Entry, error) {
-	var outk []yang.TypeKind
-	m := make(map[yang.TypeKind]interface{})
-	yts, oute, err := getUnionTypesAndEntries(schema, t)
+// setFieldWithTypedValue sets the field destV that has type ft and the given
+// parent type with v, which must be a compatible enum type.
+func setFieldWithTypedValue(parentT reflect.Type, destV reflect.Value, destElemT reflect.Type, v interface{}) error {
+	util.DbgPrint("setFieldWithTypedValue value %v into type %s", util.ValueStr(v), destElemT)
+	if destElemT.Kind() == reflect.Slice {
+		// leaf-list case
+		destElemT = destElemT.Elem()
+	}
+	mn := "To_" + destElemT.Name()
+	mapMethod := reflect.New(parentT).Elem().MethodByName(mn)
+	if !mapMethod.IsValid() {
+		return fmt.Errorf("%s does not have a %s function", destElemT.Name(), mn)
+	}
+	ec := mapMethod.Call([]reflect.Value{reflect.ValueOf(v)})
+	if len(ec) != 2 {
+		return fmt.Errorf("%s %s function returns %d params", destElemT.Name(), mn, len(ec))
+	}
+	ei := ec[0].Interface()
+	ee := ec[1].Interface()
+	if ee != nil {
+		return fmt.Errorf("unmarshaled %v type %T does not have a union type: %v", v, v, ee)
+	}
+
+	util.DbgPrint("unmarshaling %v into type %s", v, reflect.TypeOf(ei))
+
+	eiv := reflect.ValueOf(ei)
+	if destV.Type().Kind() == reflect.Slice {
+		destV.Set(reflect.Append(destV, eiv))
+	} else {
+		destV.Set(eiv)
+	}
+
+	return nil
+}
+
+// getUnionKindsAndTypes returns the YANG kinds of basic types and and 
+// reflect.Types of enum types that are possible for values for the union with 
+// the given schema and type.
+func getUnionKindsAndTypes(schema *yang.Entry, parentT reflect.Type) ([]yang.TypeKind, []reflect.Type, error) {
+	uks, err := getUnionKindsNotEnums(schema)
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, yt := range yts {
+	uts, err := schemaToEnumTypes(schema, parentT)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return uks, uts, nil
+}
+
+// getUnionKindsNotEnums returns all the YANG kinds under the given schema node,
+// dereferencing any refs.
+func getUnionKindsNotEnums(schema *yang.Entry) ([]yang.TypeKind, error) {
+	var uks []yang.TypeKind
+	m := make(map[yang.TypeKind]interface{})
+	uts, err := getUnionTypesNotEnums(schema, schema.Type)
+	if err != nil {
+		return nil, err
+	}
+	for _, yt := range uts {
 		m[yt.Kind] = nil
 	}
 	for k := range m {
-		outk = append(outk, k)
+		uks = append(uks, k)
 	}
-	return outk, oute, nil
+	return uks, nil
 }
 
-func getUnionTypesAndEntries(schema *yang.Entry, t *yang.YangType) ([]*yang.YangType, []*yang.Entry, error) {
-	var outk []*yang.YangType
-	var oute []*yang.Entry
-	switch t.Kind {
-	case yang.Yidentityref:
-		ns, err := findLeafRefSchema(schema, t.Path)
+// getUnionTypesNotEnums returns all the non-enum YANG types under the given schema 
+// node, dereferencing any refs.
+func getUnionTypesNotEnums(schema *yang.Entry, yt *yang.YangType) ([]*yang.YangType, error) {
+	var uts []*yang.YangType
+	switch yt.Kind {
+	case yang.Yenum, yang.Yidentityref:
+		// Enum types handled separately.
+		return nil, nil
+	case yang.Yleafref:
+		ns, err := findLeafRefSchema(schema, yt.Path)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		return nil, []*yang.Entry{ns}, nil
+		return getUnionTypesNotEnums(ns, ns.Type)
 	case yang.Yunion:
-		for _, t := range t.Type {
-			nk, ne, err := getUnionTypesAndEntries(schema, t)
+		for _, t := range yt.Type {
+			nt, err := getUnionTypesNotEnums(schema, t)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			outk = append(outk, nk...)
-			oute = append(oute, ne...)
+			uts = append(uts, nt...)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 		}
 	default:
-		outk = []*yang.YangType{t}
+		uts = []*yang.YangType{yt}
 	}
 
-	return outk, oute, nil
+	return uts, nil
 }
 
-func getFieldElemType(parent interface{}, fieldName string) (reflect.Type, error) {
-	t := reflect.TypeOf(parent)
-	ft, ok := t.Elem().FieldByName(fieldName)
-	if !ok {
-		return reflect.TypeOf(nil), fmt.Errorf("%s is not a valid field name in %T", fieldName, parent)
-	}
-	switch {
-	case util.IsTypeStructPtr(t):
-		return ft.Type, nil
-	case util.IsTypeSlicePtr(t):
-		// Dereference slice ptr, then Elem() gives slice element type.
-		return ft.Type.Elem().Elem(), nil
+// schemaToEnumTypes returns the actual enum types (rather than the interface
+// type) for a given schema, which must be for an enum type.
+func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, error) {
+	enumTypesMethod := reflect.New(t).Elem().MethodByName("ΛEnumTypeMap")
+	if !enumTypesMethod.IsValid() {
+		return nil, fmt.Errorf("type %s does not have a ΛEnumTypesMap function", t)
 	}
 
-	return reflect.TypeOf(nil), fmt.Errorf("%T is not a valid parent type", parent)
+	ec := enumTypesMethod.Call(nil)
+	if len(ec) == 0 {
+		return nil, fmt.Errorf("%s ΛEnumTypes function returns empty value", t)
+	}
+	ei := ec[0].Interface()
+	enumTypesMap, ok := ei.(map[string][]reflect.Type)
+	if !ok {
+		return nil, fmt.Errorf("%s ΛEnumTypes function returned wrong type %T, want map[string][]reflect.Type", t, ei)
+	}
+	util.DbgPrint("path is %s for schema %s", ygen.EntrySchemaPath(schema), schema.Name)
+
+	return enumTypesMap[ygen.EntrySchemaPath(schema)], nil
 }
 
 // unmarshalScalar unmarshals value, which is the Go type from json.Unmarshal,
@@ -686,6 +722,8 @@ func unmarshalScalar(parent interface{}, schema *yang.Entry, fieldName string, v
 	if err := validateLeafSchema(schema); err != nil {
 		return nil, err
 	}
+
+	util.DbgPrint("unmarshalScalar value %v, type %T, into parent type %T field %s", value, value, parent, fieldName)
 
 	ykind := schema.Type.Kind
 
@@ -720,7 +758,7 @@ func unmarshalScalar(parent interface{}, schema *yang.Entry, fieldName string, v
 		return floatV, nil
 
 	case yang.Yenum, yang.Yidentityref:
-		return enumStringToValue(schema, parent, fieldName, value.(string))
+		return enumStringToValue(parent, fieldName, value.(string))
 
 	case yang.Yint64:
 		// TODO(b/64812268): value types are different for internal style JSON.

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -709,7 +709,7 @@ func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, erro
 	p := ygen.EntrySchemaPath(schema)
 	m, ok := enumTypesMap[p]
 	if !ok {
-		return fmt.Errorf("schema %s with path %s does not have an entry in ΛEnumTypesMap", schema.Name, p)
+		return nil, fmt.Errorf("schema %s with path %s does not have an entry in ΛEnumTypesMap", schema.Name, p)
 	}
 	return m, nil
 }

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -815,9 +815,19 @@ func (*UnionLeafType_EnumType) ΛMap() map[string]map[int64]ygot.EnumDefinition 
 	return globalEnumMap
 }
 
+type UnionLeafType_EnumType2 struct {
+	EnumType2 EnumType2
+}
+
+func (*UnionLeafType_EnumType2) Is_UnionLeafType() {}
+
+func (*UnionLeafType_EnumType2) ΛMap() map[string]map[int64]ygot.EnumDefinition {
+	return globalEnumMap
+}
+
 func (*LeafContainerStruct) ΛEnumTypeMap() map[string][]reflect.Type {
 	return map[string][]reflect.Type{
-		"/union-leaf": []reflect.Type{reflect.TypeOf(UnionLeafType_EnumType{})},
+		"/union-leaf": []reflect.Type{reflect.TypeOf(EnumType(0)), reflect.TypeOf(EnumType2(0))},
 	}
 }
 
@@ -829,6 +839,8 @@ func (*LeafContainerStruct) To_UnionLeafType(i interface{}) (UnionLeafType, erro
 		return &UnionLeafType_Uint32{v}, nil
 	case EnumType:
 		return &UnionLeafType_EnumType{v}, nil
+	case EnumType2:
+		return &UnionLeafType_EnumType2{v}, nil
 	default:
 		return nil, fmt.Errorf("cannot convert %v to To_UnionLeafType, unknown union type, got: %T, want any of [string, uint32]", i, i)
 	}
@@ -905,6 +917,11 @@ func TestUnmarshalLeaf(t *testing.T) {
 			want: LeafContainerStruct{UnionLeaf: &UnionLeafType_EnumType{EnumType: 42}},
 		},
 		{
+			desc: "union enum2 success",
+			json: `{"union-leaf" : "E_VALUE_FORTY_THREE"}`,
+			want: LeafContainerStruct{UnionLeaf: &UnionLeafType_EnumType2{EnumType2: 43}},
+		},
+		{
 			desc:    "int32 bad type",
 			json:    `{"int32-leaf" : "-42"}`,
 			wantErr: `got string type for field int32-leaf, expect float64`,
@@ -962,7 +979,7 @@ func TestUnmarshalLeaf(t *testing.T) {
 		{
 			desc:    "enum bad value",
 			json:    `{"enum-leaf" : "E_BAD_VALUE"}`,
-			wantErr: `E_BAD_VALUE is not a valid value for enum field ytypes.EnumType`,
+			wantErr: `E_BAD_VALUE is not a valid value for enum field EnumLeaf, type ytypes.EnumType`,
 		},
 		{
 			desc:    "union bad type",
@@ -990,8 +1007,10 @@ func TestUnmarshalLeaf(t *testing.T) {
 					Kind: yang.Yuint32,
 				},
 				{
+					Kind: yang.Yenum,
+				},
+				{
 					Kind: yang.Yidentityref,
-					Path: "../enum-leaf",
 				},
 			},
 		},
@@ -1018,7 +1037,6 @@ func TestUnmarshalLeaf(t *testing.T) {
 	}
 
 	var jsonTree interface{}
-	// TODO DEBUG REMOVE
 	for _, test := range tests {
 		var parent LeafContainerStruct
 

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -895,7 +895,6 @@ func TestUnmarshalLeaf(t *testing.T) {
 			want: LeafContainerStruct{Uint64Leaf: ygot.Uint64(42)},
 		},
 		{
-			// TODO DEBUG 8
 			desc: "enum success",
 			json: `{"enum-leaf" : "E_VALUE_FORTY_TWO"}`,
 			want: LeafContainerStruct{EnumLeaf: 42},
@@ -911,7 +910,6 @@ func TestUnmarshalLeaf(t *testing.T) {
 			want: LeafContainerStruct{UnionLeaf: &UnionLeafType_Uint32{Uint32: 42}},
 		},
 		{
-			// TODO DEBUG 11
 			desc: "union enum success",
 			json: `{"union-leaf" : "E_VALUE_FORTY_TWO"}`,
 			want: LeafContainerStruct{UnionLeaf: &UnionLeafType_EnumType{EnumType: 42}},

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1027,7 +1027,7 @@ func TestUnmarshalLeaf(t *testing.T) {
 			Kind: yang.Yunion,
 			Type: []*yang.YangType{
 				{
-					// Note that Validate is not called as part of Unmarshal, 
+					// Note that Validate is not called as part of Unmarshal,
 					// therefore any string pattern will actually match.
 					Kind:    yang.Ystring,
 					Pattern: []string{"a+"},

--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -349,14 +349,14 @@ func unmarshalList(schema *yang.Entry, parent interface{}, jsonList interface{})
 }
 
 // makeKeyForInsert returns a key for inserting a struct newVal into the parent,
-// which must be a map. 
+// which must be a map.
 func makeKeyForInsert(schema *yang.Entry, parentMap interface{}, newVal reflect.Value) (reflect.Value, error) {
 	// Key is always a value type, never a ptr.
 	listKeyType := reflect.TypeOf(parentMap).Key()
 	newKey := reflect.New(listKeyType).Elem()
 
 	if listKeyType.Kind() == reflect.Struct {
-		// For struct key type, copy the key fields from the new list entry 
+		// For struct key type, copy the key fields from the new list entry
 		// struct newVal into the key struct.
 		for i := 0; i < newKey.NumField(); i++ {
 			kfn := listKeyType.Field(i).Name

--- a/ytypes/util_schema.go
+++ b/ytypes/util_schema.go
@@ -245,6 +245,20 @@ func schemaTreeRoot(schema *yang.Entry) *yang.Entry {
 	return root
 }
 
+// absoluteSchemaDataPath returns the absolute path of the schema, excluding
+// any choice or case entries.
+// TODO(mostrowski): why are these excluded?
+func absoluteSchemaDataPath(schema *yang.Entry) string {
+	out := []string{schema.Name}
+	for s := schema.Parent; s != nil; s = s.Parent {
+		if !isChoiceOrCase(s) && !isFakeRoot(s) {
+			out = append([]string{s.Name}, out...)
+		}
+	}
+
+	return "/" + strings.Join(out, "/")
+}
+
 // findFirstNonChoiceOrCase recursively traverses the schema tree and populates
 // m with the set of the first nodes in every path that neither case nor choice
 // nodes. The keys in the map are the schema element names of the matching


### PR DESCRIPTION
Unions with enums depend on new type resolution in the generated code. 
Enum types are strings in JSON source tree. To determine whether they can be represented as enums, the list of all possible enum types and their values is needed from the local schema context. 
If any of these values match, the field is cast as the corresponding type that implements the union interface. Otherwise, unmarshal is attempted into the other, non-enum types.