### PR TITLE
Add utility to validate given gNMI Path against given schema 

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -39,8 +39,8 @@ func stringMapKeys(m map[string]*yang.Entry) []string {
 
 // TODO(mostrowski): move below functions into path package.
 
-// pathMatchesPrefix reports whether prefix is a prefix of path.
-func pathMatchesPrefix(path *gpb.Path, prefix []string) bool {
+// PathMatchesPrefix reports whether prefix is a prefix of path.
+func PathMatchesPrefix(path *gpb.Path, prefix []string) bool {
 	if len(path.GetElem()) < len(prefix) {
 		return false
 	}
@@ -56,13 +56,13 @@ func pathMatchesPrefix(path *gpb.Path, prefix []string) bool {
 	return true
 }
 
-// trimGNMIPathPrefix returns path with the prefix trimmed. It returns the
+// TrimGNMIPathPrefix returns path with the prefix trimmed. It returns the
 // original path if the prefix does not fully match.
-func trimGNMIPathPrefix(path *gpb.Path, prefix []string) *gpb.Path {
+func TrimGNMIPathPrefix(path *gpb.Path, prefix []string) *gpb.Path {
 	for len(prefix) != 0 && prefix[len(prefix)-1] == "" {
 		prefix = prefix[:len(prefix)-1]
 	}
-	if !pathMatchesPrefix(path, prefix) {
+	if !PathMatchesPrefix(path, prefix) {
 		return path
 	}
 	out := *path
@@ -70,9 +70,9 @@ func trimGNMIPathPrefix(path *gpb.Path, prefix []string) *gpb.Path {
 	return &out
 }
 
-// popGNMIPath returns the supplied GNMI path with the first path element
+// PopGNMIPath returns the supplied GNMI path with the first path element
 // removed. If the path is empty, it returns an empty path.
-func popGNMIPath(path *gpb.Path) *gpb.Path {
+func PopGNMIPath(path *gpb.Path) *gpb.Path {
 	if len(path.GetElem()) == 0 {
 		return path
 	}

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -114,7 +114,7 @@ func TestPathMatchesPrefix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := pathMatchesPrefix(pathNoKeysToGNMIPath(tt.path), strings.Split(tt.prefix, "/")), tt.want; got != want {
+			if got, want := PathMatchesPrefix(pathNoKeysToGNMIPath(tt.path), strings.Split(tt.prefix, "/")), tt.want; got != want {
 				t.Errorf("%s: got: %v want: %v", tt.desc, got, want)
 			}
 		})
@@ -182,7 +182,7 @@ func TestTrimGNMIPathPrefix(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			path := pathNoKeysToGNMIPath(tt.path)
 			prefix := strings.Split(tt.prefix, "/")
-			got := gnmiPathNoKeysToPath(trimGNMIPathPrefix(path, prefix))
+			got := gnmiPathNoKeysToPath(TrimGNMIPathPrefix(path, prefix))
 			if got != tt.want {
 				t.Errorf("%s: got: %s want: %s", tt.desc, got, tt.want)
 			}
@@ -220,7 +220,7 @@ func TestPopGNMIPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := gnmiPathNoKeysToPath(popGNMIPath(pathNoKeysToGNMIPath(tt.path))), tt.want; got != want {
+			if got, want := gnmiPathNoKeysToPath(PopGNMIPath(pathNoKeysToGNMIPath(tt.path))), tt.want; got != want {
 				t.Errorf("%s: got: %s want: %s", tt.desc, got, want)
 			}
 		})

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -806,14 +806,14 @@ func getNodesContainer(schema *yang.Entry, root interface{}, path *gpb.Path) ([]
 			return nil, nil, err
 		}
 		for _, p := range ps {
-			if pathMatchesPrefix(path, p) {
+			if PathMatchesPrefix(path, p) {
 				// don't trim whole prefix  for keyed list since name and key
 				// are a in the same element.
 				to := len(p)
 				if IsTypeMap(ft.Type) {
 					to--
 				}
-				return getNodesInternal(cschema, f.Interface(), trimGNMIPathPrefix(path, p[0:to]))
+				return getNodesInternal(cschema, f.Interface(), TrimGNMIPathPrefix(path, p[0:to]))
 			}
 		}
 	}
@@ -902,7 +902,7 @@ func getNodesList(schema *yang.Entry, root interface{}, path *gpb.Path) ([]inter
 			// Pass in the list schema, but the actual selected element
 			// rather than the whole list.
 			DbgPrint("key matches")
-			n, s, err := getNodesInternal(schema, ev.Interface(), popGNMIPath(path))
+			n, s, err := getNodesInternal(schema, ev.Interface(), PopGNMIPath(path))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -424,7 +424,7 @@ func mapValuePath(key, value reflect.Value, parentPath *gnmiPath) (*gnmiPath, er
 	}
 
 	if parentPath.isStringSlicePath() {
-		keyval, err := keyValueAsString(key.Interface())
+		keyval, err := KeyValueAsString(key.Interface())
 		if err != nil {
 			return nil, fmt.Errorf("can't append path element key: %v", err)
 		}
@@ -506,7 +506,7 @@ func appendgNMIPathElemKey(v reflect.Value, p *gnmiPath) (*gnmiPath, error) {
 func keyMapAsStrings(keys map[string]interface{}) (map[string]string, error) {
 	nk := map[string]string{}
 	for kn, k := range keys {
-		v, err := keyValueAsString(k)
+		v, err := KeyValueAsString(k)
 		if err != nil {
 			return nil, err
 		}
@@ -515,10 +515,10 @@ func keyMapAsStrings(keys map[string]interface{}) (map[string]string, error) {
 	return nk, nil
 }
 
-// keyValueAsString returns a string representation of the interface{} supplied. If the
+// KeyValueAsString returns a string representation of the interface{} supplied. If the
 // type provided cannot be represented as a string for use in a gNMI path, an error is
 // returned.
-func keyValueAsString(v interface{}) (string, error) {
+func KeyValueAsString(v interface{}) (string, error) {
 	kv := reflect.ValueOf(v)
 	if _, isEnum := v.(GoEnum); isEnum {
 		name, _, err := enumFieldToString(kv, false)
@@ -538,7 +538,7 @@ func keyValueAsString(v interface{}) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return keyValueAsString(iv)
+		return KeyValueAsString(iv)
 	}
 
 	return "", fmt.Errorf("cannot convert type %v to a string for use in a key: %v", kv.Kind(), v)

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -1,0 +1,261 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ytypes
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygot"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// Type retrieveNodeArgs contains the set of parameters that changes
+// behavior of how retrieveNode works.
+type retrieveNodeArgs struct {
+	// If create is set to true, retrieveNode initializes all the nodes
+	// along the path. It also creates and inserts a key into the map
+	// if it is missing in the keyed list node.
+	create bool
+	// If delete is set to true, retrieve node deletes the node at the
+	// to supplied path.
+	delete bool
+	// If partialKeyMatch is set to true, retrieveNode tolerates missing
+	// key(s) in the given path. If no key is provided, all the nodes
+	// in the keyed list are treated as match. If some of the keys are
+	// provided, it returns the nodes corresponding to provided keys.
+	partialKeyMatch bool
+	// If dontModifyRoot is set to true, retrieveNode traverses the GoStruct
+	// without initializing nodes or inserting keys into maps.
+	dontModifyRoot bool
+	// If val is set to a non-nil value, leaf/leaflist node corresponding
+	// to the given path is updated with this value.
+	val interface{}
+}
+
+// retrieveNode is an internal function that retrieves the node specified by
+// the supplied path from the root which must have the schema supplied.
+// retrieveNodeArgs change the way retrieveNode works.
+// retrieveNode returns the list of matching nodes and their schemas, and error.
+// Note that retrieveNode may mutate the tree even if it fails.
+func retrieveNode(schema *yang.Entry, root interface{}, path *gpb.Path, args retrieveNodeArgs) ([]interface{}, []*yang.Entry, error) {
+	switch {
+	case path == nil || len(path.Elem) == 0:
+		return []interface{}{root}, []*yang.Entry{schema}, nil
+	case util.IsValueNil(root):
+		return nil, nil, status.Errorf(codes.InvalidArgument, "root is nil for type %T, path %v", root, path)
+	case schema == nil:
+		return nil, nil, status.Errorf(codes.InvalidArgument, "schema is nil for type %T, path %v", root, path)
+	}
+
+	switch {
+	// Check if the schema is a container, or the schema is a list and the parent provided is a member of that list.
+	case schema.IsContainer() || (schema.IsList() && util.IsTypeStructPtr(reflect.TypeOf(root))):
+		return retrieveNodeContainer(schema, root, path, args)
+	case schema.IsList():
+		return retrieveNodeList(schema, root, path, args)
+	}
+	return nil, nil, status.Errorf(codes.InvalidArgument, "can not use a parent that is not a container or list; schema %v root %T, path %v", schema, root, path)
+}
+
+// retrieveNodeContainer is an internal function and operates on GoStruct. It retrieves
+// the node by the supplied path from the root which must have the schema supplied.
+// It recurses by calling retrieveNode. If create is set to true, nodes along the path are initialized
+// if they are nil. If val isn't nil, then it is set on the leaf or leaflist node.
+// Note that root is modified even if function returns error status.
+func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path, args retrieveNodeArgs) ([]interface{}, []*yang.Entry, error) {
+	rv := reflect.ValueOf(root)
+	if !util.IsTypeStructPtr(rv.Type()) {
+		return nil, nil, status.Errorf(codes.InvalidArgument, "got %T, want struct ptr root in retrieveNodeContainer", root)
+	}
+
+	// dereference reflect value as it points to a pointer.
+	v := rv.Elem()
+
+	for i := 0; i < v.NumField(); i++ {
+		fv, ft := v.Field(i), v.Type().Field(i)
+
+		if util.IsYgotAnnotation(ft) {
+			continue
+		}
+
+		cschema, err := childSchema(schema, ft)
+		switch {
+		case err != nil:
+			return nil, nil, status.Errorf(codes.Unknown, "failed to get child schema for %T, field %s: %s", root, ft.Name, err)
+		case cschema == nil:
+			return nil, nil, status.Errorf(codes.NotFound, "could not find schema for type %T, field %s", root, ft.Name)
+		default:
+			if cschema, err = resolveLeafRef(cschema); err != nil {
+				return nil, nil, status.Errorf(codes.Unknown, "failed to resolve schema for %T, field %s: %s", root, ft.Name, err)
+			}
+		}
+
+		schPaths, err := util.SchemaPaths(ft)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Unknown, "failed to get schema paths for %T, field %s: %s", root, ft.Name, err)
+		}
+
+		for _, p := range schPaths {
+			if !util.PathMatchesPrefix(path, p) {
+				continue
+			}
+			to := len(p)
+			if util.IsTypeMap(ft.Type) {
+				to--
+			}
+			// If the node is a leaf node and path is exhausted, check whether val is set to a non-nil value. If
+			// these are satisfied, the leaf value is updated.
+			if (cschema.IsLeaf() || cschema.IsLeafList()) && len(path.Elem) == to && !util.IsValueNil(args.val) {
+				return nil, nil, status.Errorf(codes.Unimplemented, "setting leaf/leaflist node is unimplemented")
+			}
+
+			if args.create {
+				if err := util.InitializeStructField(root, ft.Name); err != nil {
+					return nil, nil, status.Errorf(codes.Unknown, "failed to initialize struct field %s in %T, child schema %v, path %v", ft.Name, root, cschema, path)
+				}
+			}
+			return retrieveNode(cschema, fv.Interface(), util.TrimGNMIPathPrefix(path, p[0:to]), args)
+		}
+	}
+
+	return nil, nil, status.Errorf(codes.NotFound, "no match found in %T, for path %v", root, path)
+}
+
+// retrieveNodeList is an internal function and operates on a map. It returns the nodes matching
+// with keys corresponding to the key supplied in path.
+// Function returns list of nodes, list of schemas and error.
+func retrieveNodeList(schema *yang.Entry, root interface{}, path *gpb.Path, args retrieveNodeArgs) ([]interface{}, []*yang.Entry, error) {
+	rv := reflect.ValueOf(root)
+	switch {
+	case schema.Key == "":
+		return nil, nil, status.Errorf(codes.InvalidArgument, "unkeyed list can't be traversed, type %T, path %v", root, path)
+	case len(path.GetElem()) == 0:
+		return nil, nil, status.Errorf(codes.InvalidArgument, "path length is 0, schema %v, root %v", schema, root)
+	case path.GetElem()[0].GetKey() == nil:
+		return nil, nil, status.Errorf(codes.InvalidArgument, "path %v at %T points to a list without a key element", path, root)
+	case !util.IsValueMap(rv):
+		return nil, nil, status.Errorf(codes.InvalidArgument, "root has type %T, expect map", root)
+	}
+
+	var matchNodes []interface{}
+	var matchSchemas []*yang.Entry
+
+	listKeyT := rv.Type().Key()
+	listElemT := rv.Type().Elem()
+	for _, k := range rv.MapKeys() {
+		listElemV := rv.MapIndex(k)
+
+		// Handle lists with a single key.
+		if !util.IsValueStruct(k) {
+			pathKey, ok := path.GetElem()[0].GetKey()[schema.Key]
+			if !ok {
+				return nil, nil, status.Errorf(codes.NotFound, "schema key %s is not found in gNMI path %v, root %T", schema.Key, path, root)
+			}
+
+			kv, err := getKeyValue(listElemV.Elem(), schema.Key)
+			if err != nil {
+				return nil, nil, status.Errorf(codes.Unknown, "failed to get key value for %v, path %v: %v", listElemV.Interface(), path, err)
+			}
+			if fmt.Sprint(kv) == pathKey {
+				return retrieveNode(schema, listElemV.Interface(), util.PopGNMIPath(path), args)
+			}
+			continue
+		}
+
+		match := true
+		for i := 0; i < k.NumField(); i++ {
+			fieldName := listKeyT.Field(i).Name
+			fieldValue := k.Field(i)
+			if !fieldValue.IsValid() {
+				return nil, nil, status.Errorf(codes.InvalidArgument, "invalid field %s in %T", fieldName, k)
+			}
+
+			elemFieldT, ok := listElemT.Elem().FieldByName(fieldName)
+			if !ok {
+				return nil, nil, status.Errorf(codes.NotFound, "element struct type %v does not contain key field %s", listElemT, fieldName)
+			}
+
+			schemaKey, err := directDescendantSchema(elemFieldT)
+			if err != nil {
+				return nil, nil, status.Errorf(codes.Unknown, "unable to get direct descendant schema name for %v: %v", schemaKey, err)
+			}
+
+			pathKey, ok := path.GetElem()[0].GetKey()[schemaKey]
+			// If key isn't found in the path key, treat it as error if partialKeyMatch is set to false.
+			// Otherwise, continue searching other keys of key struct and count the value as match
+			// if other keys are also match.
+			if !ok && !args.partialKeyMatch {
+				return nil, nil, status.Errorf(codes.NotFound, "gNMI path %v does not contain a map entry for schema %v, root %T", path, schemaKey, root)
+			}
+			keyAsString, err := ygot.KeyValueAsString(fieldValue.Interface())
+			if err != nil {
+				return nil, nil, status.Errorf(codes.Unknown, "failed to convert the field value to string, field %v: %v", fieldName, err)
+			}
+			if pathKey != keyAsString {
+				match = false
+				break
+			}
+		}
+
+		if match {
+			nodes, schemas, err := retrieveNode(schema, listElemV.Interface(), util.PopGNMIPath(path), args)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if nodes != nil {
+				matchNodes = append(matchNodes, nodes...)
+				matchSchemas = append(matchSchemas, schemas...)
+			}
+		}
+	}
+
+	if len(matchNodes) == 0 && args.create {
+		key, err := insertAndGetKey(schema, root, path.GetElem()[0].GetKey())
+		if err != nil {
+			return nil, nil, err
+		}
+		nodes, schemas, err := retrieveNode(schema, rv.MapIndex(reflect.ValueOf(key)).Interface(), util.PopGNMIPath(path), args)
+		if err != nil {
+			return nil, nil, err
+		}
+		matchNodes = append(matchNodes, nodes...)
+		matchSchemas = append(matchSchemas, schemas...)
+	}
+
+	return matchNodes, matchSchemas, nil
+}
+
+// GetOrCreateNode function retrieves the node specified by the supplied path from the root which must have the
+// schema supplied. It strictly matches keys in the path, in other words doesn't treat partial match as match.
+// However, if there is no match, a new entry in the map is created. GetOrCreateNode also initializes the nodes
+// along the path if they are nil.
+// Function returns the value and schema of the node as well as error.
+// Note that this function may modify the supplied root even if the function fails.
+func GetOrCreateNode(schema *yang.Entry, root interface{}, path *gpb.Path) (interface{}, *yang.Entry, error) {
+	nodes, schemas, err := retrieveNode(schema, root, path, retrieveNodeArgs{create: true})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// There must be a result as this function initializes nodes along the supplied path.
+	return nodes[0], schemas[0], nil
+}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -48,11 +48,11 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 		Name: "container",
 		Kind: yang.DirectoryEntry,
 		Dir: map[string]*yang.Entry{
-			"config": &yang.Entry{
+			"config": {
 				Name: "config",
 				Kind: yang.DirectoryEntry,
 				Dir: map[string]*yang.Entry{
-					"simple-key-list": &yang.Entry{
+					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
 						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
@@ -68,25 +68,25 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 								Name: "outer",
 								Kind: yang.DirectoryEntry,
 								Dir: map[string]*yang.Entry{
-									"config": &yang.Entry{
+									"config": {
 										Name: "config",
 										Kind: yang.DirectoryEntry,
 										Dir: map[string]*yang.Entry{
-											"inner": &yang.Entry{
+											"inner": {
 												Name: "inner",
 												Kind: yang.DirectoryEntry,
 												Dir: map[string]*yang.Entry{
-													"int32-leaf-field": &yang.Entry{
+													"int32-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Yint32},
 													},
-													"string-leaf-field": &yang.Entry{
+													"string-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Ystring},
 													},
-													"enum-leaf-field": &yang.Entry{
+													"enum-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Yenum},
@@ -107,11 +107,11 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 		Name: "container",
 		Kind: yang.DirectoryEntry,
 		Dir: map[string]*yang.Entry{
-			"config": &yang.Entry{
+			"config": {
 				Name: "config",
 				Kind: yang.DirectoryEntry,
 				Dir: map[string]*yang.Entry{
-					"simple-key-list": &yang.Entry{
+					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
 						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
@@ -127,25 +127,25 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 								Name: "outer",
 								Kind: yang.DirectoryEntry,
 								Dir: map[string]*yang.Entry{
-									"config": &yang.Entry{
+									"config": {
 										Name: "config",
 										Kind: yang.DirectoryEntry,
 										Dir: map[string]*yang.Entry{
-											"inner": &yang.Entry{
+											"inner": {
 												Name: "inner",
 												Kind: yang.DirectoryEntry,
 												Dir: map[string]*yang.Entry{
-													"int32-leaf-field": &yang.Entry{
+													"int32-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Yint32},
 													},
-													"string-leaf-field": &yang.Entry{
+													"string-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Ystring},
 													},
-													"enum-leaf-field": &yang.Entry{
+													"enum-leaf-field": {
 														Name: "leaf-field",
 														Kind: yang.LeafEntry,
 														Type: &yang.YangType{Kind: yang.Yenum},
@@ -351,7 +351,7 @@ func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
 		Name: "container",
 		Kind: yang.DirectoryEntry,
 		Dir: map[string]*yang.Entry{
-			"struct-key-list": &yang.Entry{
+			"struct-key-list": {
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
 				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
@@ -377,25 +377,25 @@ func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
 						Name: "outer",
 						Kind: yang.DirectoryEntry,
 						Dir: map[string]*yang.Entry{
-							"config": &yang.Entry{
+							"config": {
 								Name: "config",
 								Kind: yang.DirectoryEntry,
 								Dir: map[string]*yang.Entry{
-									"inner": &yang.Entry{
+									"inner": {
 										Name: "inner",
 										Kind: yang.DirectoryEntry,
 										Dir: map[string]*yang.Entry{
-											"int32-leaf-field": &yang.Entry{
+											"int32-leaf-field": {
 												Name: "leaf-field",
 												Kind: yang.LeafEntry,
 												Type: &yang.YangType{Kind: yang.Yint32},
 											},
-											"string-leaf-field": &yang.Entry{
+											"string-leaf-field": {
 												Name: "leaf-field",
 												Kind: yang.LeafEntry,
 												Type: &yang.YangType{Kind: yang.Ystring},
 											},
-											"enum-leaf-field": &yang.Entry{
+											"enum-leaf-field": {
 												Name: "leaf-field",
 												Kind: yang.LeafEntry,
 												Type: &yang.YangType{Kind: yang.Yenum},
@@ -424,7 +424,7 @@ func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
 			inSchema: containerWithLeafListSchema,
 			inParent: &ContainerStruct3{
 				StructKeyList: map[KeyStruct]*ListElemStruct3{
-					{"forty-two", 42, 42}: &ListElemStruct3{
+					{"forty-two", 42, 42}: {
 						Key1:    ygot.String("forty-two"),
 						Key2:    ygot.Int32(42),
 						EnumKey: EnumType(42),
@@ -440,7 +440,7 @@ func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
 			inSchema: containerWithLeafListSchema,
 			inParent: &ContainerStruct3{
 				StructKeyList: map[KeyStruct]*ListElemStruct3{
-					{"forty-two", 42, EnumType(42)}: &ListElemStruct3{
+					{"forty-two", 42, EnumType(42)}: {
 						Key1:    ygot.String("forty-two"),
 						Key2:    ygot.Int32(42),
 						EnumKey: EnumType(42),
@@ -504,25 +504,25 @@ func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
 				Name: "outer",
 				Kind: yang.DirectoryEntry,
 				Dir: map[string]*yang.Entry{
-					"config": &yang.Entry{
+					"config": {
 						Name: "config",
 						Kind: yang.DirectoryEntry,
 						Dir: map[string]*yang.Entry{
-							"inner": &yang.Entry{
+							"inner": {
 								Name: "inner",
 								Kind: yang.DirectoryEntry,
 								Dir: map[string]*yang.Entry{
-									"int32-leaf-field": &yang.Entry{
+									"int32-leaf-field": {
 										Name: "int32-leaf-field",
 										Kind: yang.LeafEntry,
 										Type: &yang.YangType{Kind: yang.Yint32},
 									},
-									"string-leaf-field": &yang.Entry{
+									"string-leaf-field": {
 										Name: "string-leaf-field",
 										Kind: yang.LeafEntry,
 										Type: &yang.YangType{Kind: yang.Ystring},
 									},
-									"enum-leaf-field": &yang.Entry{
+									"enum-leaf-field": {
 										Name: "enum-leaf-field",
 										Kind: yang.LeafEntry,
 										Type: &yang.YangType{Kind: yang.Yenum},

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -1,0 +1,633 @@
+package ytypes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/gnmi/errdiff"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+type InnerContainerType1 struct {
+	Int32LeafName  *int32   `path:"int32-leaf-field"`
+	StringLeafName *string  `path:"string-leaf-field"`
+	EnumLeafName   EnumType `path:"enum-leaf-field"`
+	Annotation     *string  `ygotAnnotation:"true"`
+}
+type OuterContainerType1 struct {
+	Inner *InnerContainerType1 `path:"inner|config/inner"`
+}
+type ListElemStruct1 struct {
+	Key1       *string              `path:"key1"`
+	Outer      *OuterContainerType1 `path:"outer"`
+	Annotation *string              `ygotAnnotation:"true"`
+}
+type ContainerStruct1 struct {
+	StructKeyList map[string]*ListElemStruct1 `path:"config/simple-key-list"`
+}
+type ListElemStruct2 struct {
+	Key1       *uint32              `path:"key1"`
+	Outer      *OuterContainerType1 `path:"outer"`
+	Annotation *string              `ygotAnnotation:"true"`
+}
+type ContainerStruct2 struct {
+	StructKeyList map[uint32]*ListElemStruct2 `path:"config/simple-key-list"`
+}
+
+func (*InnerContainerType1) IsYANGGoStruct() {}
+func (*OuterContainerType1) IsYANGGoStruct() {}
+func (*ListElemStruct1) IsYANGGoStruct()     {}
+func (*ContainerStruct1) IsYANGGoStruct()    {}
+
+func TestGetOrCreateNodeSimpleKey(t *testing.T) {
+	containerWithStringKey := &yang.Entry{
+		Name: "container",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"config": &yang.Entry{
+				Name: "config",
+				Kind: yang.DirectoryEntry,
+				Dir: map[string]*yang.Entry{
+					"simple-key-list": &yang.Entry{
+						Name:     "simple-key-list",
+						Kind:     yang.DirectoryEntry,
+						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						Key:      "key1",
+						Config:   yang.TSTrue,
+						Dir: map[string]*yang.Entry{
+							"key1": {
+								Name: "key1",
+								Kind: yang.LeafEntry,
+								Type: &yang.YangType{Kind: yang.Ystring},
+							},
+							"outer": {
+								Name: "outer",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"config": &yang.Entry{
+										Name: "config",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"inner": &yang.Entry{
+												Name: "inner",
+												Kind: yang.DirectoryEntry,
+												Dir: map[string]*yang.Entry{
+													"int32-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Yint32},
+													},
+													"string-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Ystring},
+													},
+													"enum-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Yenum},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	containerWithUInt32Key := &yang.Entry{
+		Name: "container",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"config": &yang.Entry{
+				Name: "config",
+				Kind: yang.DirectoryEntry,
+				Dir: map[string]*yang.Entry{
+					"simple-key-list": &yang.Entry{
+						Name:     "simple-key-list",
+						Kind:     yang.DirectoryEntry,
+						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						Key:      "key1",
+						Config:   yang.TSTrue,
+						Dir: map[string]*yang.Entry{
+							"key1": {
+								Name: "key1",
+								Kind: yang.LeafEntry,
+								Type: &yang.YangType{Kind: yang.Yuint32},
+							},
+							"outer": {
+								Name: "outer",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"config": &yang.Entry{
+										Name: "config",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"inner": &yang.Entry{
+												Name: "inner",
+												Kind: yang.DirectoryEntry,
+												Dir: map[string]*yang.Entry{
+													"int32-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Yint32},
+													},
+													"string-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Ystring},
+													},
+													"enum-leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Yenum},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		inDesc           string
+		inParent         interface{}
+		inSchema         *yang.Entry
+		inPath           *gpb.Path
+		want             interface{}
+		wantErrSubstring string
+	}{
+		{
+			inDesc: "success get int32 leaf with an existing key",
+			inParent: &ContainerStruct1{
+				StructKeyList: map[string]*ListElemStruct1{
+					"forty-two": {
+						Key1: ygot.String("forty-two"),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								Int32LeafName: ygot.Int32(42),
+							},
+						},
+					},
+				},
+			},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/int32-leaf-field"),
+			want:     ygot.Int32(42),
+		},
+		{
+			inDesc:   "success get int32 leaf with a new key",
+			inParent: &ContainerStruct1{},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/int32-leaf-field"),
+			want:     ygot.Int32(0),
+		},
+		{
+			inDesc: "success get string leaf with an existing key",
+			inParent: &ContainerStruct1{
+				StructKeyList: map[string]*ListElemStruct1{
+					"forty-two": {
+						Key1: ygot.String("forty-two"),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								StringLeafName: ygot.String("forty_two"),
+							},
+						},
+					},
+				},
+			},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/string-leaf-field"),
+			want:     ygot.String("forty_two"),
+		},
+		{
+			inDesc:   "success get string leaf with a new key",
+			inParent: &ContainerStruct1{},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/string-leaf-field"),
+			want:     ygot.String(""),
+		},
+		{
+			inDesc: "success get enum leaf with an existing key",
+			inParent: &ContainerStruct1{
+				StructKeyList: map[string]*ListElemStruct1{
+					"forty-two": {
+						Key1: ygot.String("forty-two"),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								EnumLeafName: EnumType(43),
+							},
+						},
+					},
+				},
+			},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/enum-leaf-field"),
+			want:     EnumType(43),
+		},
+		{
+			inDesc:   "success get enum leaf with a new key",
+			inParent: &ContainerStruct1{},
+			inSchema: containerWithStringKey,
+			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/enum-leaf-field"),
+			want:     EnumType(0),
+		},
+		{
+			inDesc:           "fail get enum leaf incorrect container schema",
+			inParent:         &ContainerStruct1{},
+			inSchema:         containerWithStringKey,
+			inPath:           mustPath("/config/simple-key-list[key1=forty-two]/INVAID_CONTAINER/inner/enum-leaf-field"),
+			wantErrSubstring: "no match found in *ytypes.ListElemStruct1",
+		},
+		{
+			inDesc:           "fail get enum leaf incorrect leaf schema",
+			inParent:         &ContainerStruct1{},
+			inSchema:         containerWithStringKey,
+			inPath:           mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/INVALID_LEAF"),
+			wantErrSubstring: "no match found in *ytypes.InnerContainerType1",
+		},
+		{
+			inDesc: "success get int32 leaf from the map with key type uint32",
+			inParent: &ContainerStruct2{
+				StructKeyList: map[uint32]*ListElemStruct2{
+					42: {
+						Key1: ygot.Uint32(42),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								Int32LeafName: ygot.Int32(42),
+							},
+						},
+					},
+				},
+			},
+			inSchema: containerWithUInt32Key,
+			inPath:   mustPath("/config/simple-key-list[key1=42]/outer/inner/int32-leaf-field"),
+			want:     ygot.Int32(42),
+		},
+		{
+			inDesc:           "fail get enum leaf with incorrect map key",
+			inParent:         &ContainerStruct2{},
+			inSchema:         containerWithUInt32Key,
+			inPath:           mustPath("/config/simple-key-list[key1=INVALID_KEY]/outer/inner/enum-leaf-field"),
+			wantErrSubstring: `unable to convert "INVALID_KEY" to uint32`,
+		},
+		{
+			inDesc:   "success get a new InnerContainerType1 node",
+			inParent: &ContainerStruct2{},
+			inSchema: containerWithUInt32Key,
+			inPath:   mustPath("/config/simple-key-list[key1=42]/outer/inner"),
+			want:     &InnerContainerType1{},
+		},
+		{
+			inDesc: "success get an existing InnerContainerType1 node",
+			inParent: &ContainerStruct2{
+				StructKeyList: map[uint32]*ListElemStruct2{
+					42: {
+						Key1: ygot.Uint32(42),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								Int32LeafName: ygot.Int32(42),
+							},
+						},
+					},
+				},
+			},
+			inSchema: containerWithUInt32Key,
+			inPath:   mustPath("/config/simple-key-list[key1=42]/outer/inner"),
+			want:     &InnerContainerType1{Int32LeafName: ygot.Int32(42)},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			got, _, err := GetOrCreateNode(tt.inSchema, tt.inParent, tt.inPath)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("#%d: %s\ngot %v\nwant %v\n", i, tt.inDesc, err, tt.wantErrSubstring)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s:\ngot: %v\nwant: %v\n", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			}
+		})
+	}
+}
+
+type KeyStruct struct {
+	Key1    string   `path:"key1"`
+	Key2    int32    `path:"key2"`
+	EnumKey EnumType `path:"key3"`
+}
+type ListElemStruct3 struct {
+	Key1    *string              `path:"key1"`
+	Key2    *int32               `path:"key2"`
+	EnumKey EnumType             `path:"key3"`
+	Outer   *OuterContainerType1 `path:"outer"`
+}
+type ContainerStruct3 struct {
+	StructKeyList map[KeyStruct]*ListElemStruct3 `path:"struct-key-list"`
+}
+
+func (*ListElemStruct3) IsYANGGoStruct()  {}
+func (*ContainerStruct3) IsYANGGoStruct() {}
+
+func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
+	containerWithLeafListSchema := &yang.Entry{
+		Name: "container",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"struct-key-list": &yang.Entry{
+				Name:     "struct-key-list",
+				Kind:     yang.DirectoryEntry,
+				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				Key:      "key1 key2 key3",
+				Config:   yang.TSTrue,
+				Dir: map[string]*yang.Entry{
+					"key1": {
+						Name: "key1",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Ystring},
+					},
+					"key2": {
+						Name: "key2",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Yint32},
+					},
+					"key3": {
+						Name: "key3",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Yenum},
+					},
+					"outer": {
+						Name: "outer",
+						Kind: yang.DirectoryEntry,
+						Dir: map[string]*yang.Entry{
+							"config": &yang.Entry{
+								Name: "config",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"inner": &yang.Entry{
+										Name: "inner",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"int32-leaf-field": &yang.Entry{
+												Name: "leaf-field",
+												Kind: yang.LeafEntry,
+												Type: &yang.YangType{Kind: yang.Yint32},
+											},
+											"string-leaf-field": &yang.Entry{
+												Name: "leaf-field",
+												Kind: yang.LeafEntry,
+												Type: &yang.YangType{Kind: yang.Ystring},
+											},
+											"enum-leaf-field": &yang.Entry{
+												Name: "leaf-field",
+												Kind: yang.LeafEntry,
+												Type: &yang.YangType{Kind: yang.Yenum},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		inDesc           string
+		inParent         interface{}
+		inSchema         *yang.Entry
+		inPath           *gpb.Path
+		want             interface{}
+		wantErrSubstring string
+	}{
+		{
+			inDesc:   "success get int32 leaf from a struct keyed list",
+			inSchema: containerWithLeafListSchema,
+			inParent: &ContainerStruct3{
+				StructKeyList: map[KeyStruct]*ListElemStruct3{
+					{"forty-two", 42, 42}: &ListElemStruct3{
+						Key1:    ygot.String("forty-two"),
+						Key2:    ygot.Int32(42),
+						EnumKey: EnumType(42),
+						Outer:   &OuterContainerType1{Inner: &InnerContainerType1{Int32LeafName: ygot.Int32(1234)}},
+					},
+				},
+			},
+			inPath: mustPath("/struct-key-list[key1=forty-two][key2=42][key3=E_VALUE_FORTY_TWO]/outer/inner/int32-leaf-field"),
+			want:   ygot.Int32(1234),
+		},
+		{
+			inDesc:   "success get InnerContainerType1 from a struct keyed list",
+			inSchema: containerWithLeafListSchema,
+			inParent: &ContainerStruct3{
+				StructKeyList: map[KeyStruct]*ListElemStruct3{
+					{"forty-two", 42, EnumType(42)}: &ListElemStruct3{
+						Key1:    ygot.String("forty-two"),
+						Key2:    ygot.Int32(42),
+						EnumKey: EnumType(42),
+						Outer:   &OuterContainerType1{Inner: &InnerContainerType1{Int32LeafName: ygot.Int32(1234)}},
+					},
+				},
+			},
+			inPath: mustPath("/struct-key-list[key1=forty-two][key2=42][key3=E_VALUE_FORTY_TWO]/outer/inner"),
+			want:   &InnerContainerType1{Int32LeafName: ygot.Int32(1234)},
+		},
+		{
+			inDesc:   "success get string leaf from a struct keyed list with a new key",
+			inSchema: containerWithLeafListSchema,
+			inParent: &ContainerStruct3{},
+			inPath:   mustPath("/struct-key-list[key1=forty-two][key2=42][key3=E_VALUE_FORTY_TWO]/outer/inner/string-leaf-field"),
+			want:     ygot.String(""),
+		},
+		{
+			inDesc:           "fail get string leaf from a struct keyed list due to invalid key",
+			inSchema:         containerWithLeafListSchema,
+			inParent:         &ContainerStruct3{},
+			inPath:           mustPath("/struct-key-list[key1=forty-two][key2=42][key3=INVALID_ENUM]/outer/inner/string-leaf-field"),
+			wantErrSubstring: "no enum matching with INVALID_ENUM: <nil>",
+		},
+		{
+			inDesc:           "fail get due to partial key for struct keyed list",
+			inSchema:         containerWithLeafListSchema,
+			inParent:         &ContainerStruct3{},
+			inPath:           mustPath("/struct-key-list[key1=forty-two][key2=42]/outer"),
+			wantErrSubstring: "missing key3 key in map",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			got, _, err := GetOrCreateNode(tt.inSchema, tt.inParent, tt.inPath)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("#%d: %s\ngot %v\nwant %v\n", i, tt.inDesc, err, tt.wantErrSubstring)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s:\ngot: %v\nwant: %v\n", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			}
+		})
+	}
+}
+
+func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
+	simpleSchema := &yang.Entry{
+		Name: "list-elem-struct1",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"key1": {
+				Name: "key1",
+				Kind: yang.LeafEntry,
+				Type: &yang.YangType{Kind: yang.Ystring},
+			},
+			"outer": {
+				Name: "outer",
+				Kind: yang.DirectoryEntry,
+				Dir: map[string]*yang.Entry{
+					"config": &yang.Entry{
+						Name: "config",
+						Kind: yang.DirectoryEntry,
+						Dir: map[string]*yang.Entry{
+							"inner": &yang.Entry{
+								Name: "inner",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"int32-leaf-field": &yang.Entry{
+										Name: "int32-leaf-field",
+										Kind: yang.LeafEntry,
+										Type: &yang.YangType{Kind: yang.Yint32},
+									},
+									"string-leaf-field": &yang.Entry{
+										Name: "string-leaf-field",
+										Kind: yang.LeafEntry,
+										Type: &yang.YangType{Kind: yang.Ystring},
+									},
+									"enum-leaf-field": &yang.Entry{
+										Name: "enum-leaf-field",
+										Kind: yang.LeafEntry,
+										Type: &yang.YangType{Kind: yang.Yenum},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		inDesc           string
+		inSchema         *yang.Entry
+		inParent         interface{}
+		inPath           *gpb.Path
+		wantErrSubstring string
+		want             interface{}
+	}{
+		{
+			inDesc:   "success retrieving container with direct descendant schema",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{},
+			inPath:   mustPath("/outer/inner"),
+			want:     &InnerContainerType1{},
+		},
+		{
+			inDesc:   "success retrieving container with indirect descendant schema",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{},
+			inPath:   mustPath("/outer/config/inner"),
+			want:     &InnerContainerType1{},
+		},
+		{
+			inDesc:   "success retrieving int32 leaf with direct descendant schema",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{},
+			inPath:   mustPath("/outer/inner/int32-leaf-field"),
+			want:     ygot.Int32(0),
+		},
+		{
+			inDesc:   "success retrieving int32 leaf with indirect descendant schema",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{},
+			inPath:   mustPath("/outer/config/inner/int32-leaf-field"),
+			want:     ygot.Int32(0),
+		},
+		{
+			inDesc:   "success retrieving enum leaf with direct descendant schema",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{},
+			inPath:   mustPath("/outer/inner/enum-leaf-field"),
+			want:     EnumType(0),
+		},
+		{
+			inDesc:   "success retrieving enum leaf from existing container",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						EnumLeafName: EnumType(42),
+					},
+				},
+			},
+			inPath: mustPath("/outer/inner/enum-leaf-field"),
+			want:   EnumType(42),
+		},
+		{
+			inDesc:   "success retrieving container from existing container",
+			inSchema: simpleSchema,
+			inParent: &ListElemStruct1{
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						EnumLeafName: EnumType(42),
+					},
+				},
+			},
+			inPath: mustPath("/outer/inner"),
+			want: &InnerContainerType1{
+				EnumLeafName: EnumType(42),
+			},
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			got, _, err := GetOrCreateNode(tt.inSchema, tt.inParent, tt.inPath)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("#%d: %s\ngot %v\nwant %v\n", i, tt.inDesc, err, tt.wantErrSubstring)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s:\ngot: %v\nwant: %v\n", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			}
+		})
+	}
+}
+
+func mustPath(s string) *gpb.Path {
+	p, err := ygot.StringToStructuredPath(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}


### PR DESCRIPTION
- Added an internal function to use  while unmarshalling a gNMI notification into GoStruct
- Behavior of the internal function can be modified with the flags provided
- Exposed GetOrCreateNode function to use while retrieving a node corresponding to given gNMI path

This change will be followed by a set of changes that use the internal function mentioned above with different combination of flags. We aim to consolidate existing similar functions listed below;

See **NewNode** and **GetNode** in _experimental/ygotutils/getnode.go_
See **GetNodes** in _util/reflect.go_
