### PR TITLE
Fix various nits

### DIFF
--- a/demo/getting_started/interfaces.go
+++ b/demo/getting_started/interfaces.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	oc "github.com/openconfig/ygot/demo/getting_started/pkg/ocdemo"
-	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -116,12 +115,10 @@ func main() {
 	}
 	ygot.BuildEmptyTree(subif)
 	_, err = subif.Ipv4.NewAddress("Not a valid address")
-	if errs := invalidIf.Validate(); errs == nil {
-		panic(fmt.Sprintf("Did not find invalid address, got nil err: %v", errs))
+	if err := invalidIf.Validate(); err == nil {
+		panic(fmt.Sprintf("Did not find invalid address, got nil err: %v", err))
 	} else {
-		for _, e := range errs {
-			fmt.Printf("Got expected error: %v\n", e)
-		}
+		fmt.Printf("Got expected error: %v\n", err)
 	}
 
 	// We can also validate the device overall.
@@ -143,10 +140,10 @@ func main() {
 	}
 	fmt.Println(json)
 
-  // The generated code includes an Unmarshal function, which can be used to load
-  // a data tree such as the one that we just created.
-  loadd := &oc.Device{}
-  if err := oc.Unmarshal([]byte(json), loadd); err != nil {
-    panic(fmt.Sprintf("Can't unmarshal JSON: %v", err))
-  }
+	// The generated code includes an Unmarshal function, which can be used to load
+	// a data tree such as the one that we just created.
+	loadd := &oc.Device{}
+	if err := oc.Unmarshal([]byte(json), loadd); err != nil {
+		panic(fmt.Sprintf("Can't unmarshal JSON: %v", err))
+	}
 }

--- a/demo/getting_started/interfaces.go
+++ b/demo/getting_started/interfaces.go
@@ -116,12 +116,11 @@ func main() {
 	}
 	ygot.BuildEmptyTree(subif)
 	_, err = subif.Ipv4.NewAddress("Not a valid address")
