### PR TITLE
Add option not to log when leafref validation is skipped.

### DIFF
--- a/ytypes/leafref.go
+++ b/ytypes/leafref.go
@@ -85,12 +85,17 @@ func ValidateLeafRefData(schema *yang.Entry, value interface{}, opt *LeafrefOpti
 
 // leafrefErrOrLog returns an error if the global ValidationOptions specifies
 // that missing data should cause an error to be thrown. If the missing data is to
-// be ignored by leafrefs, it logs the error that would have been returned.
+// be ignored by leafrefs, it logs the error that would have been returned if the
+// Log field of the LeafrefOptions is set to true.
 func leafrefErrOrLog(e util.Errors, opt *LeafrefOptions) util.Errors {
 	if opt == nil || !opt.IgnoreMissingData {
 		return e
 	}
-	log.Errorf("%v", e)
+
+	if opt.Log {
+		log.Errorf("%v", e)
+	}
+
 	return nil
 }
 

--- a/ytypes/validate.go
+++ b/ytypes/validate.go
@@ -34,6 +34,9 @@ type LeafrefOptions struct {
 	// a protocol within OpenConfig references an interface, but the schema being
 	// validated does not contain the interface definitions.
 	IgnoreMissingData bool
+	// Log specifies whether log entries should be created where a leafref
+	// cannot be successfully resolved.
+	Log bool
 }
 
 // IsValidationOption ensures that LeafrefOptions implements the ValidationOption


### PR DESCRIPTION
```
 * (M) ytypes/leafref.go
   - Skip log.Errorf if leafref validation fails when IgnoreMissingData
     is set.
 * (M) ytypes/validate.go
   - Add Log bool to LeafrefOptions to allow control of logging
     behaviour.
```

This PR addresses some overly chatty logging observed when `IgnoreMissingData` is set in a `Validate` `LeafrefOption`.