### PR TITLE
Add a method to rename a list entry, and associated testing.

### DIFF
--- a/exampleoc/update.sh
+++ b/exampleoc/update.sh
@@ -6,6 +6,7 @@ cp ../demo/getting_started/yang/{ietf,iana}* deps
 go run ../generator/generator.go -path=public,deps -output_file=oc.go \
   -package_name=exampleoc -generate_fakeroot -fakeroot_name=device -compress_paths=true \
   -exclude_modules=ietf-interfaces \
+  -generate_rename \
   public/release/models/network-instance/openconfig-network-instance.yang \
   public/release/models/optical-transport/openconfig-optical-amplifier.yang \
   public/release/models/optical-transport/openconfig-terminal-device.yang \

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -43,6 +43,7 @@ var (
 	ygotImportPath   = flag.String("ygot_path", ygen.DefaultYgotImportPath, "The import path to use for ygot.")
 	ytypesImportPath = flag.String("ytypes_path", ygen.DefaultYtypesImportPath, "The import path to use for ytypes.")
 	goyangImportPath = flag.String("goyang_path", ygen.DefaultGoyangImportPath, "The import path to use for goyang's yang package.")
+	generateRename   = flag.Bool("generate_rename", false, "If set to true, rename methods are generated for lists within the Go code.")
 )
 
 // writeGoCode takes a ygen.GeneratedGoCode struct and writes the Go code
@@ -149,9 +150,10 @@ func main() {
 			IgnoreSubmoduleCircularDependencies: *ignoreCircDeps,
 		},
 		GoOptions: ygen.GoOpts{
-			YgotImportPath:   *ygotImportPath,
-			YtypesImportPath: *ytypesImportPath,
-			GoyangImportPath: *goyangImportPath,
+			YgotImportPath:       *ygotImportPath,
+			YtypesImportPath:     *ytypesImportPath,
+			GoyangImportPath:     *goyangImportPath,
+			GenerateRenameMethod: *generateRename,
 		},
 	})
 

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -99,6 +99,9 @@ type GoOpts struct {
 	// YtypesImportPath specifies the path to ytypes library that should be used
 	// in the generated code.
 	YtypesImportPath string
+	// GenerateRenameMethod specifies whether methods for renaming list entries
+	// should be generated in the output Go code.
+	GenerateRenameMethod bool
 }
 
 // ProtoOpts stores Protobuf specific options for the code generation library.
