### PR TITLE
Fix bug whereby BuildEmptyTree + Merge results in empty struct.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -400,7 +400,10 @@ func copyStruct(dstVal, srcVal reflect.Value) error {
 }
 
 // copyPtrField copies srcField to dstField. srcField and dstField must be
-// reflect.Value structs which represent pointers.
+// reflect.Value structs which represent pointers. If the source and destination
+// are struct pointers, then their contents are merged. If the source and
+// destination are non-struct pointers, values are not merged and an error
+// is returned.
 func copyPtrField(dstField, srcField reflect.Value) error {
 
 	if util.IsNilOrInvalidValue(srcField) {

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -414,12 +414,26 @@ func copyPtrField(dstField, srcField reflect.Value) error {
 	// Check for struct ptr, or ptr to avoid panic.
 	if util.IsValueStructPtr(srcField) {
 		var d reflect.Value
-		d = reflect.New(srcField.Type().Elem())
+
+		// If the destination value is non-nil, then we maintain its contents
+		// this ensures that we maintain the non-overlapping contents in the
+		// struct that is being copied to.
+		if util.IsNilOrInvalidValue(dstField) {
+			d = reflect.New(srcField.Type().Elem())
+		} else {
+			d = dstField
+		}
+
 		if err := copyStruct(d.Elem(), srcField.Elem()); err != nil {
 			return err
 		}
 		dstField.Set(d)
 		return nil
+	}
+
+	if !util.IsNilOrInvalidValue(dstField) {
+		// Return an error when we are overwriting fields in the destination.
+		return fmt.Errorf("destination value was set when merging, src: %v, dst: %v", srcField.Elem().Interface(), dstField.Elem().Interface())
 	}
 
 	p := reflect.New(srcField.Type().Elem())


### PR DESCRIPTION
Fix bug found by @ejbrever in `MergeStructs`

```
 * (M) ygot/struct_validation_map.go
   - Fix an issue whereby an empty dst struct ptr was always used
     (created with reflect.New) in the case that structs were being
     merged. This means that if BuildEmptyTree had been used on the
     structs being merged, then even empty branches would be
     overwritten.
   - Return an error if a non-struct ptr is non-nil in two different
     structs.
  * (M) ygot/struct_validation_map_test.go
   - Add testing for returned errors.
   - Add testing to validate the BuildEmptyTree issue above.
```