### PR TITLE
Remove leading "/" from PathToStrings

### DIFF
--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -43,7 +43,7 @@ const (
 // representing the path.
 func PathToString(path *gnmipb.Path) (string, error) {
 	s, err := PathToStrings(path)
-	return stdpath.Join(s...), err
+	return "/" + stdpath.Join(s...), err
 }
 
 // PathToStrings takes a gNMI Path and provides its string representation. For example,
@@ -54,7 +54,7 @@ func PathToString(path *gnmipb.Path) (string, error) {
 // the path element using the format [name=value]. If the path specifies both pre-
 // and post-0.4.0 paths, the pre-0.4.0 version is returned.
 func PathToStrings(path *gnmipb.Path) ([]string, error) {
-	p := []string{"/"}
+	var p []string
 	if path.Element != nil {
 		for i, e := range path.Element {
 			if e == "" {

--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -40,7 +40,7 @@ const (
 )
 
 // PathToString is like PathToStrings, but returns a single formatted string
-// representing the path.
+// representing the path. Path is always treated as absolute.
 func PathToString(path *gnmipb.Path) (string, error) {
 	s, err := PathToStrings(path)
 	return "/" + stdpath.Join(s...), err

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -15,6 +15,7 @@
 package ygot
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -106,6 +107,22 @@ func TestPathToString(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("%s: PathToString(%v): got: %s, want: %s", tt.name, tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestPathToStrings(t *testing.T) {
+	in := &gnmipb.Path{Elem: []*gnmipb.PathElem{
+		{Name: "a"},
+		{Name: "b"},
+	}}
+	want := []string{"a", "b"}
+	got, err := PathToStrings(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PathToStrings(%v): got %q, want %q", in, got, want)
 	}
 }
 


### PR DESCRIPTION
The "/" is only needed in formatted string from PathToString.

Also add a short sanity unit test for PathToStrings, more detailed cases
are already covered via TestPathToString.