### PR TITLE
Add ygot.Diff public API to diff two GoStructs

### DIFF
--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -994,15 +994,11 @@ func TestDiff(t *testing.T) {
 	}, {
 		desc:    "invalid original",
 		inOrig:  &invalidGoStructEntity{},
+		inMod:   &invalidGoStructEntity{},
 		wantErr: String("could not extract set leaves from original struct"),
 	}, {
-		desc:    "invalid modified",
-		inOrig:  &renderExample{},
-		inMod:   &invalidGoStructEntity{},
-		wantErr: String("could not extract set leaves from modified struct"),
-	}, {
 		desc:   "invalid enum in modified",
-		inOrig: &renderExample{},
+		inOrig: &badGoStruct{},
 		inMod: &badGoStruct{
 			InvalidEnum: 42,
 		},
@@ -1016,6 +1012,11 @@ func TestDiff(t *testing.T) {
 			InvalidEnum: 42,
 		},
 		wantErr: String("cannot represent field value 42 as TypedValue for path /an-enum"),
+	}, {
+		desc:    "different types",
+		inOrig:  &renderExample{},
+		inMod:   &pathElemExample{},
+		wantErr: String("cannot diff structs of different types"),
 	}}
 
 	for _, tt := range tests {

--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -447,22 +447,6 @@ func TestFindSetLeaves(t *testing.T) {
 					},
 				}},
 			}: "value-three",
