### PR TITLE
Add error handling for nil paths.

### DIFF
--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -50,6 +50,10 @@ func PathToString(path *gnmipb.Path) (string, error) {
 // The YANG schema path removes any keys (i.e., predicates) from the path, using
 // only the name.
 func PathToSchemaPath(path *gnmipb.Path) (string, error) {
+	if path == nil {
+		return "", fmt.Errorf("received nil path in PathToSchemaPath")
+	}
+
 	if path.Element != nil {
 		var sp []string
 		for _, e := range path.Element {
@@ -81,6 +85,10 @@ func PathToSchemaPath(path *gnmipb.Path) (string, error) {
 // the path element using the format [name=value]. If the path specifies both pre-
 // and post-0.4.0 paths, the pre-0.4.0 version is returned.
 func PathToStrings(path *gnmipb.Path) ([]string, error) {
+	if path == nil {
+		return nil, fmt.Errorf("received nil path in PathToStrings")
+	}
+
 	if path.Element != nil {
 		return elementsToString(path.Element)
 	}

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -33,6 +33,10 @@ func TestPathToString(t *testing.T) {
 		want    string
 		wantErr string
 	}{{
+		name:    "nil path",
+		in:      nil,
+		wantErr: "received nil path",
+	}, {
 		name: "root path",
 		in:   &gnmipb.Path{Element: []string{}},
 		want: "/",
@@ -456,6 +460,10 @@ func TestPathToSchemaPath(t *testing.T) {
 		want             string
 		wantErrSubstring string
 	}{{
+		name:             "nil path",
+		inPath:           nil,
+		wantErrSubstring: "received nil path",
+	}, {
 		name: "element path",
 		inPath: &gnmipb.Path{
 			Element: []string{"one", "two", "three"},


### PR DESCRIPTION
Fixes a silly NPE in the public API :-(

```
  * (M) ygot/pathstrings.go
  * (M) ygot/pathstrings_test.go
    - Add implementation and tests for a nil path being passed to
      PathToX methods.
```