@@ -341,7 +344,7 @@ func (cg *YANGCodeGenerator) GenerateGoCode(yangFiles, includePaths []string) (*
 	codegenErr := NewYANGCodeGeneratorError()
 	var structSnippets []string
 	for _, structName := range orderedStructNames {
-		structOut, errs := writeGoStruct(structNameMap[structName], goStructs, cg.state, cg.Config.CompressOCPaths, cg.Config.GenerateJSONSchema)
+		structOut, errs := writeGoStruct(structNameMap[structName], goStructs, cg.state, cg.Config.CompressOCPaths, cg.Config.GenerateJSONSchema, cg.Config.GoOptions.GenerateRenameMethod)
 		if errs != nil {
 			codegenErr.Errors = append(codegenErr.Errors, errs...)
 			continue

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -392,9 +392,14 @@ func TestSimpleStructs(t *testing.T) {
 		inFiles:             []string{filepath.Join(TestRoot, "testdata/structs/openconfig-simple.yang")},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata/structs/openconfig-simple-no-compress.formatted-txt"),
 	}, {
-		name:                "simple openconfig test, with a list",
-		inFiles:             []string{filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.yang")},
-		inConfig:            GeneratorConfig{CompressOCPaths: true},
+		name:    "simple openconfig test, with a list",
+		inFiles: []string{filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.yang")},
+		inConfig: GeneratorConfig{
+			CompressOCPaths: true,
+			GoOptions: GoOpts{
+				GenerateRenameMethod: true,
+			},
+		},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.formatted-txt"),
 	}, {
 		name:                "simple openconfig test, with a list that has an enumeration key",

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -631,18 +631,26 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 }
 
 // RenameListWithKey renames an entry in the list ListWithKey within
-// the Tstruct struct. The entry with key old is renamed to new, updating
+// the Tstruct struct. The entry with key oldk is renamed to newk updating
 // the key within the value.
-func (t *Tstruct) RenameListWithKey(old, new string) error {
-	e, ok := t.ListWithKey[old]
+func (t *Tstruct) RenameListWithKey(oldk, newk string) error {
+	e, ok := t.ListWithKey[oldk]
 	if !ok {
-		return fmt.Errorf("key %v not found in ListWithKey", old)
+		return fmt.Errorf("key %v not found in ListWithKey", oldk)
 	}
 
-	n := ygot.DeepCopy(e)
-	n.KeyLeaf = new
-	delete(t.ListWithKey, old)
-	t.ListWithKey[new] = n
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*ListWithKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.KeyLeaf = &newk
+
+	delete(t.ListWithKey, oldk)
+	t.ListWithKey[newk] = n
 	return nil
 }
 
@@ -700,18 +708,26 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 }
 
 // RenameListWithKey renames an entry in the list ListWithKey within
-// the Tstruct struct. The entry with key old is renamed to new, updating
+// the Tstruct struct. The entry with key oldk is renamed to newk updating
 // the key within the value.
-func (t *Tstruct) RenameListWithKey(old, new string) error {
-	e, ok := t.ListWithKey[old]
+func (t *Tstruct) RenameListWithKey(oldk, newk string) error {
+	e, ok := t.ListWithKey[oldk]
 	if !ok {
-		return fmt.Errorf("key %v not found in ListWithKey", old)
+		return fmt.Errorf("key %v not found in ListWithKey", oldk)
 	}
 
-	n := ygot.DeepCopy(e)
-	n.KeyLeaf = new
-	delete(t.ListWithKey, old)
-	t.ListWithKey[new] = n
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*ListWithKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.KeyLeaf = &newk
+
+	delete(t.ListWithKey, oldk)
+	t.ListWithKey[newk] = n
 	return nil
 }
 
@@ -902,18 +918,27 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 }
 
 // RenameListWithKey renames an entry in the list ListWithKey within
-// the Tstruct struct. The entry with key old is renamed to new, updating
+// the Tstruct struct. The entry with key oldk is renamed to newk updating
 // the key within the value.
-func (t *Tstruct) RenameListWithKey(old, new Tstruct_ListWithKey_Key) error {
-	e, ok := t.ListWithKey[old]
+func (t *Tstruct) RenameListWithKey(oldk, newk Tstruct_ListWithKey_Key) error {
+	e, ok := t.ListWithKey[oldk]
 	if !ok {
-		return fmt.Errorf("key %v not found in ListWithKey", old)
+		return fmt.Errorf("key %v not found in ListWithKey", oldk)
 	}
 
-	n := ygot.DeepCopy(e)
-	n.KeyLeafOne = new.KeyLeafOnen.KeyLeafTwo = new.KeyLeafTwo
-	delete(t.ListWithKey, old)
-	t.ListWithKey[new] = n
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*ListWithKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.KeyLeafOne = &newk.KeyLeafOne
+	n.KeyLeafTwo = &newk.KeyLeafTwo
+
+	delete(t.ListWithKey, oldk)
+	t.ListWithKey[newk] = n
 	return nil
 }
 
@@ -982,18 +1007,27 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 }
 
 // RenameListWithKey renames an entry in the list ListWithKey within
-// the Tstruct struct. The entry with key old is renamed to new, updating
+// the Tstruct struct. The entry with key oldk is renamed to newk updating
 // the key within the value.
-func (t *Tstruct) RenameListWithKey(old, new Tstruct_ListWithKey_Key) error {
-	e, ok := t.ListWithKey[old]
+func (t *Tstruct) RenameListWithKey(oldk, newk Tstruct_ListWithKey_Key) error {
+	e, ok := t.ListWithKey[oldk]
 	if !ok {
-		return fmt.Errorf("key %v not found in ListWithKey", old)
+		return fmt.Errorf("key %v not found in ListWithKey", oldk)
 	}
 
-	n := ygot.DeepCopy(e)
-	n.KeyLeafOne = new.KeyLeafOnen.KeyLeafTwo = new.KeyLeafTwo
-	delete(t.ListWithKey, old)
-	t.ListWithKey[new] = n
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*ListWithKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.KeyLeafOne = &newk.KeyLeafOne
+	n.KeyLeafTwo = &newk.KeyLeafTwo
+
+	delete(t.ListWithKey, oldk)
+	t.ListWithKey[newk] = n
 	return nil
 }
 

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -62,6 +62,7 @@ func TestGoCodeStructGeneration(t *testing.T) {
 		// defined during the pre-processing of the module, it is used to
 		// determine the names of referenced lists and structs.
 		inUniqueDirectoryNames map[string]string
+		inGenerateRenameMethod bool
 		wantCompressed         wantGoStructOut
 		wantUncompressed       wantGoStructOut
 	}{{
@@ -588,6 +589,7 @@ func (t *QStruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes
 		inUniqueDirectoryNames: map[string]string{
 			"/root-module/tstruct/listWithKey": "ListWithKey",
 		},
+		inGenerateRenameMethod: true,
 		wantCompressed: wantGoStructOut{
 			structs: `
 // Tstruct represents the /root-module/tstruct YANG schema element.
@@ -626,6 +628,22 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 	}
 
 	return t.ListWithKey[key], nil
+}
+
+// RenameListWithKey renames an entry in the list ListWithKey within
+// the Tstruct struct. The entry with key old is renamed to new, updating
+// the key within the value.
+func (t *Tstruct) RenameListWithKey(old, new string) error {
+	e, ok := t.ListWithKey[old]
+	if !ok {
+		return fmt.Errorf("key %v not found in ListWithKey", old)
+	}
+
+	n := ygot.DeepCopy(e)
+	n.KeyLeaf = new
+	delete(t.ListWithKey, old)
+	t.ListWithKey[new] = n
+	return nil
 }
 
 // Validate validates s against the YANG schema corresponding to its type.
@@ -679,6 +697,22 @@ func (t *Tstruct) NewListWithKey(KeyLeaf string) (*ListWithKey, error){
 	}
 
 	return t.ListWithKey[key], nil
+}
+
+// RenameListWithKey renames an entry in the list ListWithKey within
+// the Tstruct struct. The entry with key old is renamed to new, updating
+// the key within the value.
+func (t *Tstruct) RenameListWithKey(old, new string) error {
+	e, ok := t.ListWithKey[old]
+	if !ok {
+		return fmt.Errorf("key %v not found in ListWithKey", old)
+	}
+
+	n := ygot.DeepCopy(e)
+	n.KeyLeaf = new
+	delete(t.ListWithKey, old)
+	t.ListWithKey[new] = n
+	return nil
 }
 
 // Validate validates s against the YANG schema corresponding to its type.
@@ -815,6 +849,7 @@ func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes
 		inUniqueDirectoryNames: map[string]string{
 			"/root-module/tstruct/listWithKey": "ListWithKey",
 		},
+		inGenerateRenameMethod: true,
 		wantCompressed: wantGoStructOut{
 			structs: `
 // Tstruct represents the /root-module/tstruct YANG schema element.
@@ -864,6 +899,22 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 	}
 
 	return t.ListWithKey[key], nil
+}
+
+// RenameListWithKey renames an entry in the list ListWithKey within
+// the Tstruct struct. The entry with key old is renamed to new, updating
+// the key within the value.
+func (t *Tstruct) RenameListWithKey(old, new Tstruct_ListWithKey_Key) error {
+	e, ok := t.ListWithKey[old]
+	if !ok {
+		return fmt.Errorf("key %v not found in ListWithKey", old)
+	}
+
+	n := ygot.DeepCopy(e)
+	n.KeyLeafOne = new.KeyLeafOnen.KeyLeafTwo = new.KeyLeafTwo
+	delete(t.ListWithKey, old)
+	t.ListWithKey[new] = n
+	return nil
 }
 
 // Validate validates s against the YANG schema corresponding to its type.
@@ -930,6 +981,22 @@ func (t *Tstruct) NewListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 	return t.ListWithKey[key], nil
 }
 
+// RenameListWithKey renames an entry in the list ListWithKey within
+// the Tstruct struct. The entry with key old is renamed to new, updating
+// the key within the value.
+func (t *Tstruct) RenameListWithKey(old, new Tstruct_ListWithKey_Key) error {
+	e, ok := t.ListWithKey[old]
+	if !ok {
+		return fmt.Errorf("key %v not found in ListWithKey", old)
+	}
+
+	n := ygot.DeepCopy(e)
+	n.KeyLeafOne = new.KeyLeafOnen.KeyLeafTwo = new.KeyLeafTwo
+	delete(t.ListWithKey, old)
+	t.ListWithKey[new] = n
+	return nil
+}
+
 // Validate validates s against the YANG schema corresponding to its type.
 func (s *Tstruct) Validate(opts ...ygot.ValidationOption) error {
 	if err := ytypes.Validate(SchemaTree["Tstruct"], s, opts...); err != nil {
@@ -951,7 +1018,7 @@ func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes
 			s.uniqueDirectoryNames = tt.inUniqueDirectoryNames
 
 			// Always generate the JSON schema for this test.
-			got, errs := writeGoStruct(tt.inStructToMap, tt.inMappableEntities, s, compressed, true)
+			got, errs := writeGoStruct(tt.inStructToMap, tt.inMappableEntities, s, compressed, true, tt.inGenerateRenameMethod)
 
 			if len(errs) != 0 && !want.wantErr {
 				t.Errorf("%s writeGoStruct(CompressOCPaths: %v, targetStruct: %v): received unexpected errors: %v",

--- a/ygen/schema_tests/schema.go
+++ b/ygen/schema_tests/schema.go
@@ -1,0 +1,17 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package schematest is used for testing with the default OpenConfig generated
+// structs.
+package schematest

--- a/ygen/schema_tests/schema_test.go
+++ b/ygen/schema_tests/schema_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package schematest is used for testing with the default OpenConfig generated
+// structs.
+package schematest
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openconfig/ygot/exampleoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestSimpleListRename(t *testing.T) {
+	in := &exampleoc.Device{}
+	if _, err := in.NewInterface("eth0"); err != nil {
+		t.Fatalf("could not create eth0 entry, got: %v, want: nil", err)
+	}
+
+	if err := in.RenameInterface("eth0", "eth1"); err != nil {
+		t.Fatalf("could not rename eth0 entry, got: %v, want: nil", err)
+	}
+
+	if _, ok := in.Interface["eth0"]; ok {
+		t.Fatalf("did not remove eth0 from list")
+	}
+
+	if _, ok := in.Interface["eth1"]; !ok {
+		t.Fatalf("did not populate eth1 in list")
+	}
+
+	if !reflect.DeepEqual(in.Interface["eth1"].Name, ygot.String("eth1")) {
+		t.Errorf("did not get correct name value, got: %v, want: eth1", *in.Interface["eth1"].Name)
+	}
+}
+
+func TestMultiKeyListRename(t *testing.T) {
+	in := &exampleoc.Device{}
+	ni, err := in.NewNetworkInstance("DEFAULT")
+	if err != nil {
+		t.Fatalf("could not create DEFAULT network instance, got: %v, want: nil", err)
+	}
+
+	if _, err := ni.NewProtocol(exampleoc.OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, "15169"); err != nil {
+		t.Fatalf("could not create BGP protocol instance, got: %v, want: nil", err)
+	}
+
+	oldBGP := exampleoc.NetworkInstance_Protocol_Key{Identifier: exampleoc.OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, Name: "15169"}
+	newBGP := exampleoc.NetworkInstance_Protocol_Key{Identifier: exampleoc.OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP, Name: "36040"}
+	if err := ni.RenameProtocol(oldBGP, newBGP); err != nil {
+		t.Fatalf("could not rename BGP protocol instance, got: %v, want: nil", err)
+	}
+
+	if _, ok := ni.Protocol[oldBGP]; ok {
+		t.Fatalf("did not remove old BGP protocol instance, got: %v, want: nil", err)
+	}
+
+	if _, ok := ni.Protocol[newBGP]; !ok {
+		t.Fatalf("did not find new BGP protocol instance, got: %v, want: nil", err)
+	}
+
+	if ni.Protocol[newBGP].Identifier != exampleoc.OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP {
+		t.Errorf("did not have correct identifier in newBGP, got: %v, want: OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP", ni.Protocol[newBGP].Identifier)
+	}
+
+	if !reflect.DeepEqual(ni.Protocol[newBGP].Name, ygot.String("36040")) {
+		t.Errorf("did not have correct name in newBGP, got: %v, want: 36040", *ni.Protocol[newBGP].Name)
+	}
+}

--- a/ygen/testdata/structs/openconfig-withlist.formatted-txt
+++ b/ygen/testdata/structs/openconfig-withlist.formatted-txt
@@ -78,6 +78,31 @@ func (t *Model) NewMultiKey(Key1 uint32, Key2 uint64) (*Model_MultiKey, error){
 	return t.MultiKey[key], nil
 }
 
+// RenameMultiKey renames an entry in the list MultiKey within
+// the Model struct. The entry with key oldk is renamed to newk updating
+// the key within the value.
+func (t *Model) RenameMultiKey(oldk, newk Model_MultiKey_Key) error {
+	e, ok := t.MultiKey[oldk]
+	if !ok {
+		return fmt.Errorf("key %v not found in MultiKey", oldk)
+	}
+
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*Model_MultiKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.Key1 = &newk.Key1
+	n.Key2 = &newk.Key2
+
+	delete(t.MultiKey, oldk)
+	t.MultiKey[newk] = n
+	return nil
+}
+
 // NewSingleKey creates a new entry in the SingleKey list of the
 // Model struct. The keys of the list are populated from the input
 // arguments.
@@ -103,6 +128,30 @@ func (t *Model) NewSingleKey(Key string) (*Model_SingleKey, error){
 	}
 
 	return t.SingleKey[key], nil
+}
+
+// RenameSingleKey renames an entry in the list SingleKey within
+// the Model struct. The entry with key oldk is renamed to newk updating
+// the key within the value.
+func (t *Model) RenameSingleKey(oldk, newk string) error {
+	e, ok := t.SingleKey[oldk]
+	if !ok {
+		return fmt.Errorf("key %v not found in SingleKey", oldk)
+	}
+
+	ns, err := ygot.DeepCopy(e)
+	if err != nil {
+		return fmt.Errorf("cannot DeepCopy entry %v, got error: %v", oldk, err)
+	}
+	n, ok := ns.(*Model_SingleKey)
+	if !ok {
+		return fmt.Errorf("wrong type returned in list, got error: %v", err)
+	}
+	n.Key = &newk
+
+	delete(t.SingleKey, oldk)
+	t.SingleKey[newk] = n
+	return nil
 }
 
 // Model_MultiKey represents the /openconfig-withlist/model/b/multi-key YANG schema element.


### PR DESCRIPTION
This CL adds a generated method for each list which allows a list entry to be renamed from an old key to a new key. The method is supported for both single and compound key lists.

Tests are added for the generated code, along with a new `schema_tests` directory and set of tests which use the `exampleoc` schema to check functionality of the new `RenameXXX` methods.