### PR TITLE
Add support for Delete generation.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -49,6 +49,7 @@ var (
 	excludeState     = flag.Bool("exclude_state", false, "If set to true, state (config false) fields in the YANG schema are not included in the generated Go code.")
 	generateAppend   = flag.Bool("generate_append", false, "If set to true, append methods are generated for YANG lists (Go maps) within the Go code.")
 	generateGetters  = flag.Bool("generate_getters", false, "If set to true, getter methdos that retrieve or create an element are generated for YANG container (Go struct pointer) or list (Go map) fields within the generated code.")
+	generateDelete   = flag.Bool("generate_delete", false, "If set to true, delete methods are generated for YANG lists (Go maps) within the Go code.")
 )
 
 // writeGoCode takes a ygen.GeneratedGoCode struct and writes the Go code
@@ -162,6 +163,7 @@ func main() {
 			AddAnnotationFields:  *addAnnotations,
 			AnnotationPrefix:     *annotationPrefix,
 			GenerateGetters:      *generateGetters,
+			GenerateDeleteMethod: *generateDelete,
 			GenerateAppendMethod: *generateAppend,
 		},
 		ExcludeState: *excludeState,

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -119,6 +119,9 @@ type GoOpts struct {
 	// for struct pointer (YANG container) and map (YANG list) fields of generated
 	// structs.
 	GenerateGetters bool
+	// GenerateDeleteMethod specifies whether Delete* methods should be created for
+	// map (YANG list) fields of generated structs.
+	GenerateDeleteMethod bool
 	// GenerateAppendList specifies whether Append* methods should be created for
 	// list fields of a struct. These methods take an input list member type, extract
 	// the key and append the supplied value to the list.

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -597,13 +597,14 @@ func TestSimpleStructs(t *testing.T) {
 		},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata", "structs", "openconfig-config-false-compressed.formatted-txt"),
 	}, {
-		name:    "module with getters and append methods",
+		name:    "module with getters, delete and append methods",
 		inFiles: []string{filepath.Join(TestRoot, "testdata", "structs", "openconfig-list-enum-key.yang")},
 		inConfig: GeneratorConfig{
 			GenerateFakeRoot: true,
 			GoOptions: GoOpts{
 				GenerateAppendMethod: true,
 				GenerateGetters:      true,
+				GenerateDeleteMethod: true,
 			},
 		},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata", "structs", "openconfig-list-enum-key.getters-append.formatted-txt"),

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -632,7 +632,6 @@ func (t *{{ .Receiver }}) Delete{{ .ListName }}(
 	{{- if ne (inc $i) $length -}}, {{ end -}}
   {{- end -}}
   ) {
-
 	{{ if ne .KeyStruct "" -}}
 	key := {{ .KeyStruct }}{
 		{{- range $key := .Keys }}

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -624,7 +624,8 @@ func (t *{{ .Receiver }}) GetOrCreate{{ .ListName }}(
 	// particular list key, deletes an existing map value.
 	goDeleteListTemplate = `
 // Delete{{ .ListName }} deletes the value with the specified keys from
-// the receiver {{ .Receiver }}.
+// the receiver {{ .Receiver }}. If there is no such element, the function
+// is a no-op.
 func (t *{{ .Receiver }}) Delete{{ .ListName }}(
   {{- $length := len .Keys -}}
   {{- range $i, $key := .Keys -}}

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -1267,7 +1267,6 @@ func (t *Tstruct) GetListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 // DeleteListWithKey deletes the value with the specified keys from
 // the receiver Tstruct.
 func (t *Tstruct) DeleteListWithKey(KeyLeafOne string, KeyLeafTwo int8) {
-
 	key := Tstruct_ListWithKey_Key{
 		KeyLeafOne: KeyLeafOne,
 		KeyLeafTwo: KeyLeafTwo,
@@ -1446,7 +1445,6 @@ func (t *Tstruct) GetListWithKey(KeyLeaf string) (*ListWithKey){
 // DeleteListWithKey deletes the value with the specified keys from
 // the receiver Tstruct.
 func (t *Tstruct) DeleteListWithKey(KeyLeaf string) {
-
 	key := KeyLeaf
 
 	delete(t.ListWithKey, key)

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -1168,6 +1168,7 @@ func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes
 		inGoOpts: GoOpts{
 			GenerateAppendMethod: true,
 			GenerateGetters:      true,
+			GenerateDeleteMethod: true,
 		},
 		wantCompressed: wantGoStructOut{
 			structs: `
@@ -1263,6 +1264,18 @@ func (t *Tstruct) GetListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
   return nil
 }
 
+// DeleteListWithKey deletes the value with the specified keys from
+// the receiver Tstruct.
+func (t *Tstruct) DeleteListWithKey(KeyLeafOne string, KeyLeafTwo int8) {
+
+	key := Tstruct_ListWithKey_Key{
+		KeyLeafOne: KeyLeafOne,
+		KeyLeafTwo: KeyLeafTwo,
+	}
+
+	delete(t.ListWithKey, key)
+}
+
 // AppendListWithKey appends the supplied ListWithKey struct to the
 // list ListWithKey of Tstruct. If the key value(s) specified in
 // the supplied ListWithKey already exist in the list, an error is
@@ -1351,6 +1364,7 @@ func (t *Tstruct) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTypes
 		inGoOpts: GoOpts{
 			GenerateAppendMethod: true,
 			GenerateGetters:      true,
+			GenerateDeleteMethod: true,
 		},
 		wantCompressed: wantGoStructOut{
 			structs: `
@@ -1427,6 +1441,15 @@ func (t *Tstruct) GetListWithKey(KeyLeaf string) (*ListWithKey){
     return lm
   }
   return nil
+}
+
+// DeleteListWithKey deletes the value with the specified keys from
+// the receiver Tstruct.
+func (t *Tstruct) DeleteListWithKey(KeyLeaf string) {
+
+	key := KeyLeaf
+
+	delete(t.ListWithKey, key)
 }
 
 // AppendListWithKey appends the supplied ListWithKey struct to the

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -1265,7 +1265,8 @@ func (t *Tstruct) GetListWithKey(KeyLeafOne string, KeyLeafTwo int8) (*ListWithK
 }
 
 // DeleteListWithKey deletes the value with the specified keys from
-// the receiver Tstruct.
+// the receiver Tstruct. If there is no such element, the function
+// is a no-op.
 func (t *Tstruct) DeleteListWithKey(KeyLeafOne string, KeyLeafTwo int8) {
 	key := Tstruct_ListWithKey_Key{
 		KeyLeafOne: KeyLeafOne,
@@ -1443,7 +1444,8 @@ func (t *Tstruct) GetListWithKey(KeyLeaf string) (*ListWithKey){
 }
 
 // DeleteListWithKey deletes the value with the specified keys from
-// the receiver Tstruct.
+// the receiver Tstruct. If there is no such element, the function
+// is a no-op.
 func (t *Tstruct) DeleteListWithKey(KeyLeaf string) {
 	key := KeyLeaf
 

--- a/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
+++ b/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
@@ -201,6 +201,18 @@ func (t *OpenconfigListEnumKey_Top_MultiKey) GetEkm(K1 E_OpenconfigListEnumKey_T
   return nil
 }
 
+// DeleteEkm deletes the value with the specified keys from
+// the receiver OpenconfigListEnumKey_Top_MultiKey.
+func (t *OpenconfigListEnumKey_Top_MultiKey) DeleteEkm(K1 E_OpenconfigListEnumKey_Top_MultiKey_Ekm_Config_K1, K2 E_OpenconfigListEnumKey_FooIdentity) {
+
+	key := OpenconfigListEnumKey_Top_MultiKey_Ekm_Key{
+		K1: K1,
+		K2: K2,
+	}
+
+	delete(t.Ekm, key)
+}
+
 // AppendEkm appends the supplied OpenconfigListEnumKey_Top_MultiKey_Ekm struct to the
 // list Ekm of OpenconfigListEnumKey_Top_MultiKey. If the key value(s) specified in
 // the supplied OpenconfigListEnumKey_Top_MultiKey_Ekm already exist in the list, an error is
@@ -380,6 +392,15 @@ func (t *OpenconfigListEnumKey_Top_SingleKey) GetEks(K E_OpenconfigListEnumKey_T
     return lm
   }
   return nil
+}
+
+// DeleteEks deletes the value with the specified keys from
+// the receiver OpenconfigListEnumKey_Top_SingleKey.
+func (t *OpenconfigListEnumKey_Top_SingleKey) DeleteEks(K E_OpenconfigListEnumKey_Top_SingleKey_Eks_Config_K) {
+
+	key := K
+
+	delete(t.Eks, key)
 }
 
 // AppendEks appends the supplied OpenconfigListEnumKey_Top_SingleKey_Eks struct to the

--- a/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
+++ b/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
@@ -204,7 +204,6 @@ func (t *OpenconfigListEnumKey_Top_MultiKey) GetEkm(K1 E_OpenconfigListEnumKey_T
 // DeleteEkm deletes the value with the specified keys from
 // the receiver OpenconfigListEnumKey_Top_MultiKey.
 func (t *OpenconfigListEnumKey_Top_MultiKey) DeleteEkm(K1 E_OpenconfigListEnumKey_Top_MultiKey_Ekm_Config_K1, K2 E_OpenconfigListEnumKey_FooIdentity) {
-
 	key := OpenconfigListEnumKey_Top_MultiKey_Ekm_Key{
 		K1: K1,
 		K2: K2,
@@ -397,7 +396,6 @@ func (t *OpenconfigListEnumKey_Top_SingleKey) GetEks(K E_OpenconfigListEnumKey_T
 // DeleteEks deletes the value with the specified keys from
 // the receiver OpenconfigListEnumKey_Top_SingleKey.
 func (t *OpenconfigListEnumKey_Top_SingleKey) DeleteEks(K E_OpenconfigListEnumKey_Top_SingleKey_Eks_Config_K) {
-
 	key := K
 
 	delete(t.Eks, key)

--- a/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
+++ b/ygen/testdata/structs/openconfig-list-enum-key.getters-append.formatted-txt
@@ -202,7 +202,8 @@ func (t *OpenconfigListEnumKey_Top_MultiKey) GetEkm(K1 E_OpenconfigListEnumKey_T
 }
 
 // DeleteEkm deletes the value with the specified keys from
-// the receiver OpenconfigListEnumKey_Top_MultiKey.
+// the receiver OpenconfigListEnumKey_Top_MultiKey. If there is no such element, the function
+// is a no-op.
 func (t *OpenconfigListEnumKey_Top_MultiKey) DeleteEkm(K1 E_OpenconfigListEnumKey_Top_MultiKey_Ekm_Config_K1, K2 E_OpenconfigListEnumKey_FooIdentity) {
 	key := OpenconfigListEnumKey_Top_MultiKey_Ekm_Key{
 		K1: K1,
@@ -394,7 +395,8 @@ func (t *OpenconfigListEnumKey_Top_SingleKey) GetEks(K E_OpenconfigListEnumKey_T
 }
 
 // DeleteEks deletes the value with the specified keys from
-// the receiver OpenconfigListEnumKey_Top_SingleKey.
+// the receiver OpenconfigListEnumKey_Top_SingleKey. If there is no such element, the function
+// is a no-op.
 func (t *OpenconfigListEnumKey_Top_SingleKey) DeleteEks(K E_OpenconfigListEnumKey_Top_SingleKey_Eks_Config_K) {
 	key := K
 


### PR DESCRIPTION
This commit adds:
- A flag (`GenerateDeleteMethod`) to `ygen` that creates DeleteXXX(<list key spec>) methods for lists within the output code.
- Unit tests for the above in `ygen`.