### PR TITLE
Fix missing log.Exitf arguments.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -224,7 +224,7 @@ func main() {
 	}
 
 	if *outputFile != "" && *outputDir != "" {
-		log.Exitf("Error: cannot specify both outputFile (%s) and outputDir (%s)")
+		log.Exitf("Error: cannot specify both outputFile (%s) and outputDir (%s)", *outputFile, *outputDir)
 	}
 
 	// Perform the code generation.


### PR DESCRIPTION
This PR fixes an issue whereby there are missing `log.Exitf` arguments in the input code.