### PR TITLE
Implement a function to remove empty branches from a GoStruct.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -177,7 +177,7 @@ func pruneBranchesInternal(t reflect.Type, v reflect.Value) {
 		if util.IsTypeStructPtr(fType.Type) {
 			// Create an empty version of the struct that is within the struct pointer.
 			// We can safely call Elem() here since we verified above that this type
-			// as a struct pointer.
+			// is a struct pointer.
 			zVal := reflect.Zero(fType.Type.Elem())
 
 			switch {


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map.go
 * (M) ygot/struct_validation_map_test.go
  - When a struct is initialised with BuildEmptyTree, many of its
    branches may not be populated - but then have a nil value, such
    that comparisons with a struct literal are not equal. This
    results in complexities in testing and equality within consuming
    code. This commit implements a pruning function that removes any
    struct pointer field of a GoStruct which is found to be empty
    recursively.
```