### PR TITLE
Fix issue with marshalling entities at the root which are in different modules to their children.

### DIFF
--- a/demo/bgp/main_test.go
+++ b/demo/bgp/main_test.go
@@ -33,8 +33,8 @@ const (
 // shown to the user in a test error message.
 func generateUnifiedDiff(want, got string) (string, error) {
 	diffl := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(got),
-		B:        difflib.SplitLines(want),
+		A:        difflib.SplitLines(want),
+		B:        difflib.SplitLines(got),
 		FromFile: "got",
 		ToFile:   "want",
 		Context:  3,

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1520,6 +1520,7 @@ func (*listAtRootChild) IsYANGGoStruct() {}
 // modules at the root.
 type diffModAtRoot struct {
 	Child *diffModAtRootChild `path:"" module:"m1"`
+	Elem  *diffModAtRootElem  `path:"" module:"m1"`
 }
 
 func (*diffModAtRoot) IsYANGGoStruct() {}
@@ -1531,6 +1532,18 @@ type diffModAtRootChild struct {
 }
 
 func (*diffModAtRootChild) IsYANGGoStruct() {}
+
+type diffModAtRootElem struct {
+	C *diffModAtRootElemTwo `path:"/baz/c" module:"m1"`
+}
+
+func (*diffModAtRootElem) IsYANGGoStruct() {}
+
+type diffModAtRootElemTwo struct {
+	Name *string `path:"name" module:"m1"`
+}
+
+func (*diffModAtRootElemTwo) IsYANGGoStruct() {}
 
 func TestConstructJSON(t *testing.T) {
 	tests := []struct {
@@ -1581,6 +1594,11 @@ func TestConstructJSON(t *testing.T) {
 				ValueTwo:   String("two"),
 				ValueThree: String("three"),
 			},
+			Elem: &diffModAtRootElem{
+				C: &diffModAtRootElemTwo{
+					Name: String("baz"),
+				},
+			},
 		},
 		inAppendMod: true,
 		wantIETF: map[string]interface{}{
@@ -1589,12 +1607,22 @@ func TestConstructJSON(t *testing.T) {
 				"m3:value-two": "two",
 				"value-three":  "three",
 			},
+			"m1:baz": map[string]interface{}{
+				"c": map[string]interface{}{
+					"name": "baz",
+				},
+			},
 		},
 		wantInternal: map[string]interface{}{
 			"foo": map[string]interface{}{
 				"value-one":   "one",
 				"value-two":   "two",
 				"value-three": "three",
+			},
+			"baz": map[string]interface{}{
+				"c": map[string]interface{}{
+					"name": "baz",
+				},
 			},
 		},
 	}, {

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -63,6 +63,11 @@ func structTagToLibPaths(f reflect.StructField, parentPath *gnmiPath) ([]*gnmiPa
 			}
 			ePath.AppendName(pp)
 		}
+
+		if len(p) > 0 && p[0] == '/' {
+			ePath.isAbsolute = true
+		}
+
 		mapPaths = append(mapPaths, ePath)
 	}
 	return mapPaths, nil


### PR DESCRIPTION
See this diff:

```diff
                 {
                -  "Cisco-IOS-XR-crypto-sam-cfg:Cisco-IOS-XR-crypto-ssh-cfg:crypto": {
                -    "ssh": {
                +  "Cisco-IOS-XR-crypto-sam-cfg:crypto": {
                +    "Cisco-IOS-XR-crypto-ssh-cfg:ssh": {
```

In the case of the 'crypto' leaf, since it is a different module to its SSH child, it was erroneously rendered. This is based on an assumption in the `ygot` library around where `ygen` path compresses, which was not robust in the case of the fake root and uncompressed schemas. This CL adds a fix, and tests for this case.