### PR TITLE
Add EnumName public API.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -75,6 +75,14 @@ func structTagToLibPaths(f reflect.StructField, parentPath *gnmiPath) ([]*gnmiPa
 	return mapPaths, nil
 }
 
+// EnumName returns the string name of an input GoEnum e. If the enumeration is
+// unset, the name returned is an empty string, otherwise it is the name defined
+// within the YANG schema.
+func EnumName(e GoEnum) (string, error) {
+	name, _, err := enumFieldToString(reflect.ValueOf(e), false)
+	return name, err
+}
+
 // enumFieldToString takes an input reflect.Value, which is type asserted to
 // be a GoEnum, and resolves the string name corresponding to the value within
 // the YANG schema. Returns the string name of the enum, a bool indicating

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -262,6 +262,38 @@ func TestEnumFieldToString(t *testing.T) {
 	}
 }
 
+func TestEnumName(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               GoEnum
+		want             string
+		wantErrSubstring string
+	}{{
+		name: "simple enumeration",
+		in:   EONE,
+		want: "VAL_ONE",
+	}, {
+		name: "unset",
+		in:   EUNSET,
+		want: "",
+	}, {
+		name:             "bad enumeration",
+		in:               BONE,
+		wantErrSubstring: "cannot map enumerated value as type badEnumTest was unknown",
+	}}
+
+	for _, tt := range tests {
+		got, err := EnumName(tt.in)
+		if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+			t.Errorf("%s: EnumName(%v): did not get expected error, %s", tt.name, tt.in, diff)
+		}
+
+		if got != tt.want {
+			t.Errorf("%s: EnumName(%v): did not get expected value, got: %s, want: %s", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
 // mapStructTestOne is the base struct used for the simple-schema test.
 type mapStructTestOne struct {
 	Child *mapStructTestOneChild `path:"child" module:"test-one"`


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map*
  - Add a public EnumName API which resolves a GoEnum to its string
    value within the YANG schema. Always ignores the module name.
```