-	if err := invalidIf.Validate(); err == nil {
-		panic(fmt.Sprintf("Did not find invalid address, got nil err: %v", err))
+	if errs := invalidIf.Validate(); errs == nil {
+		panic(fmt.Sprintf("Did not find invalid address, got nil err: %v", errs))
 	} else {
-		errs := err.(util.Errors)
-		for _, err := range errs {
-			fmt.Printf("Got expected error: %v\n", err)
+		for _, e := range errs {
+			fmt.Printf("Got expected error: %v\n", e)
 		}
 	}
 

--- a/util/errs.go
+++ b/util/errs.go
@@ -27,9 +27,18 @@ func (e Errors) String() string {
 	return e.Error()
 }
 
+// NewErrs returns a slice of error with a single element err.
+// If err is nil, returns nil.
+func NewErrs(err error) Errors {
+	if err == nil {
+		return nil
+	}
+	return []error{err}
+}
+
 // AppendErr appends err to errors if it is not nil and returns the result.
 // If err is nil, it is not appended.
-func AppendErr(errors []error, err error) []error {
+func AppendErr(errors []error, err error) Errors {
 	if err == nil {
 		return errors
 	}
@@ -38,7 +47,7 @@ func AppendErr(errors []error, err error) []error {
 
 // AppendErrs appends newErrs to errors and returns the result.
 // If newErrs is empty, nothing is appended.
-func AppendErrs(errors []error, newErrs []error) []error {
+func AppendErrs(errors []error, newErrs []error) Errors {
 	if len(newErrs) == 0 {
 		return errors
 	}

--- a/util/errs_test.go
+++ b/util/errs_test.go
@@ -42,6 +42,19 @@ func TestToString(t *testing.T) {
 	}
 }
 
+func TestNewErrs(t *testing.T) {
+	var errs Errors
+	errs = NewErrs(nil)
+	if errs != nil {
+		t.Errorf("got: %s, want: nil", errs)
+	}
+
+	errs = NewErrs(fmt.Errorf("err1"))
+	if got, want := errs.String(), "err1"; got != want {
+		t.Errorf("got: %s, want: %s", got, want)
+	}
+}
+
 func TestAppendErr(t *testing.T) {
 	var errs Errors
 	if got, want := errs.String(), ""; got != want {

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -320,7 +320,8 @@ func InsertIntoMapStructField(parentStruct interface{}, fieldName string, key, f
 }
 
 // isFieldTypeCompatible reports whether f.Set(v) can be called successfully on
-// a struct field f corresponding to ft.
+// a struct field f corresponding to ft. It is assumed that f is exported and 
+// addressable.
 func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 	if ft.Type.Kind() == reflect.Ptr {
 		if !v.IsValid() {
@@ -335,7 +336,8 @@ func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 }
 
 // isValueTypeCompatible reports whether f.Set(v) can be called successfully on
-// a struct field f with type t.
+// a struct field f with type t. It is assumed that f is exported and 
+// addressable.
 func isValueTypeCompatible(t reflect.Type, v reflect.Value) bool {
 	if !v.IsValid() {
 		return t.Kind() == reflect.Ptr

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -66,8 +66,8 @@ func IsNilOrInvalidValue(v reflect.Value) bool {
 	return !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) || IsValueNil(v.Interface())
 }
 
-// IsValueNil is a general purpose nil check for the kinds of value types expected in
-// this package.
+// IsValueNil returns true if either value is nil, or has dynamic type {ptr,
+// map, slice} with value nil.
 func IsValueNil(value interface{}) bool {
 	if value == nil {
 		return true
@@ -123,19 +123,19 @@ func IsValueScalar(v reflect.Value) bool {
 	return !IsValueStruct(v) && !IsValueMap(v) && !IsValueSlice(v)
 }
 
-// IsInterfaceToStructPtr reports whether v is an interface that contains a pointer
-// to a struct.
+// IsInterfaceToStructPtr reports whether v is an interface that contains a
+// pointer to a struct.
 func IsValueInterfaceToStructPtr(v reflect.Value) bool {
 	return IsValueInterface(v) && IsValueStructPtr(v.Elem())
 }
 
-// IsStructValueWithNFields returns true if the reflect.Value representing a struct
-// v has n fields.
+// IsStructValueWithNFields returns true if the reflect.Value representing a
+// struct v has n fields.
 func IsStructValueWithNFields(v reflect.Value, n int) bool {
 	return IsValueStruct(v) && v.NumField() == n
 }
 
-// InsertIntoSlice inserts value into parent which must be a slice.
+// InsertIntoSlice inserts value into parent which must be a slice ptr.
 func InsertIntoSlice(parentSlice interface{}, value interface{}) error {
 	DbgPrint("InsertIntoSlice into parent type %T with value %v, type %T", parentSlice, ValueStr(value), value)
 
@@ -238,8 +238,8 @@ func InsertIntoStruct(parentStruct interface{}, fieldName string, fieldValue int
 	return nil
 }
 
-// InsertIntoSliceStructField inserts fieldValue into a field of type slice in parentStruct
-// called fieldName (which must exist, but may be nil).
+// InsertIntoSliceStructField inserts fieldValue into a field of type slice in
+// parentStruct called fieldName (which must exist, but may be nil).
 func InsertIntoSliceStructField(parentStruct interface{}, fieldName string, fieldValue interface{}) error {
 	DbgPrint("InsertIntoSliceStructField field %s of parent type %T with value %v", fieldName, parentStruct, ValueStr(fieldValue))
 
@@ -276,9 +276,10 @@ func InsertIntoSliceStructField(parentStruct interface{}, fieldName string, fiel
 	return nil
 }
 
-// InsertIntoMapStructField inserts fieldValue into a field of type map in parentStruct
-// called fieldName (which must exist, but may be nil), using the given key.
-// If the key already exists in the map, the corresponding value is updated.
+// InsertIntoMapStructField inserts fieldValue into a field of type map in
+// parentStruct called fieldName (which must exist, but may be nil), using the
+// given key. If the key already exists in the map, the corresponding value is
+// updated.
 func InsertIntoMapStructField(parentStruct interface{}, fieldName string, key, fieldValue interface{}) error {
 	DbgPrint("InsertIntoMapStructField field %s of parent type %T with key %v, value %v", fieldName, parentStruct, key, ValueStr(fieldValue))
 
@@ -318,6 +319,8 @@ func InsertIntoMapStructField(parentStruct interface{}, fieldName string, key, f
 	return nil
 }
 
+// isFieldTypeCompatible reports whether f.Set(v) can be called successfully on
+// a struct field f corresponding to ft.
 func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 	if ft.Type.Kind() == reflect.Ptr {
 		if !v.IsValid() {
@@ -325,12 +328,14 @@ func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 		}
 		return v.Type() == ft.Type
 	}
-	if !v.IsValid() || IsValueNil(v.Interface()) {
+	if !v.IsValid() {
 		return false
 	}
 	return v.Type() == ft.Type
 }
 
+// isValueTypeCompatible reports whether f.Set(v) can be called successfully on
+// a struct field f with type t.
 func isValueTypeCompatible(t reflect.Type, v reflect.Value) bool {
 	if !v.IsValid() {
 		return t.Kind() == reflect.Ptr

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -320,7 +320,7 @@ func InsertIntoMapStructField(parentStruct interface{}, fieldName string, key, f
 }
 
 // isFieldTypeCompatible reports whether f.Set(v) can be called successfully on
-// a struct field f corresponding to ft. It is assumed that f is exported and 
+// a struct field f corresponding to ft. It is assumed that f is exported and
 // addressable.
 func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 	if ft.Type.Kind() == reflect.Ptr {
@@ -336,7 +336,7 @@ func isFieldTypeCompatible(ft reflect.StructField, v reflect.Value) bool {
 }
 
 // isValueTypeCompatible reports whether f.Set(v) can be called successfully on
-// a struct field f with type t. It is assumed that f is exported and 
+// a struct field f with type t. It is assumed that f is exported and
 // addressable.
 func isValueTypeCompatible(t reflect.Type, v reflect.Value) bool {
 	if !v.IsValid() {

--- a/ytypes/any_type_test.go
+++ b/ytypes/any_type_test.go
@@ -39,7 +39,7 @@ func TestValidateAny(t *testing.T) {
 	for _, test := range tests {
 		err := validateAny(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateAny(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateAny(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -64,7 +64,7 @@ func TestValidateAnySlice(t *testing.T) {
 	for _, test := range tests {
 		err := validateAnySlice(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateAny(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateAny(%v) got error: %v, want error: %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/binary_type_test.go
+++ b/ytypes/binary_type_test.go
@@ -59,7 +59,7 @@ func TestValidateBinarySchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateBinarySchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBinarySchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateBinarySchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -114,7 +114,7 @@ func TestValidateBinarySchemaRanges(t *testing.T) {
 	for _, test := range tests {
 		err := validateBinarySchema(yrangeToBinarySchema(test.schemaName, test.length))
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBinarySchema(%v) got error: %v, wanted error? %v, ", test.desc, test.length, err, test.wantErr)
+			t.Errorf("%s: validateBinarySchema(%v) got error: %v, want error? %v, ", test.desc, test.length, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -167,7 +167,7 @@ func TestValidateBinary(t *testing.T) {
 	for _, test := range tests {
 		err := validateBinary(yrangeToBinarySchema(test.schemaName, test.length), test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: b.validateBinary(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: b.validateBinary(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -220,7 +220,7 @@ func TestValidateBinarySlice(t *testing.T) {
 	for _, test := range tests {
 		err := validateBinarySlice(yrangeToBinarySchema(test.schemaName, test.length), test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: b.validateBinarySlice(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: b.validateBinarySlice(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/bitset_type_test.go
+++ b/ytypes/bitset_type_test.go
@@ -66,7 +66,7 @@ func TestValidateBitsetSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateBitsetSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBitsetSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateBitsetSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -107,7 +107,7 @@ func TestValidateBitset(t *testing.T) {
 	for _, test := range tests {
 		err := validateBitset(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBitset(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateBitset(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -148,7 +148,7 @@ func TestValidateBitsetSlice(t *testing.T) {
 	for _, test := range tests {
 		err := validateBitsetSlice(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBitset(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateBitset(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/bool_type_test.go
+++ b/ytypes/bool_type_test.go
@@ -52,7 +52,7 @@ func TestValidateBoolSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateBoolSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBoolSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateBoolSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -87,7 +87,7 @@ func TestValidateBool(t *testing.T) {
 	for _, test := range tests {
 		err := validateBool(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBool(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateBool(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -128,7 +128,7 @@ func TestValidateSliceBoolType(t *testing.T) {
 	for _, test := range tests {
 		err := validateBoolSlice(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateBool(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateBool(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/choice_test.go
+++ b/ytypes/choice_test.go
@@ -98,7 +98,7 @@ func TestValidateChoice(t *testing.T) {
 	for _, test := range tests {
 		errs := Validate(containerWithChoiceSchema, test.val)
 		if got, want := (errs != nil), test.wantErr; got != want {
-			t.Errorf("%s: Validate got error: %s, wanted error? %v", test.desc, errs, test.wantErr)
+			t.Errorf("%s: Validate got error: %s, want error? %v", test.desc, errs, test.wantErr)
 		}
 		testErrLog(t, test.desc, errs)
 	}
@@ -208,7 +208,7 @@ func TestUnmarshalChoice(t *testing.T) {
 
 		err := Unmarshal(test.schema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {

--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -216,7 +216,7 @@ func TestValidateListAttr(t *testing.T) {
 		err := validateListAttr(test.schema, test.value)
 		// TODO(mostrowski): make consistent with rest of structs library.
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: TestValidateListAttr(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: TestValidateListAttr(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		if err != nil {
 			if testErrOutput {

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -28,13 +28,14 @@ import (
 
 // validateContainer validates each of the values in the map, keyed by the list
 // Key value, against the given list schema.
-func validateContainer(schema *yang.Entry, value ygot.GoStruct) (errors []error) {
+func validateContainer(schema *yang.Entry, value ygot.GoStruct) util.Errors {
+	var errors []error
 	if util.IsValueNil(value) {
 		return nil
 	}
 	// Check that the schema itself is valid.
 	if err := validateContainerSchema(schema); err != nil {
-		return util.AppendErr(errors, err)
+		return util.NewErrs(err)
 	}
 	util.DbgPrint("validateContainer with value %v, type %T, schema name %s", util.ValueStr(value), value, schema.Name)
 
@@ -60,7 +61,7 @@ func validateContainer(schema *yang.Entry, value ygot.GoStruct) (errors []error)
 				continue
 			case cschema != nil:
 				// Regular named child.
-				if errs := Validate(cschema, fieldValue); len(errs) != 0 {
+				if errs := Validate(cschema, fieldValue); errs != nil {
 					errors = util.AppendErrs(util.AppendErr(errors, fmt.Errorf("%s/", fieldName)), errs)
 				}
 			case !structElems.Field(i).IsNil():
@@ -93,7 +94,7 @@ func validateContainer(schema *yang.Entry, value ygot.GoStruct) (errors []error)
 		errors = util.AppendErr(errors, fmt.Errorf("fields %v are not found in the container schema %s", stringMapSetToSlice(extraFields), schema.Name))
 	}
 
-	return
+	return errors
 }
 
 // unmarshalContainer unmarshals a JSON tree into a struct.

--- a/ytypes/container_test.go
+++ b/ytypes/container_test.go
@@ -90,7 +90,7 @@ func TestValidateContainerSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateContainerSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateContainerSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateContainerSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -171,11 +171,11 @@ func TestValidateContainer(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", test.desc, got, want)
+		errs := Validate(test.schema, test.val)
+		if got, want := errs.String(), test.wantErr; got != want {
+			t.Errorf("%s: got error: %v, want error: %v", test.desc, got, want)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -284,7 +284,7 @@ func TestUnmarshalContainer(t *testing.T) {
 
 		err := Unmarshal(test.schema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {

--- a/ytypes/decimal_type_test.go
+++ b/ytypes/decimal_type_test.go
@@ -74,7 +74,7 @@ func TestValidateDecimalSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateDecimalSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validDecimalSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validDecimalSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -137,7 +137,7 @@ func TestValidateDecimalType(t *testing.T) {
 	for _, test := range tests {
 		err := validateDecimal(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateDecimal(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateDecimal(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -307,7 +307,7 @@ func TestValidateDecimalSlice(t *testing.T) {
 	for _, test := range tests {
 		err := validateDecimalSlice(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateDecimal(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateDecimal(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/empty_type_test.go
+++ b/ytypes/empty_type_test.go
@@ -52,7 +52,7 @@ func TestValidateEmptySchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateEmptySchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateEmptySchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateEmptySchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -104,7 +104,7 @@ func TestValidateEmpty(t *testing.T) {
 	for _, test := range tests {
 		err := validateEmpty(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateEmpty(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: validateEmpty(%v) got error: %v, want error? %v", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/int_type.go
+++ b/ytypes/int_type.go
@@ -152,8 +152,8 @@ func validateIntSchema(schema *yang.Entry) error {
 	}
 
 	if len(ranges) != 0 {
-		if err := ranges.Validate(); err != nil {
-			return err
+		if errs := ranges.Validate(); errs != nil {
+			return errs
 		}
 	}
 

--- a/ytypes/int_type_test.go
+++ b/ytypes/int_type_test.go
@@ -111,7 +111,7 @@ func TestValidateIntSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateIntSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateIntSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateIntSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -157,7 +157,7 @@ func TestValidateIntSchemaRanges(t *testing.T) {
 		for _, ty := range yangIntTypes {
 			err := validateIntSchema(typeAndRangeToIntSchema(test.desc+"-schema", ty, test.ranges))
 			if got, want := (err != nil), test.wantErr; got != want {
-				t.Errorf("%s: validateIntSchema(%v) for %v got error: %v, wanted error? %v",
+				t.Errorf("%s: validateIntSchema(%v) for %v got error: %v, want error? %v",
 					test.desc, ty, test.ranges, err, test.wantErr)
 			}
 			testErrLog(t, test.desc, err)

--- a/ytypes/leaf_list.go
+++ b/ytypes/leaf_list.go
@@ -28,13 +28,14 @@ import (
 // validateLeafList validates each of the values in value against the given
 // schema. value is expected to be a slice of the Go type corresponding to the
 // YANG type in the schema.
-func validateLeafList(schema *yang.Entry, value interface{}) (errors []error) {
+func validateLeafList(schema *yang.Entry, value interface{}) util.Errors {
+	var errors []error
 	if util.IsValueNil(value) {
 		return nil
 	}
 	// Check that the schema itself is valid.
 	if err := validateLeafListSchema(schema); err != nil {
-		return util.AppendErr(errors, err)
+		return util.NewErrs(err)
 	}
 
 	util.DbgPrint("validateLeafList with value %v, type %T, schema name %s", util.ValueStr(value), value, schema.Name)
@@ -58,7 +59,7 @@ func validateLeafList(schema *yang.Entry, value interface{}) (errors []error) {
 		errors = util.AppendErr(errors, fmt.Errorf("expected slice type for %s, got %T", schema.Name, value))
 	}
 
-	return
+	return errors
 }
 
 // validateLeafListSchema validates the given list type schema. This is a sanity

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -68,7 +68,7 @@ func TestValidateLeafListSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateLeafListSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateListSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateListSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -112,30 +112,30 @@ func TestValidateLeafList(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Validate(%v) got error: %v, wanted error? %v", test.desc, test.val, got, want)
+		errs := Validate(test.schema, test.val)
+		if got, want := errs.String(), test.wantErr; got != want {
+			t.Errorf("%s: Validate(%v) got error: %v, want error: %v", test.desc, test.val, got, want)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 
 	// nil value
 	if got := validateLeafList(nil, nil); got != nil {
-		t.Errorf("nil value: got error: %v, wanted error: nil", got)
+		t.Errorf("nil value: got error: %v, want error: nil", got)
 	}
 
 	// nil schema
 	err := util.Errors(validateLeafList(nil, &struct{}{})).Error()
 	wantErr := `list schema is nil`
 	if got, want := err, wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error: %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad value type
 	err = util.Errors(validateLeafList(validLeafListSchema, struct{}{})).Error()
 	wantErr = `expected slice type for valid-leaf-list-schema, got struct {}`
 	if got, want := err, wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 }
 
@@ -208,7 +208,7 @@ func TestUnmarshalLeafList(t *testing.T) {
 
 		err := Unmarshal(containerWithLeafListSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {
@@ -230,18 +230,18 @@ func TestUnmarshalLeafList(t *testing.T) {
 
 	// nil value
 	if got := unmarshalLeafList(nil, nil, nil); got != nil {
-		t.Errorf("nil value: Unmarshal got error: %v, wanted error? nil", got)
+		t.Errorf("nil value: Unmarshal got error: %v, want error: nil", got)
 	}
 
 	// nil schema
 	wantErr := `list schema is nil`
 	if got, want := errToString(unmarshalLeafList(nil, nil, []struct{}{})), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad value type
 	wantErr = `unmarshalLeafList for schema valid-leaf-list-schema: value 42 (type int): got type int, expect []interface{}`
 	if got, want := errToString(unmarshalLeafList(validLeafListSchema, &struct{}{}, int(42))), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 }

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -93,7 +93,7 @@ func TestValidateLeafSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateLeafSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateLeafSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateLeafSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -246,11 +246,11 @@ func TestValidateLeaf(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: Validate(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+		errs := Validate(test.schema, test.val)
+		if got, want := (errs != nil), test.wantErr; got != want {
+			t.Errorf("%s: Validate(%v) got error: %v, want error? %v", test.desc, test.schema, errs, test.wantErr)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -460,11 +460,11 @@ func TestValidateLeafUnion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", test.desc, err, test.wantErr)
+		errs := Validate(test.schema, test.val)
+		if got, want := (errs != nil), test.wantErr; got != want {
+			t.Errorf("%s: got error: %v, want error? %v", test.desc, errs, test.wantErr)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -802,11 +802,11 @@ func TestValidateLeafRef(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", test.desc, err, test.wantErr)
+		errs := Validate(test.schema, test.val)
+		if got, want := (errs != nil), test.wantErr; got != want {
+			t.Errorf("%s: got error: %v, want error? %v", test.desc, errs, test.wantErr)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -1224,7 +1224,7 @@ func TestUnmarshalLeaf(t *testing.T) {
 
 		err := Unmarshal(containerSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s (#%d): Unmarshal got error: %v, wanted error? %v", test.desc, idx, got, want)
+			t.Errorf("%s (#%d): Unmarshal got error: %v, want error: %v", test.desc, idx, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {
@@ -1238,14 +1238,14 @@ func TestUnmarshalLeaf(t *testing.T) {
 	err := Unmarshal(nil, &LeafContainerStruct{}, map[string]interface{}{})
 	wantErr := `nil schema for parent type *ytypes.LeafContainerStruct, value map[] (map[string]interface {})`
 	if got, want := errToString(err), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad parent type
 	err = unmarshalUnion(containerSchema, LeafContainerStruct{}, "int8-leaf", 42)
 	wantErr = `ytypes.LeafContainerStruct is not a struct ptr in unmarshalUnion`
 	if got, want := errToString(err), wantErr; got != want {
-		t.Errorf("bad parent type: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("bad parent type: Unmarshal got error: %v, want error: %v", got, want)
 	}
 }
 
@@ -1308,7 +1308,7 @@ func TestUnmarshalLeafRef(t *testing.T) {
 
 		err := Unmarshal(containerSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -111,7 +111,7 @@ func TestValidateListSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateListSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateListSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateListSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -120,21 +120,21 @@ func TestValidateListSchema(t *testing.T) {
 func TestValidateList(t *testing.T) {
 	// nil value
 	if got := validateList(nil, nil); got != nil {
-		t.Errorf("nil value: Unmarshal got error: %v, wanted error? nil", got)
+		t.Errorf("nil value: Unmarshal got error: %v, want error: nil", got)
 	}
 
 	// nil schema
 	err := util.Errors(validateList(nil, &struct{}{})).Error()
 	wantErr := `list schema is nil`
 	if got, want := err, wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad value type
 	err = util.Errors(validateList(validListSchema, struct{}{})).Error()
 	wantErr = `validateList expected map/slice type for valid-list-schema, got struct {}`
 	if got, want := err, wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 }
 
@@ -200,11 +200,11 @@ func TestValidateListNoKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := errToString(err), test.wantErr; got != want {
+		errs := Validate(test.schema, test.val)
+		if got, want := errs.String(), test.wantErr; got != want {
 			t.Errorf("%s: Validate got error: %v, want error: %v", test.desc, got, want)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -263,11 +263,11 @@ func TestValidateListSimpleKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(listSchema, test.val)
-		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: b.Validate(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+		errs := Validate(listSchema, test.val)
+		if got, want := (errs != nil), test.wantErr; got != want {
+			t.Errorf("%s: b.Validate(%v) got error: %v, want error? %v", test.desc, test.val, errs, test.wantErr)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
@@ -356,42 +356,42 @@ func TestValidateListStructKey(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(listSchemaStructKey, test.val)
-		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: b.Validate(%v) got error: %v, wanted error? %v", test.desc, test.val, err, test.wantErr)
+		errs := Validate(listSchemaStructKey, test.val)
+		if got, want := (errs != nil), test.wantErr; got != want {
+			t.Errorf("%s: b.Validate(%v) got error: %v, want error? %v", test.desc, test.val, errs, test.wantErr)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 }
 
 func TestUnmarshalList(t *testing.T) {
 	// nil value
 	if got := unmarshalList(nil, nil, nil); got != nil {
-		t.Errorf("nil value: Unmarshal got error: %v, wanted error? nil", got)
+		t.Errorf("nil value: Unmarshal got error: %v, want error: nil", got)
 	}
 
 	// nil schema
 	wantErr := `list schema is nil`
 	if got, want := errToString(unmarshalList(nil, nil, []struct{}{})), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad parent type
 	wantErr = `unmarshalList for valid-list-schema got parent type struct, expect map, slice ptr or struct ptr`
 	if got, want := errToString(unmarshalList(validListSchema, struct{}{}, []interface{}{})), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad value type
 	wantErr = `unmarshalContainer for schema valid-list-schema: jsonTree 42 (type int): got type int inside container, expect map[string]interface{}`
 	if got, want := errToString(unmarshalList(validListSchema, &struct{}{}, int(42))), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 
 	// bad parent type for unmarshalContainerWithListSchema
 	wantErr = `unmarshalContainerWithListSchema value [], type []interface {}, into parent type struct {}, schema name valid-list-schema: parent must be a struct ptr`
 	if got, want := errToString(unmarshalContainerWithListSchema(validListSchema, struct{}{}, []interface{}{})), wantErr; got != want {
-		t.Errorf("nil schema: Unmarshal got error: %v, wanted error? %v", got, want)
+		t.Errorf("nil schema: Unmarshal got error: %v, want error: %v", got, want)
 	}
 }
 
@@ -481,7 +481,7 @@ func TestUnmarshalUnkeyedList(t *testing.T) {
 
 		err := Unmarshal(test.schema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {
@@ -562,7 +562,7 @@ func TestUnmarshalKeyedList(t *testing.T) {
 
 		err := Unmarshal(containerWithLeafListSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {
@@ -657,7 +657,7 @@ func TestUnmarshalStructKeyedList(t *testing.T) {
 
 		err := Unmarshal(containerWithLeafListSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {
@@ -723,7 +723,7 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 
 		err := Unmarshal(listSchema, &parent, jsonTree)
 		if got, want := errToString(err), test.wantErr; got != want {
-			t.Errorf("%s: Unmarshal got error: %v, wanted error? %v", test.desc, got, want)
+			t.Errorf("%s: Unmarshal got error: %v, want error: %v", test.desc, got, want)
 		}
 		testErrLog(t, test.desc, err)
 		if err == nil {

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -447,7 +447,7 @@ func TestUnmarshal(t *testing.T) {
 
 		err = oc.Unmarshal(j, tt.parent)
 		if got, want := errToString(err), tt.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v ", tt.desc, got, want)
+			t.Errorf("%s: got error: %v, want error: %v ", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, err)
 		if err == nil {

--- a/ytypes/string_type_test.go
+++ b/ytypes/string_type_test.go
@@ -57,7 +57,7 @@ func TestValidateStringSchema(t *testing.T) {
 	for _, test := range tests {
 		err := validateStringSchema(test.schema)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateStringSchema(%v) got error: %v, wanted error? %v", test.desc, test.schema, err, test.wantErr)
+			t.Errorf("%s: validateStringSchema(%v) got error: %v, want error? %v", test.desc, test.schema, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -124,7 +124,7 @@ func TestValidateStringSchemaRanges(t *testing.T) {
 	for _, test := range tests {
 		err := validateStringSchema(yrangeAndPatternToStringSchema(test.schemaName, test.length, test.re))
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: validateStringSchema got error: %v, wanted error? %v", test.desc, err, test.wantErr)
+			t.Errorf("%s: validateStringSchema got error: %v, want error? %v", test.desc, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -292,7 +292,7 @@ func TestValidateString(t *testing.T) {
 	for _, test := range tests {
 		err := validateString(yrangeAndPatternToStringSchema(test.schemaName, test.length, test.re), test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: s.validateString(%v) got error: %v, wanted error? %t", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: s.validateString(%v) got error: %v, want error? %t", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}
@@ -339,7 +339,7 @@ func TestValidateStringSlice(t *testing.T) {
 	for _, test := range tests {
 		err := validateStringSlice(test.schema, test.val)
 		if got, want := (err != nil), test.wantErr; got != want {
-			t.Errorf("%s: s.validateStringSlice(%v) got error: %v, wanted error? %t", test.desc, test.val, err, test.wantErr)
+			t.Errorf("%s: s.validateStringSlice(%v) got error: %v, want error? %t", test.desc, test.val, err, test.wantErr)
 		}
 		testErrLog(t, test.desc, err)
 	}

--- a/ytypes/unmarshal_test.go
+++ b/ytypes/unmarshal_test.go
@@ -65,7 +65,7 @@ func TestUnmarshal(t *testing.T) {
 
 		err := Unmarshal(tt.schema, &parent, tt.value)
 		if got, want := errToString(err), tt.wantErr; got != want {
-			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
+			t.Errorf("%s: got error: %v, want error: %v", tt.desc, got, want)
 		}
 	}
 }

--- a/ytypes/util_schema.go
+++ b/ytypes/util_schema.go
@@ -78,12 +78,13 @@ func isInRange(yr yang.YRange, val yang.Number) bool {
 // validateListAttr validates any attributes of value present in the schema,
 // such as min/max elements. The schema and value can be a container,
 // list, or leaf-list type.
-func validateListAttr(schema *yang.Entry, value interface{}) (errors []error) {
+func validateListAttr(schema *yang.Entry, value interface{}) util.Errors {
+	var errors []error
 	if schema == nil {
-		return util.AppendErr(errors, fmt.Errorf("schema is nil"))
+		return util.NewErrs(fmt.Errorf("schema is nil"))
 	}
 	if schema.ListAttr == nil {
-		return util.AppendErr(errors, fmt.Errorf("schema %s ListAttr is nil", schema.Name))
+		return util.NewErrs(fmt.Errorf("schema %s ListAttr is nil", schema.Name))
 	}
 
 	var size int
@@ -94,7 +95,7 @@ func validateListAttr(schema *yang.Entry, value interface{}) (errors []error) {
 		case reflect.Slice, reflect.Map:
 			size = reflect.ValueOf(value).Len()
 		default:
-			return util.AppendErr(errors, fmt.Errorf("value %v type %T must be map or slice type for schema %s", value, value, schema.Name))
+			return util.NewErrs(fmt.Errorf("value %v type %T must be map or slice type for schema %s", value, value, schema.Name))
 		}
 	}
 
@@ -124,7 +125,7 @@ func validateListAttr(schema *yang.Entry, value interface{}) (errors []error) {
 		}
 	}
 
-	return
+	return errors
 }
 
 // isChoiceOrCase returns true if the entry is either a 'case' or a 'choice'

--- a/ytypes/validate_test.go
+++ b/ytypes/validate_test.go
@@ -162,11 +162,11 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Validate(test.schema, test.val)
-		if got, want := errToString(err), test.wantErr; got != want {
+		errs := Validate(test.schema, test.val)
+		if got, want := errs.String(), test.wantErr; got != want {
 			t.Errorf("%s: Validate got error: %s, want error: %s", test.desc, got, want)
 		}
-		testErrLog(t, test.desc, err)
+		testErrLog(t, test.desc, errs)
 	}
 
 }


### PR DESCRIPTION
- use NewErrs instead of AppendErr(errors, ...
- change signatures to return Errors so that caller can immediately print return value
- make various error strings consistent:
  - wanted error -> want error
  - use "want error?" only for bools
  - use errs where util.Errors are returned 
- other minor cleanups