### PR TITLE
Add option framework for MergeStructs.

### DIFF
--- a/demo/device/devicedemo.go
+++ b/demo/device/devicedemo.go
@@ -79,7 +79,20 @@ func CreateDemoDeviceInstance() (*oc.Device, error) {
 	}
 	c.Type = &oc.Component_Type_Union_E_OpenconfigPlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT{oc.OpenconfigPlatformTypes_OPENCONFIG_SOFTWARE_COMPONENT_OPERATING_SYSTEM}
 
-	return d, nil
+	// Create a second device instance, and populate the OS component under
+	// it. This code demonstrates how ygot.MergeStructs can be used to combine
+	// multiple instances of the same type of struct together, allowing each
+	// subtree to be generated in its own context.
+	secondDev := &oc.Device{}
+	sc, err := secondDev.NewComponent("os")
+	sc.Description = ygot.String("RouterOS 14.0")
+	mergedDev, err := ygot.MergeStructs(d, secondDev)
+	if err != nil {
+		return nil, err
+	}
+	// Since ygot.MergeStructs returns an ygot.ValidatedGoStruct interface, we
+	// must type assert it back to *oc.Device.
+	return mergedDev.(*oc.Device), nil
 }
 
 // EmitJSON outputs the device instance specified as internal format JSON.

--- a/demo/device/testdata/device-ietf.json
+++ b/demo/device/testdata/device-ietf.json
@@ -48,6 +48,7 @@
             },
             "name": "os",
             "state": {
+               "description": "RouterOS 14.0",
                "type": "openconfig-platform-types:OPERATING_SYSTEM"
             }
          }

--- a/demo/device/testdata/device.json
+++ b/demo/device/testdata/device.json
@@ -7,6 +7,7 @@
             },
             "name": "os",
             "state": {
+               "description": "RouterOS 14.0",
                "type": "OPERATING_SYSTEM"
             }
          }

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -203,22 +203,12 @@ type EmitJSONConfig struct {
 	// Indent is the string used for indentation within the JSON output. The
 	// default value is three spaces.
 	Indent string
-	// ValidationOpts is the set of options that should be used to determine how
-	// the schema should be validated. This allows fine-grained control of particular
-	// validation rules in the case that a partially populated data instance is
-	// to be emitted.
-	ValidationOpts []ValidationOption
 }
 
 // EmitJSON takes an input ValidatedGoStruct (produced by ygen with validation enabled)
 // and serialises it to a JSON string. By default, produces the Internal format JSON.
 func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
