### PR TITLE
Fix ValidationOpts interface implementation for LeafrefOptions.

### DIFF
--- a/ytypes/validate.go
+++ b/ytypes/validate.go
@@ -38,7 +38,7 @@ type LeafrefOptions struct {
 
 // IsValidationOption ensures that LeafrefOptions implements the ValidationOption
 // interface.
-func (LeafrefOptions) IsValidationOption() {}
+func (*LeafrefOptions) IsValidationOption() {}
 
 // Validate recursively validates the value of the given data tree struct
 // against the given schema.


### PR DESCRIPTION
```
 * (M) ytypes/validate.go
  - LeafrefOptions was previously implementing ValidationOpts as
    a non-pointer receiver. The handling code expected the
    implementation to be a pointer - this CL changes the receiver to
    be a pointer receiver.
```