### PR TITLE
Fix ygot with latest Go master build.

### DIFF
--- a/demo/gnmi_telemetry/gnmi.go
+++ b/demo/gnmi_telemetry/gnmi.go
@@ -49,7 +49,7 @@ func main() {
 		}
 
 		if len(g) != 1 {
-			log.Exitf("Unexpected number of notifications returned %s", len(g))
+			log.Exitf("Unexpected number of notifications returned %d", len(g))
 		}
 		fmt.Printf("%v\n", proto.MarshalTextString(g[0]))
 	}
@@ -106,7 +106,7 @@ func CreateAFTInstance() (*oc.Device, error) {
 	// based on the input interface.
 	expNull, err := nh.To_NetworkInstance_Afts_LabelEntry_NextHop_PushedMplsLabelStack_Union(oc.OpenconfigAft_NextHop_PushedMplsLabelStack_IPV4_EXPLICIT_NULL)
 	if err != nil {
-    return nil, fmt.Errorf("error converting explicit null to union, got: %v", err)
+		return nil, fmt.Errorf("error converting explicit null to union, got: %v", err)
 	}
 	nh.PushedMplsLabelStack = []oc.NetworkInstance_Afts_LabelEntry_NextHop_PushedMplsLabelStack_Union{
 		&oc.NetworkInstance_Afts_LabelEntry_NextHop_PushedMplsLabelStack_Union_Uint32{42},

--- a/experimental/ygotutils/common.go
+++ b/experimental/ygotutils/common.go
@@ -101,7 +101,7 @@ func popGNMIPath(path *gpb.Path) *gpb.Path {
 func pathStructTagKey(f reflect.StructField) string {
 	p, err := pathToSchema(f)
 	if err != nil {
-		log.Errorln("struct field %s does not have a path tag, bad schema?", f.Name)
+		log.Errorf("struct field %s does not have a path tag, bad schema?", f.Name)
 		return ""
 	}
 	return p[len(p)-1]

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -890,7 +890,7 @@ func getNodesList(schema *yang.Entry, root interface{}, path *gpb.Path) ([]inter
 func pathStructTagKey(f reflect.StructField) string {
 	p, err := pathToSchema(f)
 	if err != nil {
-		log.Errorln("struct field %s does not have a path tag, bad schema?", f.Name)
+		log.Errorf("struct field %s does not have a path tag, bad schema?", f.Name)
 		return ""
 	}
 	return p[len(p)-1]


### PR DESCRIPTION
It looks like HEAD@master for Go has added error handling for incorrect `Errorf` formatting strings, and detection of them in `Errorln`.

This fixes the tests.
 