-	var vopts []ValidationOption
-	if opts != nil {
-		vopts = opts.ValidationOpts
-	}
-
-	if err := s.Validate(vopts...); err != nil {
+	if err := s.Validate(); err != nil {
 		return "", fmt.Errorf("validation err: %v", err)
 	}
 
@@ -332,18 +322,35 @@ func MergeJSON(a, b map[string]interface{}) (map[string]interface{}, error) {
 	return o, nil
 }
 
+// MergeOption is an interface that is implemented by all parameters which specify a merge
+// behaviour when merging GoStructs.
+type MergeOption interface {
+	// IsMergeOption is a marker method for these options.
+	IsMergeOption()
+}
+
+// AllowLeafOverwrite allows scalar (leaf) fields to be overwritten in the destination
+// strucft when specified.
+type AllowLeafOverwrite struct {
+	IfEqual bool // IfEqual allows leaves to be overwritten only if their value is equal.
+}
+
+// IsMergeOption marks AllowLeafOverwrite as a valid MergeOption.
+func (*AllowLeafOverwrite) IsMergeOption() {}
+
+// NewAllowLeafOverwrite returns a new AllowLeafOverwrite pointer. The ifeq argument
+// specifies whether merging should only be allowed if the source and destination
+// leaves have equal values.
+func NewAllowLeafOverwrite(ifeq bool) *AllowLeafOverwrite { return &AllowLeafOverwrite{IfEqual: ifeq} }
+
 // MergeStructs takes two input ValidatedGoStructs and merges their contents,
 // returning a new ValidatedGoStruct. If the input structs a and b are of
 // different types, an error is returned.
 //
-// In the case that the structs contain a slice, or a map that is already
-// populated in both structs, an error is returned. Merging two lists with
-// identical members will be added in future iterations of this code.
-//
-// TODO(robjs): Fix the unimplemented test cases where two structs of
-// the same type have slices or maps that are already populated.
-// See https://github.com/openconfig/ygot/issues/74.
-func MergeStructs(a, b ValidatedGoStruct) (ValidatedGoStruct, error) {
+// Where two structs contain maps or slices that are populated in both a and b
+// their contents are merged. If a leaf is populated in both a and b, an error
+// is returned unless the AllowLeafOverwrite MergeOption is supplied.
+func MergeStructs(a, b ValidatedGoStruct, opts ...MergeOption) (ValidatedGoStruct, error) {
 	if reflect.TypeOf(a) != reflect.TypeOf(b) {
 		return nil, fmt.Errorf("cannot merge structs that are not of matching types, %T != %T", a, b)
 	}
@@ -354,7 +361,7 @@ func MergeStructs(a, b ValidatedGoStruct) (ValidatedGoStruct, error) {
 	}
 	n := reflect.ValueOf(tn)
 
-	if err := copyStruct(n.Elem(), reflect.ValueOf(b).Elem()); err != nil {
+	if err := copyStruct(n.Elem(), reflect.ValueOf(b).Elem(), opts...); err != nil {
 		return nil, fmt.Errorf("error merging b to new struct: %v", err)
 	}
 
@@ -372,7 +379,7 @@ func DeepCopy(s GoStruct) (GoStruct, error) {
 }
 
 // copyStruct copies the fields of srcVal into the dstVal struct in-place.
-func copyStruct(dstVal, srcVal reflect.Value) error {
+func copyStruct(dstVal, srcVal reflect.Value, opts ...MergeOption) error {
 	if srcVal.Type() != dstVal.Type() {
 		return fmt.Errorf("cannot copy %s to %s", srcVal.Type().Name(), dstVal.Type().Name())
 	}
@@ -381,13 +388,15 @@ func copyStruct(dstVal, srcVal reflect.Value) error {
 		return fmt.Errorf("cannot handle non-struct types, src: %v, dst: %v", srcVal.Type().Kind(), dstVal.Type().Kind())
 	}
 
+	lo := leafOverwriteOption(opts)
+
 	for i := 0; i < srcVal.NumField(); i++ {
 		srcField := srcVal.Field(i)
 		dstField := dstVal.Field(i)
 
 		switch srcField.Kind() {
 		case reflect.Ptr:
-			if err := copyPtrField(dstField, srcField); err != nil {
+			if err := copyPtrField(dstField, srcField, lo); err != nil {
 				return err
 			}
 		case reflect.Interface:
@@ -409,12 +418,26 @@ func copyStruct(dstVal, srcVal reflect.Value) error {
 	return nil
 }
 
+// leafOverwriteOption extracts the first AllowLeafOverwrite option from the supplied
+// slice of MergeOptions.
+func leafOverwriteOption(opts []MergeOption) *AllowLeafOverwrite {
+	for _, l := range opts {
+		switch l.(type) {
+		case *AllowLeafOverwrite:
+			return l.(*AllowLeafOverwrite)
+		}
+	}
+	return nil
+}
+
 // copyPtrField copies srcField to dstField. srcField and dstField must be
 // reflect.Value structs which represent pointers. If the source and destination
 // are struct pointers, then their contents are merged. If the source and
 // destination are non-struct pointers, values are not merged and an error
-// is returned.
-func copyPtrField(dstField, srcField reflect.Value) error {
+// is returned. If the source and destination both have a pointer field, which is
+// populated then an error is returned unless the AllowLeafOverwrite option is
+// supplied.
+func copyPtrField(dstField, srcField reflect.Value, ao *AllowLeafOverwrite) error {
 
 	if util.IsNilOrInvalidValue(srcField) {
 		return nil
@@ -445,8 +468,15 @@ func copyPtrField(dstField, srcField reflect.Value) error {
 	}
 
 	if !util.IsNilOrInvalidValue(dstField) {
-		// Return an error when we are overwriting fields in the destination.
-		return fmt.Errorf("destination value was set when merging, src: %v, dst: %v", srcField.Elem().Interface(), dstField.Elem().Interface())
+		if ao == nil {
+			// Return an error when we are overwriting fields in the destination unless
+			// the AllowLeafOverwrite option is specified.
+			return fmt.Errorf("destination value was set when merging, src: %v, dst: %v", srcField.Elem().Interface(), dstField.Elem().Interface())
+		}
+
+		if s, d := srcField.Elem().Interface(), dstField.Elem().Interface(); ao != nil && ao.IfEqual && !reflect.DeepEqual(s, d) {
+			return fmt.Errorf("destination value was not equal to source when merging with override, src: %v, dst: %v", s, d)
+		}
 	}
 
 	p := reflect.New(srcField.Type().Elem())
@@ -529,7 +559,10 @@ func copyMapField(dstField, srcField reflect.Value) error {
 				existingKeys[k.Interface()] = v
 			}
 
-			if err := copyStruct(d.Elem(), v.Elem()); err != nil {
+      // By default, we always set the allow leaf overwrite option for equal keys for merging
+      // maps, since the key value of the map is set within both of the structs. This means that
+      // we must allow leaves to be overwritten.
+			if err := copyStruct(d.Elem(), v.Elem(), NewAllowLeafOverwrite(true)); err != nil {
 				return err
 			}
 			nm.SetMapIndex(k, d)

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -203,12 +203,22 @@ type EmitJSONConfig struct {
 	// Indent is the string used for indentation within the JSON output. The
 	// default value is three spaces.
 	Indent string
+	// ValidationOpts is the set of options that should be used to determine how
+	// the schema should be validated. This allows fine-grained control of particular
+	// validation rules in the case that a partially populated data instance is
+	// to be emitted.
+	ValidationOpts []ValidationOption
 }
 
 // EmitJSON takes an input ValidatedGoStruct (produced by ygen with validation enabled)
 // and serialises it to a JSON string. By default, produces the Internal format JSON.
 func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
-	if err := s.Validate(); err != nil {
+	var vopts []ValidationOption
+	if opts != nil {
+		vopts = opts.ValidationOpts
+	}
+
+	if err := s.Validate(vopts...); err != nil {
 		return "", fmt.Errorf("validation err: %v", err)
 	}
 
@@ -559,9 +569,9 @@ func copyMapField(dstField, srcField reflect.Value) error {
 				existingKeys[k.Interface()] = v
 			}
 
-      // By default, we always set the allow leaf overwrite option for equal keys for merging
-      // maps, since the key value of the map is set within both of the structs. This means that
-      // we must allow leaves to be overwritten.
+			// By default, we always set the allow leaf overwrite option for equal keys for merging
+			// maps, since the key value of the map is set within both of the structs. This means that
+			// we must allow leaves to be overwritten.
 			if err := copyStruct(d.Elem(), v.Elem(), NewAllowLeafOverwrite(true)); err != nil {
 				return err
 			}

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -1361,7 +1361,6 @@ func TestMergeStructs(t *testing.T) {
 		name    string
 		inA     ValidatedGoStruct
 		inB     ValidatedGoStruct
-		inOpts  []MergeOption
 		want    ValidatedGoStruct
 		wantErr string
 	}{{
@@ -1397,29 +1396,21 @@ func TestMergeStructs(t *testing.T) {
 		name:    "error, field set in both structs",
 		inA:     &validatedMergeTest{String: String("karbach-hopadillo")},
 		inB:     &validatedMergeTest{String: String("blackwater-draw-brewing-co-border-town")},
-		wantErr: "error merging b to new struct: destination value was set when merging, src: blackwater-draw-brewing-co-border-town, dst: karbach-hopadillo",
+		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field, src: blackwater-draw-brewing-co-border-town, dst: karbach-hopadillo",
 	}, {
-		name:   "allow leaf overwrite if equal",
-		inA:    &validatedMergeTest{String: String("new-belgium-sour-saison")},
-		inB:    &validatedMergeTest{String: String("new-belgium-sour-saison")},
-		inOpts: []MergeOption{NewAllowLeafOverwrite(true)},
-		want:   &validatedMergeTest{String: String("new-belgium-sour-saison")},
-	}, {
-		name:   "allow leaf overwrite if unequal",
-		inA:    &validatedMergeTest{String: String("sierra-nevada-sidecar")},
-		inB:    &validatedMergeTest{String: String("deschutes-pacific-wonderland")},
-		inOpts: []MergeOption{NewAllowLeafOverwrite(false)},
-		want:   &validatedMergeTest{String: String("deschutes-pacific-wonderland")},
+		name: "allow leaf overwrite if equal",
+		inA:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
+		inB:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
+		want: &validatedMergeTest{String: String("new-belgium-sour-saison")},
 	}, {
 		name:    "error - merge leaf overwrite but not equal",
 		inA:     &validatedMergeTest{String: String("schneider-weisse-hopfenweisse")},
 		inB:     &validatedMergeTest{String: String("deschutes-jubelale")},
-		inOpts:  []MergeOption{NewAllowLeafOverwrite(true)},
-		wantErr: "error merging b to new struct: destination value was not equal to source when merging with override, src: deschutes-jubelale, dst: schneider-weisse-hopfenweisse",
+		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field, src: deschutes-jubelale, dst: schneider-weisse-hopfenweisse",
 	}}
 
 	for _, tt := range tests {
-		got, err := MergeStructs(tt.inA, tt.inB, tt.inOpts...)
+		got, err := MergeStructs(tt.inA, tt.inB)
 		if err != nil && err.Error() != tt.wantErr {
 			t.Errorf("%s: MergeStructs(%v, %v): did not get expected error status, got: %v, want: %v", tt.name, tt.inA, tt.inB, err, tt.wantErr)
 		}
@@ -1509,7 +1500,7 @@ func TestCopyErrorCases(t *testing.T) {
 		{"non-ptr", reflect.ValueOf(""), reflect.ValueOf(""), "received non-ptr type: string"},
 	}
 	for _, tt := range ptrErrs {
-		if err := copyPtrField(tt.inDst, tt.inSrc, nil); err == nil || err.Error() != tt.wantErr {
+		if err := copyPtrField(tt.inDst, tt.inSrc); err == nil || err.Error() != tt.wantErr {
 			t.Errorf("%s: copyPtrField(%v, %v): did not get expected error, got: %v, want: %v", tt.name, tt.inSrc, tt.inDst, err, tt.wantErr)
 		}
 	}

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -422,7 +422,7 @@ type mapStructNoPaths struct {
 func (*mapStructNoPaths) IsYANGGoStruct() {}
 
 // Validate implements the ValidatedGoStruct interface.
-func (*mapStructNoPaths) Validate(...ValidationOption) error                         { return nil }
+func (*mapStructNoPaths) Validate(...ValidationOption) error      { return nil }
 func (*mapStructNoPaths) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // TestEmitJSON validates that the EmitJSON function outputs the expected JSON
@@ -1343,7 +1343,7 @@ type validatedMergeTest struct {
 	Uint32Field *uint32
 }
 
-func (*validatedMergeTest) Validate(...ValidationOption) error                         { return nil }
+func (*validatedMergeTest) Validate(...ValidationOption) error      { return nil }
 func (*validatedMergeTest) IsYANGGoStruct()                         {}
 func (*validatedMergeTest) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1352,7 +1352,7 @@ type validatedMergeTestTwo struct {
 	I      interface{}
 }
 
-func (*validatedMergeTestTwo) Validate(...ValidationOption) error                         { return nil }
+func (*validatedMergeTestTwo) Validate(...ValidationOption) error      { return nil }
 func (*validatedMergeTestTwo) IsYANGGoStruct()                         {}
 func (*validatedMergeTestTwo) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1595,7 +1595,7 @@ type buildEmptyTreeMergeTest struct {
 	String   *string
 }
 
-func (*buildEmptyTreeMergeTest) Validate(...ValidationOption) error                         { return nil }
+func (*buildEmptyTreeMergeTest) Validate(...ValidationOption) error      { return nil }
 func (*buildEmptyTreeMergeTest) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTest) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1605,7 +1605,7 @@ type buildEmptyTreeMergeTestChild struct {
 	String        *string
 }
 
-func (*buildEmptyTreeMergeTestChild) Validate(...ValidationOption) error                         { return nil }
+func (*buildEmptyTreeMergeTestChild) Validate(...ValidationOption) error      { return nil }
 func (*buildEmptyTreeMergeTestChild) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTestChild) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1613,7 +1613,7 @@ type buildEmptyTreeMergeTestGrandchild struct {
 	String *string
 }
 
-func (*buildEmptyTreeMergeTestGrandchild) Validate(...ValidationOption) error                         { return nil }
+func (*buildEmptyTreeMergeTestGrandchild) Validate(...ValidationOption) error      { return nil }
 func (*buildEmptyTreeMergeTestGrandchild) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTestGrandchild) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -422,7 +422,7 @@ type mapStructNoPaths struct {
 func (*mapStructNoPaths) IsYANGGoStruct() {}
 
 // Validate implements the ValidatedGoStruct interface.
-func (*mapStructNoPaths) Validate(...ValidationOption) error      { return nil }
+func (*mapStructNoPaths) Validate(...ValidationOption) error                         { return nil }
 func (*mapStructNoPaths) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
 // TestEmitJSON validates that the EmitJSON function outputs the expected JSON
@@ -1343,7 +1343,7 @@ type validatedMergeTest struct {
 	Uint32Field *uint32
 }
 
-func (*validatedMergeTest) Validate(...ValidationOption) error      { return nil }
+func (*validatedMergeTest) Validate(...ValidationOption) error                         { return nil }
 func (*validatedMergeTest) IsYANGGoStruct()                         {}
 func (*validatedMergeTest) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1352,7 +1352,7 @@ type validatedMergeTestTwo struct {
 	I      interface{}
 }
 
-func (*validatedMergeTestTwo) Validate(...ValidationOption) error      { return nil }
+func (*validatedMergeTestTwo) Validate(...ValidationOption) error                         { return nil }
 func (*validatedMergeTestTwo) IsYANGGoStruct()                         {}
 func (*validatedMergeTestTwo) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1361,6 +1361,7 @@ func TestMergeStructs(t *testing.T) {
 		name    string
 		inA     ValidatedGoStruct
 		inB     ValidatedGoStruct
+		inOpts  []MergeOption
 		want    ValidatedGoStruct
 		wantErr string
 	}{{
@@ -1397,10 +1398,28 @@ func TestMergeStructs(t *testing.T) {
 		inA:     &validatedMergeTest{String: String("karbach-hopadillo")},
 		inB:     &validatedMergeTest{String: String("blackwater-draw-brewing-co-border-town")},
 		wantErr: "error merging b to new struct: destination value was set when merging, src: blackwater-draw-brewing-co-border-town, dst: karbach-hopadillo",
+	}, {
+		name:   "allow leaf overwrite if equal",
+		inA:    &validatedMergeTest{String: String("new-belgium-sour-saison")},
+		inB:    &validatedMergeTest{String: String("new-belgium-sour-saison")},
+		inOpts: []MergeOption{NewAllowLeafOverwrite(true)},
+		want:   &validatedMergeTest{String: String("new-belgium-sour-saison")},
+	}, {
+		name:   "allow leaf overwrite if unequal",
+		inA:    &validatedMergeTest{String: String("sierra-nevada-sidecar")},
+		inB:    &validatedMergeTest{String: String("deschutes-pacific-wonderland")},
+		inOpts: []MergeOption{NewAllowLeafOverwrite(false)},
+		want:   &validatedMergeTest{String: String("deschutes-pacific-wonderland")},
+	}, {
+		name:    "error - merge leaf overwrite but not equal",
+		inA:     &validatedMergeTest{String: String("schneider-weisse-hopfenweisse")},
+		inB:     &validatedMergeTest{String: String("deschutes-jubelale")},
+		inOpts:  []MergeOption{NewAllowLeafOverwrite(true)},
+		wantErr: "error merging b to new struct: destination value was not equal to source when merging with override, src: deschutes-jubelale, dst: schneider-weisse-hopfenweisse",
 	}}
 
 	for _, tt := range tests {
-		got, err := MergeStructs(tt.inA, tt.inB)
+		got, err := MergeStructs(tt.inA, tt.inB, tt.inOpts...)
 		if err != nil && err.Error() != tt.wantErr {
 			t.Errorf("%s: MergeStructs(%v, %v): did not get expected error status, got: %v, want: %v", tt.name, tt.inA, tt.inB, err, tt.wantErr)
 		}
@@ -1490,7 +1509,7 @@ func TestCopyErrorCases(t *testing.T) {
 		{"non-ptr", reflect.ValueOf(""), reflect.ValueOf(""), "received non-ptr type: string"},
 	}
 	for _, tt := range ptrErrs {
-		if err := copyPtrField(tt.inDst, tt.inSrc); err == nil || err.Error() != tt.wantErr {
+		if err := copyPtrField(tt.inDst, tt.inSrc, nil); err == nil || err.Error() != tt.wantErr {
 			t.Errorf("%s: copyPtrField(%v, %v): did not get expected error, got: %v, want: %v", tt.name, tt.inSrc, tt.inDst, err, tt.wantErr)
 		}
 	}
@@ -1576,7 +1595,7 @@ type buildEmptyTreeMergeTest struct {
 	String   *string
 }
 
-func (*buildEmptyTreeMergeTest) Validate(...ValidationOption) error      { return nil }
+func (*buildEmptyTreeMergeTest) Validate(...ValidationOption) error                         { return nil }
 func (*buildEmptyTreeMergeTest) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTest) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1586,7 +1605,7 @@ type buildEmptyTreeMergeTestChild struct {
 	String        *string
 }
 
-func (*buildEmptyTreeMergeTestChild) Validate(...ValidationOption) error      { return nil }
+func (*buildEmptyTreeMergeTestChild) Validate(...ValidationOption) error                         { return nil }
 func (*buildEmptyTreeMergeTestChild) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTestChild) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 
@@ -1594,7 +1613,7 @@ type buildEmptyTreeMergeTestGrandchild struct {
 	String *string
 }
 
-func (*buildEmptyTreeMergeTestGrandchild) Validate(...ValidationOption) error      { return nil }
+func (*buildEmptyTreeMergeTestGrandchild) Validate(...ValidationOption) error                         { return nil }
 func (*buildEmptyTreeMergeTestGrandchild) IsYANGGoStruct()                         {}
 func (*buildEmptyTreeMergeTestGrandchild) ΛEnumTypeMap() map[string][]reflect.Type { return nil }
 


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map.go:
 * (M) ygot/struct_validation_map_test.go:
    - Add an opts slice to MergeStructs which allows options to be
      specified when merging structs. Particularly, allow overwrite of a
      pointer field that is specified in both structs. In the case that
      the IfEqual bool is set true, merging is only allowed when the two
      values are equal. This is particularly aimed to handle merging
      lists which always have equal keys.
    - Change default behaviour for merging map structs to be allowing
      leaf overwrites.
```