### PR TITLE
Fix unmarshal list as container.

### DIFF
--- a/util/debug.go
+++ b/util/debug.go
@@ -121,3 +121,19 @@ func SchemaTypeStr(schema *yang.Entry) string {
 	}
 	return "other"
 }
+
+// SchemaTreeString returns the schema hierarchy tree as a string with node
+// names and types only e.g.
+// clock (container)
+//   timezone (choice)
+//     timezone-name (case)
+//       timezone-name (leaf)
+//     timezone-utc-offset (case)
+//       timezone-utc-offset (leaf)
+func SchemaTreeString(schema *yang.Entry, prefix string) string {
+	out := prefix + schema.Name + " (" + SchemaTypeStr(schema) + ")" + "\n"
+	for _, ch := range schema.Dir {
+		out += SchemaTreeString(ch, prefix+"  ")
+	}
+	return out
+}

--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -399,9 +399,9 @@ func unmarshalContainerWithListSchema(schema *yang.Entry, parent interface{}, va
 	}
 	// Create a container equivalent of the list, which is just the list
 	// with ListAttrs unset.
-	newSchema := schema
+	newSchema := *schema
 	newSchema.ListAttr = nil
-	return Unmarshal(newSchema, parent, value)
+	return Unmarshal(&newSchema, parent, value)
 }
 
 // getKeyValue returns the value from the structVal field whose last path


### PR DESCRIPTION
Unmarshal as container introduced a bug where a deep copy of the schema node was not done before modifying. 