-			{
-				gNMIPaths: []*gnmipb.Path{{
-					Elem: []*gnmipb.PathElem{
-						{Name: "struct-value"},
-						{Name: "struct-three-value"},
-						{Name: "third-string-value"},
-					},
-				}, {
-					Elem: []*gnmipb.PathElem{
-						{Name: "struct-value"},
-						{Name: "struct-three-value"},
-						{Name: "config"},
-						{Name: "third-string-value"},
-					},
-				}},
-			}: "value-three",
 		},
 	}, {
 		desc: "struct with map",
@@ -666,6 +650,389 @@ func TestPathSetEqual(t *testing.T) {
 	for _, tt := range tests {
 		if got, want := tt.inA.Equal(tt.inB), tt.want; got != want {
 			t.Errorf("%s: (%#v).Equal(%#v): did not get expected result, got: %v, want: %v", tt.desc, tt.inA, tt.inB, got, want)
+		}
+	}
+}
+
+type badGoStruct struct {
+	InvalidEnum int64 `path:"an-enum"`
+}
+
+func (*badGoStruct) IsYANGGoStruct() {}
+
+func TestDiff(t *testing.T) {
+	tests := []struct {
+		desc          string
+		inOrig, inMod GoStruct
+		want          *gnmipb.Notification
+		wantErr       *string
+	}{{
+		desc:   "single path addition in modified",
+		inOrig: &renderExample{},
+		inMod: &renderExample{
+			Str: String("cabernet-sauvignon"),
+		},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "str",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"cabernet-sauvignon"}},
+			}},
+		},
+	}, {
+		desc: "single path deletion in modified",
+		inOrig: &renderExample{
+			Str: String("chardonnay"),
+		},
+		inMod: &renderExample{},
+		want: &gnmipb.Notification{
+			Delete: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "str",
+				}},
+			}},
+		},
+	}, {
+		desc: "single path modification",
+		inOrig: &renderExample{
+			Str: String("grenache"),
+		},
+		inMod: &renderExample{
+			Str: String("malbec"),
+		},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "str",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"malbec"}},
+			}},
+		},
+	}, {
+		desc:   "multiple path addition, with complex types",
+		inOrig: &renderExample{},
+		inMod: &renderExample{
+			IntVal:    Int32(42),
+			FloatVal:  Float32(42.42),
+			EnumField: EnumTestVALONE,
+			Ch: &renderExampleChild{
+				Val: Uint64(42),
+			},
+			LeafList: []string{"merlot", "pinot-noir"},
+			UnionVal: &renderExampleUnionString{"semillon"},
+			Binary:   Binary{42, 42, 42},
+			Empty:    true,
+		},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "int-val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_IntVal{42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "floatval",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_FloatVal{42.42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "enum",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "ch",
+					}, {
+						Name: "val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_UintVal{42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "leaf-list",
+					}},
+				},
+				Val: &gnmipb.TypedValue{
+					Value: &gnmipb.TypedValue_LeaflistVal{
+						&gnmipb.ScalarArray{
+							Element: []*gnmipb.TypedValue{
+								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"merlot"}},
+								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"pinot-noir"}},
+							},
+						},
+					},
+				},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "union-val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"semillon"}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "binary",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_BytesVal{[]byte{42, 42, 42}}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "empty",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_BoolVal{true}},
+			}},
+		},
+	}, {
+		desc: "multiple element set in both - no diff",
+		inOrig: &renderExample{
+			IntVal:    Int32(42),
+			FloatVal:  Float32(42.42),
+			EnumField: EnumTestVALONE,
+			Ch: &renderExampleChild{
+				Val: Uint64(42),
+			},
+			LeafList: []string{"merlot", "pinot-noir"},
+			UnionVal: &renderExampleUnionString{"semillon"},
+			Binary:   Binary{42, 42, 42},
+			Empty:    true,
+		},
+		inMod: &renderExample{
+			IntVal:    Int32(42),
+			FloatVal:  Float32(42.42),
+			EnumField: EnumTestVALONE,
+			Ch: &renderExampleChild{
+				Val: Uint64(42),
+			},
+			LeafList: []string{"merlot", "pinot-noir"},
+			UnionVal: &renderExampleUnionString{"semillon"},
+			Binary:   Binary{42, 42, 42},
+			Empty:    true,
+		},
+		want: &gnmipb.Notification{},
+	}, {
+		desc: "multiple path modify",
+		inOrig: &renderExample{
+			IntVal:    Int32(43),
+			FloatVal:  Float32(43.43),
+			EnumField: EnumTestVALTWO,
+			Ch: &renderExampleChild{
+				Val: Uint64(43),
+			},
+			LeafList: []string{"syrah", "tempranillo"},
+			UnionVal: &renderExampleUnionString{"viognier"},
+			Binary:   Binary{43, 43, 43},
+			Empty:    false,
+		},
+		inMod: &renderExample{
+			IntVal:    Int32(42),
+			FloatVal:  Float32(42.42),
+			EnumField: EnumTestVALONE,
+			Ch: &renderExampleChild{
+				Val: Uint64(42),
+			},
+			LeafList: []string{"alcase", "anjou"},
+			UnionVal: &renderExampleUnionString{"arbois"},
+			Binary:   Binary{42, 42, 42},
+			Empty:    true,
+		},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "int-val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_IntVal{42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "floatval",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_FloatVal{42.42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "enum",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "ch",
+					}, {
+						Name: "val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_UintVal{42}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "leaf-list",
+					}},
+				},
+				Val: &gnmipb.TypedValue{
+					Value: &gnmipb.TypedValue_LeaflistVal{
+						&gnmipb.ScalarArray{
+							Element: []*gnmipb.TypedValue{
+								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"alcase"}},
+								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"anjou"}},
+							},
+						},
+					},
+				},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "union-val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"arbois"}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "binary",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_BytesVal{[]byte{42, 42, 42}}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "empty",
+					}},
+				},
+				Val: &gnmipb.TypedValue{&gnmipb.TypedValue_BoolVal{true}},
+			}},
+		},
+	}, {
+		desc: "add an item to a list",
+		inOrig: &pathElemExample{
+			List: map[string]*pathElemExampleChild{
+				"p1": {Val: String("p1")},
+			},
+		},
+		inMod: &pathElemExample{
+			List: map[string]*pathElemExampleChild{
+				"p1": {Val: String("p1")},
+				"p2": {Val: String("p2")},
+			},
+		},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "list",
+						Key:  map[string]string{"val": "p2"},
+					}, {
+						Name: "val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"p2"}},
+			}, {
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "list",
+						Key:  map[string]string{"val": "p2"},
+					}, {
+						Name: "config",
+					}, {
+						Name: "val",
+					}},
+				},
+				Val: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"p2"}},
+			}},
+		},
+	}, {
+		desc: "remove item from list",
+		inOrig: &pathElemExample{
+			List: map[string]*pathElemExampleChild{
+				"p1": {Val: String("p1")},
+				"p2": {Val: String("p2")},
+			},
+		},
+		inMod: &pathElemExample{
+			List: map[string]*pathElemExampleChild{
+				"p1": {Val: String("p1")},
+			},
+		},
+		want: &gnmipb.Notification{
+			Delete: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "list",
+					Key:  map[string]string{"val": "p2"},
+				}, {
+					Name: "val",
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "list",
+					Key:  map[string]string{"val": "p2"},
+				}, {
+					Name: "config",
+				}, {
+					Name: "val",
+				}},
+			}},
+		},
+	}, {
+		desc:    "invalid original",
+		inOrig:  &invalidGoStructEntity{},
+		wantErr: String("could not extract set leaves from original struct"),
+	}, {
+		desc:    "invalid modified",
+		inOrig:  &renderExample{},
+		inMod:   &invalidGoStructEntity{},
+		wantErr: String("could not extract set leaves from modified struct"),
+	}, {
+		desc:   "invalid enum in modified",
+		inOrig: &renderExample{},
+		inMod: &badGoStruct{
+			InvalidEnum: 42,
+		},
+		wantErr: String("cannot represent field value 42 as TypedValue for path /an-enum"),
+	}, {
+		desc: "invalid enum in original",
+		inOrig: &badGoStruct{
+			InvalidEnum: 44,
+		},
+		inMod: &badGoStruct{
+			InvalidEnum: 42,
+		},
+		wantErr: String("cannot represent field value 42 as TypedValue for path /an-enum"),
+	}}
+
+	for _, tt := range tests {
+		got, err := Diff(tt.inOrig, tt.inMod)
+		if tt.wantErr != nil && err == nil || tt.wantErr != nil && !strings.Contains(err.Error(), *tt.wantErr) || tt.wantErr == nil && err != nil {
+			t.Errorf("%s: Diff(%s, %s): did not get expected error status, got: %s, want: %s", tt.desc, pretty.Sprint(tt.inOrig), pretty.Sprint(tt.inMod), err, *tt.wantErr)
+			continue
+		}
+
+		if tt.wantErr != nil {
+			continue
+		}
+		// To re-use the notificationSetEqual helper, we put the want and got into
+		// a slice.
+		if !notificationSetEqual([]*gnmipb.Notification{tt.want}, []*gnmipb.Notification{got}) {
+			diff := pretty.Compare(got, tt.want)
+			t.Errorf("%s: Diff(%s, %s): did not get expected Notification, diff(-got,+want):\n%s", tt.desc, pretty.Sprint(tt.inOrig), pretty.Sprint(tt.inMod), diff)
 		}
 	}
 }

