### PR TITLE
Add StringToType helper to use with gNMI notification unmarshalling

### DIFF
--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
 )
 
 func TestYangBuiltinTypeToGoType(t *testing.T) {
@@ -166,5 +167,63 @@ func TestYangToJSONType(t *testing.T) {
 
 	if got := yangToJSONType(yang.Yunion); got != nil {
 		t.Errorf("got: %v, want: nil", got)
+	}
+}
+
+type testEnum int64
+
+const (
+	Enum1 testEnum = 1
+	Enum2 testEnum = 2
+	Enum3 testEnum = 3
+)
+
+func (testEnum) IsYANGGoEnum() {}
+
+func (testEnum) ΛMap() map[string]map[int64]ygot.EnumDefinition { return ΛEnum }
+
+var ΛEnum = map[string]map[int64]ygot.EnumDefinition{
+	"testEnum": {
+		1: {Name: "test_enum1"},
+		2: {Name: "test_enum2"},
+		3: {Name: "test_enum3"},
+	},
+}
+
+type testStruct struct {
+	Test testEnum
+}
+
+func TestStringToType(t *testing.T) {
+	ts := testStruct{}
+	tests := []struct {
+		s       string
+		t       reflect.Type
+		wantErr bool
+	}{
+		{s: "123", t: reflect.TypeOf(uint16(10))},
+		{s: "123", t: reflect.TypeOf(uint32(20))},
+		{s: "123", t: reflect.TypeOf(int16(-30))},
+		// invalid value for the type
+		{s: "fortytwo", t: reflect.TypeOf(uint16(0)), wantErr: true},
+		// overflowing value for the type
+		{s: "257", t: reflect.TypeOf(uint8(0)), wantErr: true},
+		{s: "test_enum3", t: reflect.TypeOf(ts.Test)},
+		// invalid enum for the enum type
+		{s: "fortytwo", t: reflect.TypeOf(ts.Test), wantErr: true},
+	}
+
+	for i, tt := range tests {
+		v, e := StringToType(tt.t, tt.s)
+		if (e != nil) != tt.wantErr {
+			t.Errorf("#%d got %v, want error %v", i+1, e, tt.wantErr)
+			continue
+		}
+		if e != nil {
+			continue
+		}
+		if v.Type() != tt.t {
+			t.Errorf("#%d got %v, want %v type", i+1, v.Type(), tt.t)
+		}
 	}
 }

--- a/ytypes/util_types.go
+++ b/ytypes/util_types.go
@@ -17,6 +17,7 @@ package ytypes
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
@@ -85,6 +86,52 @@ func castToEnumValue(ft reflect.Type, value string) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+// StringToType converts given string to given type which can be one of
+// the following;
+// - int, int8, int16, int32, int64
+// - uint, uint8, uint16, uint32, uint64
+// - string
+// - GoEnum type
+// Function can be extended to support other types as well. If the given string
+// carries an incompatible or overflowing value for the given type, function
+// returns error.
+// Note that castToEnumValue returns (nil, nil) if the given string is carrying
+// an invalid enum string. Function checks not only error, but also value in this
+// case.
+func StringToType(t reflect.Type, s string) (reflect.Value, error) {
+	if t.Implements(reflect.TypeOf((*ygot.GoEnum)(nil)).Elem()) {
+		i, err := castToEnumValue(t, s)
+		if err != nil || i == nil {
+			return reflect.ValueOf(nil), fmt.Errorf("no enum matching with %s: %v", s, err)
+		}
+		return reflect.ValueOf(i), nil
+	}
+
+	switch t.Kind() {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, err := strconv.ParseUint(s, 10, int(t.Size())*8)
+		if err != nil {
+			return reflect.ValueOf(nil), fmt.Errorf("unable to convert given string to %v", t.Kind())
+		}
+		// Although Convert can panic, we know that the type is an unsigned integer type and
+		// u must be a valid uint type of the same length -- it is therefore impossible that
+		// Convert fails here.
+		return reflect.ValueOf(u).Convert(t), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		u, err := strconv.ParseInt(s, 10, int(t.Size())*8)
+		if err != nil {
+			return reflect.ValueOf(nil), fmt.Errorf("unable to convert given string to %v", t.Kind())
+		}
+		// Although Convert can panic, we know that the type is an integer type and
+		// u must be a valid int type of the same length -- it is therefore impossible that
+		// Convert fails here.
+		return reflect.ValueOf(u).Convert(t), nil
+	case reflect.String:
+		return reflect.ValueOf(s), nil
+	}
+	return reflect.ValueOf(nil), fmt.Errorf("no matching type to cast")
 }
 
 // yangBuiltinTypeToGoType returns a pointer to the Go built-in value with


### PR DESCRIPTION
gNMI PathElem carries keys in Key field. For struct key types, the Key field carries more than one <key, value> pairs. Source type is just string, but destination field in struct can be string, enum etc. This helper will be used to convert given string to given type while unmarshalling a gNMI notification into GoStruct.