### PR TITLE
Build empty skip populated

### DIFF
--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -553,9 +553,10 @@ func (*emptyTreeTestOne) IsYANGGoStruct() {}
 
 // emptyTreeTestTwo is a test case for TestBuildEmptyTree
 type emptyTreeTestTwo struct {
-	SliceVal  []*emptyTreeTestTwoChild
-	MapVal    map[string]*emptyTreeTestTwoChild
-	StructVal *emptyTreeTestTwoChild
+	SliceVal     []*emptyTreeTestTwoChild
+	MapVal       map[string]*emptyTreeTestTwoChild
+	StructVal    *emptyTreeTestTwoChild
+	StructValTwo *emptyTreeTestTwoChild
 }
 
 // IsYANGGoStruct ensures that emptyTreeTestTwo implements the GoStruct interface
@@ -579,9 +580,10 @@ func TestBuildEmptyTree(t *testing.T) {
 		name:     "struct with children",
 		inStruct: &emptyTreeTestTwo{},
 		want: &emptyTreeTestTwo{
-			SliceVal:  []*emptyTreeTestTwoChild{},
-			MapVal:    map[string]*emptyTreeTestTwoChild{},
-			StructVal: &emptyTreeTestTwoChild{},
+			SliceVal:     []*emptyTreeTestTwoChild{},
+			MapVal:       map[string]*emptyTreeTestTwoChild{},
+			StructVal:    &emptyTreeTestTwoChild{},
+			StructValTwo: &emptyTreeTestTwoChild{},
 		},
 	}, {
 		name: "struct with already populated child",
@@ -594,6 +596,7 @@ func TestBuildEmptyTree(t *testing.T) {
 			StructVal: &emptyTreeTestTwoChild{
 				Val: "foo",
 			},
+			StructValTwo: &emptyTreeTestTwoChild{},
 		},
 	}}
 

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -583,6 +583,18 @@ func TestBuildEmptyTree(t *testing.T) {
 			MapVal:    map[string]*emptyTreeTestTwoChild{},
 			StructVal: &emptyTreeTestTwoChild{},
 		},
+	}, {
+		name: "struct with already populated child",
+		inStruct: &emptyTreeTestTwo{
+			StructVal: &emptyTreeTestTwoChild{
+				Val: "foo",
+			},
+		},
+		want: &emptyTreeTestTwo{
+			StructVal: &emptyTreeTestTwoChild{
+				Val: "foo",
+			},
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
Ensure that BuildEmptyTree does not overwrite set values.

 * (M) ygot/struct_validation_map.go
 * (M) ygot/struct_validation_map_test.go
  - Where BuildEmptyTree was used previously, it would overwrite fields
    that were already set. This results in loss of data which is not
    expected by the user. This commit changes this behaviour to ensure
    that non-nil struct pointer fields are skipped during
    BuildEmptyTree.
```