### PR TITLE
Add option to EmitJSONConfig to skip validation.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -217,8 +217,11 @@ type EmitJSONConfig struct {
 // EmitJSON takes an input ValidatedGoStruct (produced by ygen with validation enabled)
 // and serialises it to a JSON string. By default, produces the Internal format JSON.
 func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
-	var vopts []ValidationOption
-	var skipValidation bool
+	var (
+		vopts []ValidationOption
+		skipValidation bool
+	)
+
 	if opts != nil {
 		vopts = opts.ValidationOpts
 		skipValidation = opts.SkipValidation

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -218,7 +218,7 @@ type EmitJSONConfig struct {
 // and serialises it to a JSON string. By default, produces the Internal format JSON.
 func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
 	var (
-		vopts []ValidationOption
+		vopts          []ValidationOption
 		skipValidation bool
 	)
 

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -203,6 +203,10 @@ type EmitJSONConfig struct {
 	// Indent is the string used for indentation within the JSON output. The
 	// default value is three spaces.
 	Indent string
+	// SkipValidation specifies whether the GoStruct supplied to EmitJSON should
+	// be validated before emitting its content. Validation is skipped when it
+	// is set to true.
+	SkipValidation bool
 	// ValidationOpts is the set of options that should be used to determine how
 	// the schema should be validated. This allows fine-grained control of particular
 	// validation rules in the case that a partially populated data instance is
@@ -214,11 +218,13 @@ type EmitJSONConfig struct {
 // and serialises it to a JSON string. By default, produces the Internal format JSON.
 func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
 	var vopts []ValidationOption
+	var skipValidation bool
 	if opts != nil {
 		vopts = opts.ValidationOpts
+		skipValidation = opts.SkipValidation
 	}
 
-	if err := s.Validate(vopts...); err != nil {
+	if err := s.Validate(vopts...); !skipValidation && err != nil {
 		return "", fmt.Errorf("validation err: %v", err)
 	}
 

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -496,6 +496,13 @@ func TestEmitJSON(t *testing.T) {
 		inStruct: &mapStructInvalid{Name: String("aardvark")},
 		wantErr:  "validation err: invalid",
 	}, {
+		name:     "invalid with skip validation",
+		inStruct: &mapStructInvalid{Name: String("aardwolf")},
+		inConfig: &EmitJSONConfig{
+			SkipValidation: true,
+		},
+		wantJSONPath: filepath.Join(TestRoot, "testdata", "invalid-struct.json-txt"),
+	}, {
 		name:     "invalid internal JSON",
 		inStruct: &mapStructNoPaths{Name: String("honey badger")},
 		wantErr:  "ConstructInternalJSON error: Name: field did not specify a path",
@@ -521,7 +528,7 @@ func TestEmitJSON(t *testing.T) {
 
 		wantJSON, ioerr := ioutil.ReadFile(tt.wantJSONPath)
 		if ioerr != nil {
-			t.Errorf("%s: ioutil.ReadFile(%s): could not open file: %v", tt.name, tt.wantJSONPath, err)
+			t.Errorf("%s: ioutil.ReadFile(%s): could not open file: %v", tt.name, tt.wantJSONPath, ioerr)
 			continue
 		}
 

--- a/ygot/testdata/invalid-struct.json-txt
+++ b/ygot/testdata/invalid-struct.json-txt
@@ -1,0 +1,3 @@
+{
+   "name": "aardwolf"
+}


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map.go
 * (M) ygot/struct_validation_map_test.go
   - Add an option to skip validating a struct in EmitJSON. The
     default is to validate, but this allows a user who explicitly
     wants to skip all validation to force JSON marshalling.
```