### PR TITLE
Add ygot helper to create map element value

### DIFF
--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -46,6 +46,8 @@ func (EnumType) ΛMap() map[string]map[int64]ygot.EnumDefinition {
 	return globalEnumMap
 }
 
+func (EnumType) IsYANGGoEnum() {}
+
 // EnumType2 is used as an enum type in various tests in the ytypes package.
 type EnumType2 int64
 

--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -227,3 +227,56 @@ func TestStringToType(t *testing.T) {
 		}
 	}
 }
+
+func TestDirectDescendantSchema(t *testing.T) {
+	tests := []struct {
+		desc    string
+		s       interface{}
+		w       string
+		wantErr bool
+	}{
+		{
+			desc: "simple schema tag",
+			s: struct {
+				f string `path:"key"`
+			}{},
+			w: "key",
+		},
+		{
+			desc: "multiple schema tag",
+			s: struct {
+				f string `path:"config/key|key"`
+			}{},
+			w: "key",
+		},
+		{
+			desc: "in the middle direct descendant",
+			s: struct {
+				f string `path:"config/key|key|state/key"`
+			}{},
+			w: "key",
+		},
+		{
+			desc: "missing schema tag",
+			s: struct {
+				f string
+			}{},
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			k, e := directDescendantSchema(reflect.TypeOf(tt.s).Field(0))
+			if (e != nil) != tt.wantErr {
+				t.Fatalf("#%d got %v, want error %v", i, e, tt.wantErr)
+			}
+			if e != nil {
+				return
+			}
+			if tt.w != k {
+				t.Errorf("#%d got %v, want %v", i, k, tt.w)
+			}
+		})
+	}
+}

--- a/ytypes/util_types.go
+++ b/ytypes/util_types.go
@@ -113,7 +113,7 @@ func StringToType(t reflect.Type, s string) (reflect.Value, error) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		u, err := strconv.ParseUint(s, 10, int(t.Size())*8)
 		if err != nil {
-			return reflect.ValueOf(nil), fmt.Errorf("unable to convert given string to %v", t.Kind())
+			return reflect.ValueOf(nil), fmt.Errorf("unable to convert %q to %v", s, t.Kind())
 		}
 		// Although Convert can panic, we know that the type is an unsigned integer type and
 		// u must be a valid uint type of the same length -- it is therefore impossible that
@@ -122,7 +122,7 @@ func StringToType(t reflect.Type, s string) (reflect.Value, error) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		u, err := strconv.ParseInt(s, 10, int(t.Size())*8)
 		if err != nil {
-			return reflect.ValueOf(nil), fmt.Errorf("unable to convert given string to %v", t.Kind())
+			return reflect.ValueOf(nil), fmt.Errorf("unable to convert %q to %v", s, t.Kind())
 		}
 		// Although Convert can panic, we know that the type is an integer type and
 		// u must be a valid int type of the same length -- it is therefore impossible that
@@ -131,7 +131,7 @@ func StringToType(t reflect.Type, s string) (reflect.Value, error) {
 	case reflect.String:
 		return reflect.ValueOf(s), nil
 	}
-	return reflect.ValueOf(nil), fmt.Errorf("no matching type to cast")
+	return reflect.ValueOf(nil), fmt.Errorf("no matching type to cast for %v", t)
 }
 
 // yangBuiltinTypeToGoType returns a pointer to the Go built-in value with


### PR DESCRIPTION
makeKeyForInsert function ,which already exists in list.go, have capability to create a map key given a map value. This change adds another helper to create a map value given a map[string]string assuming from the gNMI PathElem. After this change, it will be possible to create a map entry given a gNMI Path with Key field populated.