### PR TITLE
Add an option to ignore additional fields in input JSON.

### DIFF
--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -351,8 +351,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -362,7 +364,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 {{- end }}

--- a/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
@@ -46,8 +46,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -57,7 +59,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 // Bgp represents the /openconfig-options/bgp YANG schema element.

--- a/ygen/testdata/schema/openconfig-options-compress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress.formatted-txt
@@ -46,8 +46,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -57,7 +59,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 // Bgp represents the /openconfig-options/bgp YANG schema element.

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -46,8 +46,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -57,7 +59,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 // Fakeroot represents the /fakeroot YANG schema element.

--- a/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
@@ -46,8 +46,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -57,7 +59,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 // Device represents the /device YANG schema element.

--- a/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
@@ -46,8 +46,10 @@ func init() {
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into
 // destStruct, which must be non-nil and the correct GoStruct type. It returns
 // an error if the destStruct is not found in the schema or the data cannot be
-// unmarshaled.
-func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
+// unmarshaled. The supplied options (opts) are used to control the behaviour
+// of the unmarshal function - for example, determining whether errors are
+// thrown for unknown fields in the input JSON.
+func Unmarshal(data []byte, destStruct ygot.GoStruct, opts ...ytypes.UnmarshalOpt) error {
 	tn := reflect.TypeOf(destStruct).Elem().Name()
 	schema, ok := SchemaTree[tn]
 	if !ok {
@@ -57,7 +59,7 @@ func Unmarshal(data []byte, destStruct ygot.GoStruct) error {
 	if err := json.Unmarshal([]byte(data), &jsonTree); err != nil {
 		return err
 	}
-	return ytypes.Unmarshal(schema, destStruct, jsonTree)
+	return ytypes.Unmarshal(schema, destStruct, jsonTree, opts...)
 }
 
 // OpenconfigOptions_Bgp represents the /openconfig-options/bgp YANG schema element.

--- a/ytypes/container_test.go
+++ b/ytypes/container_test.go
@@ -250,6 +250,7 @@ func TestUnmarshalContainer(t *testing.T) {
 		desc    string
 		schema  *yang.Entry
 		json    string
+		opts    []UnmarshalOpt
 		want    interface{}
 		wantErr string
 	}{
@@ -283,6 +284,13 @@ func TestUnmarshalContainer(t *testing.T) {
 			json:    `{ "container-field": { "leaf2-field":  "forty-two"} }`,
 			wantErr: `got string type for field leaf2-field, expect float64`,
 		},
+		{
+			desc:   "unknown field name with ignore",
+			schema: containerSchema,
+			json:   `{"container-field": {"aug-field": 43 } }`,
+			opts:   []UnmarshalOpt{&IgnoreExtraFields{}},
+			want:   &ParentContainerStruct{ContainerField: &ContainerStruct{}},
+		},
 	}
 
 	var jsonTree interface{}
@@ -296,7 +304,7 @@ func TestUnmarshalContainer(t *testing.T) {
 				}
 			}
 
-			err := Unmarshal(tt.schema, &parent, jsonTree)
+			err := Unmarshal(tt.schema, &parent, jsonTree, tt.opts...)
 			if got, want := errToString(err), tt.wantErr; got != want {
 				t.Errorf("%s: got error: %v, want error: %v", tt.desc, got, want)
 			}

--- a/ytypes/schema_tests/testdata/basic-extra.json
+++ b/ytypes/schema_tests/testdata/basic-extra.json
@@ -1,0 +1,11 @@
+{
+ "another-mod:aug": "value",
+ "openconfig-bgp:bgp": {
+   "global": {
+     "config": {
+       "as": 12345,
+       "router-id": "10.10.10.10"
+     }
+   }
+ }    
+}

--- a/ytypes/schema_tests/testdata/bgp-example.json
+++ b/ytypes/schema_tests/testdata/bgp-example.json
@@ -145,8 +145,7 @@
                   "prefix-limit": {
                     "config": {
                       "max-prefixes": 20000,
-                      "restart-timer": "0",
-                      "shutdown-threshold-pct": 75
+                      "restart-timer": "0"
                     }
                   }
                 },
@@ -187,8 +186,7 @@
                   "prefix-limit": {
                     "config": {
                       "max-prefixes": 1000,
-                      "restart-timer": "0",
-                      "shutdown-threshold-pct": 75
+                      "restart-timer": "0"
                     }
                   }
                 },

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -413,8 +413,10 @@ func TestUnmarshal(t *testing.T) {
 		desc              string
 		jsonFilePath      string
 		parent            ygot.ValidatedGoStruct
+		opts              []ytypes.UnmarshalOpt
 		wantValidationErr string
 		wantErr           string
+		outjsonFilePath   string // outjsonFilePath is the output JSON expected, when not specified it is assumed input == output.
 	}{
 		{
 			desc:         "basic",
@@ -442,6 +444,13 @@ func TestUnmarshal(t *testing.T) {
 			jsonFilePath: "policy-example.json",
 			parent:       &oc.Device{},
 		},
+		{
+			desc:            "basic with extra fields",
+			jsonFilePath:    "basic-extra.json",
+			parent:          &oc.Device{},
+			opts:            []ytypes.UnmarshalOpt{&ytypes.IgnoreExtraFields{}},
+			outjsonFilePath: "basic.json",
+		},
 	}
 
 	emitJSONConfig := &ygot.EmitJSONConfig{
@@ -452,13 +461,23 @@ func TestUnmarshal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+
 			j, err := ioutil.ReadFile(filepath.Join(testRoot, "testdata", tt.jsonFilePath))
 			if err != nil {
 				t.Errorf("%s: ioutil.ReadFile(%s): could not open file: %v", tt.desc, tt.jsonFilePath, err)
 				return
 			}
 
-			err = oc.Unmarshal(j, tt.parent)
+			wantj := j
+			if tt.outjsonFilePath != "" {
+				rj, err := ioutil.ReadFile(filepath.Join(testRoot, "testdata", tt.outjsonFilePath))
+				if err != nil {
+					t.Errorf("%s: ioutil.ReadFile(%s): could not open file: %v", tt.desc, tt.outjsonFilePath, err)
+				}
+				wantj = rj
+			}
+
+			err = oc.Unmarshal(j, tt.parent, tt.opts...)
 			if got, want := errToString(err), tt.wantErr; got != want {
 				t.Errorf("%s: got error: %v, want error: %v ", tt.desc, got, want)
 			}
@@ -472,7 +491,7 @@ func TestUnmarshal(t *testing.T) {
 				if err != nil {
 					return
 				}
-				d, err := diffJSON(j, []byte(jo))
+				d, err := diffJSON(wantj, []byte(jo))
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/ytypes/unmarshal.go
+++ b/ytypes/unmarshal.go
@@ -21,10 +21,27 @@ import (
 	"github.com/openconfig/ygot/util"
 )
 
+// UnmarshalOpt is an interface used for any option to be supplied
+// to the Unmarshal function. Types implementing it can be used to
+// control the behaviour of JSON unmarshalling.
+type UnmarshalOpt interface {
+	IsUnmarshalOpt()
+}
+
+// IgnoreExtraFields is an unmarshal option that controls the
+// behaviour of the Unmarshal function when additional fields are
+// found in the input JSON. By default, an error will be returned,
+// by specifying the IgnoreExtraFields option to Unmarshal, extra
+// fields will be discarded.
+type IgnoreExtraFields struct{}
+
+// IsUnmarshalOpt marks IgnoreExtraFields as a valid UnmarshalOpt.
+func (*IgnoreExtraFields) IsUnmarshalOpt() {}
+
 // Unmarshal recursively unmarshals JSON data tree in value into the given
 // parent, using the given schema. Any values already in the parent that are
 // not present in value are preserved.
-func Unmarshal(schema *yang.Entry, parent interface{}, value interface{}) error {
+func Unmarshal(schema *yang.Entry, parent interface{}, value interface{}, opts ...UnmarshalOpt) error {
 	util.Indent()
 	defer util.Dedent()
 
@@ -43,11 +60,22 @@ func Unmarshal(schema *yang.Entry, parent interface{}, value interface{}) error 
 	case schema.IsLeafList():
 		return unmarshalLeafList(schema, parent, value)
 	case schema.IsList():
-		return unmarshalList(schema, parent, value)
+		return unmarshalList(schema, parent, value, opts...)
 	case schema.IsChoice():
 		return fmt.Errorf("cannot pass choice schema %s to Unmarshal", schema.Name)
 	case schema.IsContainer():
-		return unmarshalContainer(schema, parent, value)
+		return unmarshalContainer(schema, parent, value, opts...)
 	}
 	return fmt.Errorf("unknown schema type for type %T, value %v", value, value)
+}
+
+// hasIgnoreExtraFields determines whether the supplied slice of UnmarshalOpts contains
+// the IgnoreExtraFields option.
+func hasIgnoreExtraFields(opts []UnmarshalOpt) bool {
+	for _, o := range opts {
+		if _, ok := o.(*IgnoreExtraFields); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/ytypes/unmarshal_test.go
+++ b/ytypes/unmarshal_test.go
@@ -39,6 +39,7 @@ func TestUnmarshal(t *testing.T) {
 		desc    string
 		schema  *yang.Entry
 		value   interface{}
+		opts    []UnmarshalOpt
 		wantErr string
 	}{
 		{
@@ -58,16 +59,23 @@ func TestUnmarshal(t *testing.T) {
 			value:   "{}",
 			wantErr: `cannot pass choice schema choice to Unmarshal`,
 		},
+		{
+			desc:   "passing options to Unmarshal",
+			schema: validSchema,
+			value:  nil,
+			opts:   []UnmarshalOpt{&IgnoreExtraFields{}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			var parent ParentStruct
 
-			err := Unmarshal(tt.schema, &parent, tt.value)
+			err := Unmarshal(tt.schema, &parent, tt.value, tt.opts...)
 			if got, want := errToString(err), tt.wantErr; got != want {
 				t.Errorf("%s: got error: %v, want error: %v", tt.desc, got, want)
 			}
+
 		})
 	}
 }


### PR DESCRIPTION
Where devices have augmentation to the YANG schema, additional fields may be present in the JSON supplied to `Unmarshal`. Prior to this PR, this would result in errors being thrown relating to those missing fields. This change adds a new `UnmarshalOpt` interface which can be optionally supplied to `Unmarshal` in the generated code. When supplied it ensures that an error is not thrown for such additional fields.