--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -769,8 +769,8 @@ func TestDiff(t *testing.T) {
 					Value: &gnmipb.TypedValue_LeaflistVal{
 						&gnmipb.ScalarArray{
 							Element: []*gnmipb.TypedValue{
-								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"merlot"}},
-								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"pinot-noir"}},
+								{&gnmipb.TypedValue_StringVal{"merlot"}},
+								{&gnmipb.TypedValue_StringVal{"pinot-noir"}},
 							},
 						},
 					},
@@ -892,8 +892,8 @@ func TestDiff(t *testing.T) {
 					Value: &gnmipb.TypedValue_LeaflistVal{
 						&gnmipb.ScalarArray{
 							Element: []*gnmipb.TypedValue{
-								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"alcase"}},
-								&gnmipb.TypedValue{&gnmipb.TypedValue_StringVal{"anjou"}},
+								{&gnmipb.TypedValue_StringVal{"alcase"}},
+								{&gnmipb.TypedValue_StringVal{"anjou"}},
 							},
 						},
 					},

--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -503,3 +503,169 @@ func TestFindSetLeaves(t *testing.T) {
 		}
 	}
 }
+
+func TestPathSetEqual(t *testing.T) {
+	tests := []struct {
+		desc     string
+		inA, inB *pathSpec
+		want     bool
+	}{{
+		desc: "simple single path, equal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}},
+		},
+		want: true,
+	}, {
+		desc: "simple single path, unequal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+				}},
+			}},
+		},
+		want: false,
+	}, {
+		desc: "multiple paths, equal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+				}},
+			}},
+		},
+		want: true,
+	}, {
+		desc: "multiple paths, unequal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "baz",
+				}},
+			}},
+		},
+		want: false,
+	}, {
+		desc: "multiple paths with keys, equal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+					Key:  map[string]string{"baz": "bop"},
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+					Key:  map[string]string{"fish": "chips"},
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+					Key:  map[string]string{"baz": "bop"},
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+					Key:  map[string]string{"fish": "chips"},
+				}},
+			}},
+		},
+		want: true,
+	}, {
+		desc: "multiple paths with keys, equal",
+		inA: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+					Key:  map[string]string{"baz": "bop"},
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+					Key:  map[string]string{"fish": "chips"},
+				}},
+			}},
+		},
+		inB: &pathSpec{
+			gNMIPaths: []*gnmipb.Path{{
+				Elem: []*gnmipb.PathElem{{
+					Name: "foo",
+					Key:  map[string]string{"baz": "bop"},
+				}},
+			}, {
+				Elem: []*gnmipb.PathElem{{
+					Name: "bar",
+					Key:  map[string]string{"fish": "hat"},
+				}},
+			}},
+		},
+		want: false,
+	}, {
+		desc: "both nil",
+		inA:  nil,
+		inB:  nil,
+		want: true,
+	}, {
+		desc: "compare nil",
+		inA:  &pathSpec{},
+		inB:  nil,
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		if got, want := tt.inA.Equal(tt.inB), tt.want; got != want {
+			t.Errorf("%s: (%#v).Equal(%#v): did not get expected result, got: %v, want: %v", tt.desc, tt.inA, tt.inB, got, want)
+		}
+	}
+}

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -1265,11 +1265,15 @@ func constructJSONSlice(field reflect.Value, parentMod string, args jsonOutputCo
 // This function extracts field index 0 of the struct within the interface and returns
 // the value.
 func unionInterfaceValue(v reflect.Value, appendModuleName bool) (interface{}, error) {
-	if !util.IsValueInterfaceToStructPtr(v) {
+	var s reflect.Value
+	switch {
+	case util.IsValueInterfaceToStructPtr(v):
+		s = v.Elem().Elem()
+	case util.IsValueStructPtr(v):
+		s = v.Elem()
+	default:
 		return nil, fmt.Errorf("received a union type which was invalid: %v", v.Kind())
 	}
-
-	s := v.Elem().Elem() // Dereference the struct ptr.
 
 	if !util.IsStructValueWithNFields(s, 1) {
 		return nil, fmt.Errorf("received a union type which did not have one field, had: %v", v.Elem().Elem().NumField())

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -17,9 +17,12 @@ package ygot
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kylelemons/godebug/pretty"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
@@ -624,7 +627,6 @@ func TestAppendGNMIPathElemKey(t *testing.T) {
 		}
 
 		if diff := pretty.Compare(got, tt.wantPath); diff != "" {
-			//	if !reflect.DeepEqual(got, tt.wantPath) {
 			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected return path, diff(-got,+want):\n%s", tt.name, tt.inValue, tt.inPath, diff)
 		}
 	}
@@ -1312,14 +1314,23 @@ func notificationSetEqual(a, b []*gnmipb.Notification) bool {
 
 	matchall := true
 	for _, aelem := range a {
-		var matched bool
+		var updateMatched, deleteMatched bool
 		for _, belem := range b {
+			if aelem == nil && belem != nil || belem == nil && aelem != nil || aelem == nil && belem == nil {
+				continue
+			}
+
 			if updateSetEqual(aelem.Update, belem.Update) {
-				matched = true
+				updateMatched = true
+			}
+			if pathSliceEqual(aelem.Delete, belem.Delete) {
+				deleteMatched = true
+			}
+			if updateMatched && deleteMatched {
 				break
 			}
 		}
-		if !matched {
+		if !updateMatched || !deleteMatched {
 			matchall = false
 		}
 	}
@@ -1334,11 +1345,17 @@ func updateSetEqual(a, b []*gnmipb.Update) bool {
 		return false
 	}
 
+	bMatched := map[*gnmipb.Path]bool{}
+	for _, belem := range b {
+		bMatched[belem.Path] = true
+	}
+
 	for _, aelem := range a {
 		var matched bool
 		for _, belem := range b {
 			if proto.Equal(aelem, belem) {
 				matched = true
+				delete(bMatched, belem.Path)
 				break
 			}
 		}
@@ -1348,7 +1365,64 @@ func updateSetEqual(a, b []*gnmipb.Update) bool {
 		}
 	}
 
+	if len(bMatched) != 0 {
+		return false
+	}
+
 	return true
+}
+
+// stringKeys returns the keys of a map[string]string as a slice.
+func stringKeys(m map[string]string) []string {
+	ss := []string{}
+	for k := range m {
+		ss = append(ss, k)
+	}
+	return ss
+}
+
+// pathSliceEqual checks whether two slices of gNMI Paths are equal, ignoring
+// order. Equality of the paths within the slice are considered on an element
+// by element basis - with equality being considered as having the same element
+// name, and the same element keys and values.
+func pathSliceEqual(a, b []*gnmipb.Path) bool {
+	pathIsLess := func(a, b *gnmipb.Path) bool {
+		for _, a := range a.Elem {
+			for _, b := range b.Elem {
+				if a.Name != b.Name {
+					return a.Name < b.Name
+				}
+				// If the element names are not equal then we consider the keys in
+				// alphabetical order.
+				akeys := stringKeys(a.Key)
+				sort.Strings(akeys)
+				bkeys := stringKeys(b.Key)
+				sort.Strings(bkeys)
+
+				for _, ak := range akeys {
+					for _, bk := range bkeys {
+						// If the key names aren't equal - then we use the comparison of the
+						// two strings. The strings.Compare function returns -1 if a < b,
+						// and cmpoptions.SortedSlice requires a "less" function which must
+						// return true if a < b.
+						if ak != bk {
+							return ak < bk
+						}
+						// If the key names were equal, then we move on to comparing the
+						// keys.
+						if av, bv := a.Key[ak], b.Key[bk]; av != bv {
+							return av < bv
+						}
+					}
+				}
+			}
+		}
+		// If we get to this point, all of the elements and path values were equal -
+		// so we're dealing with the same path. Determinstically return true so that
+		// in the case of equality, a < b.
+		return true
+	}
+	return cmp.Equal(a, b, cmpopts.SortSlices(pathIsLess))
 }
 
 // exampleDevice and the following structs are a set of structs used for more

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1313,17 +1313,17 @@ func notificationSetEqual(a, b []*gnmipb.Notification) bool {
 	}
 
 	matchall := true
-	for _, aelem := range a {
+	for _, aElem := range a {
 		var updateMatched, deleteMatched bool
-		for _, belem := range b {
-			if aelem == nil && belem != nil || belem == nil && aelem != nil || aelem == nil && belem == nil {
+		for _, bElem := range b {
+			if aElem == nil && bElem != nil || bElem == nil && aElem != nil || aElem == nil && bElem == nil {
 				continue
 			}
 
-			if updateSetEqual(aelem.Update, belem.Update) {
+			if updateSetEqual(aElem.Update, bElem.Update) {
 				updateMatched = true
 			}
-			if pathSliceEqual(aelem.Delete, belem.Delete) {
+			if pathSliceEqual(aElem.Delete, bElem.Delete) {
 				deleteMatched = true
 			}
 			if updateMatched && deleteMatched {
@@ -1346,16 +1346,16 @@ func updateSetEqual(a, b []*gnmipb.Update) bool {
 	}
 
 	bMatched := map[*gnmipb.Path]bool{}
-	for _, belem := range b {
-		bMatched[belem.Path] = true
+	for _, bElem := range b {
+		bMatched[bElem.Path] = true
 	}
 
-	for _, aelem := range a {
+	for _, aElem := range a {
 		var matched bool
-		for _, belem := range b {
-			if proto.Equal(aelem, belem) {
+		for _, bElem := range b {
+			if proto.Equal(aElem, bElem) {
 				matched = true
-				delete(bMatched, belem.Path)
+				delete(bMatched, bElem.Path)
 				break
 			}
 		}
@@ -1394,13 +1394,13 @@ func pathSliceEqual(a, b []*gnmipb.Path) bool {
 				}
 				// If the element names are not equal then we consider the keys in
 				// alphabetical order.
-				akeys := stringKeys(a.Key)
-				sort.Strings(akeys)
-				bkeys := stringKeys(b.Key)
-				sort.Strings(bkeys)
+				aKeys := stringKeys(a.Key)
+				sort.Strings(aKeys)
+				bKeys := stringKeys(b.Key)
+				sort.Strings(bKeys)
 
-				for _, ak := range akeys {
-					for _, bk := range bkeys {
+				for _, ak := range aKeys {
+					for _, bk := range bKeys {
 						// If the key names aren't equal - then we use the comparison of the
 						// two strings. The strings.Compare function returns -1 if a < b,
 						// and cmpoptions.SortedSlice requires a "less" function which must


### PR DESCRIPTION
This CL adds the public API for diffing two `GoStructs`. It returns a `gnmi.Notification` message with the difference between two structs.

Schema-based tests rather than mock inputs will be added in a subsequent CL.