### PR TITLE
Fix the panic occurs when key and value fields don't match in makeKeyForInsert

### DIFF
--- a/util/reflect.go
+++ b/util/reflect.go
@@ -152,6 +152,12 @@ func IsValueScalar(v reflect.Value) bool {
 	return !IsValueStruct(v) && !IsValueMap(v) && !IsValueSlice(v)
 }
 
+// ValuesAreSameType returns true if v1 and v2 has the same reflect.Type,
+// otherwise it returns false.
+func ValuesAreSameType(v1 reflect.Value, v2 reflect.Value) bool {
+	return v1.Type() == v2.Type()
+}
+
 // IsValueInterfaceToStructPtr reports whether v is an interface that contains a
 // pointer to a struct.
 func IsValueInterfaceToStructPtr(v reflect.Value) bool {

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -213,6 +213,51 @@ func TestIsValueFuncs(t *testing.T) {
 	}
 }
 
+func TestValuesAreSameType(t *testing.T) {
+	type EnumType int64
+
+	tests := []struct {
+		inDesc string
+		inV1   interface{}
+		inV2   interface{}
+		want   bool
+	}{
+		{
+			inDesc: "success both are int32 types",
+			inV1:   int32(42),
+			inV2:   int32(43),
+			want:   true,
+		},
+		{
+			inDesc: "fail unmatching int types",
+			inV1:   int16(42),
+			inV2:   int32(43),
+			want:   false,
+		},
+		{
+			inDesc: "fail unmatching int and string type",
+			inV1:   int32(42),
+			inV2:   "42",
+			want:   false,
+		},
+		{
+			inDesc: "fail EnumType and int64 types",
+			inV1:   EnumType(42),
+			inV2:   int64(43),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			got := ValuesAreSameType(reflect.ValueOf(tt.inV1), reflect.ValueOf(tt.inV2))
+			if got != tt.want {
+				t.Errorf("got %v, want %v for comparing %T against %T", got, tt.want, tt.inV1, tt.inV2)
+			}
+		})
+	}
+}
+
 func TestIsTypeFuncs(t *testing.T) {
 	testInt := int(42)
 	testStruct := struct{}{}


### PR DESCRIPTION
- Added utility to compare types of given reflect.Values
- Fixed the panic that occurs while setting unmatching types in makeKeyForInsert
- Add tests for TestInsertAndGetKey