### PR TITLE
Add utility to translate given string slice as gNMI PathElem in a schema aware way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ script:
         - go tool vet ./util
         - go tool vet -composites=false ./ygot
         - go tool vet ./ygen
-        - go tool vet ./ytypes
+        - go tool vet .ygot/ytypes
         - go tool vet ./pathtranslate
         - diff -u <(echo -n) <(gofmt -d -s ./util)
         - diff -u <(echo -n) <(gofmt -d -s ./ygot)
         - diff -u <(echo -n) <(gofmt -d -s ./ygen)
         - diff -u <(echo -n) <(gofmt -d -s ./ytypes)
-        - diff -u <(echo -n) <(gofmt -d -s ./pathtranslate)
+        - diff -u <(echo -n) <(gofmt -d -s .ygot/pathtranslate)
 after_success:
         - ./scripts/coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ script:
         - go tool vet ./util
         - go tool vet -composites=false ./ygot
         - go tool vet ./ygen
-        - go tool vet .ygot/ytypes
-        - go tool vet ./pathtranslate
+        - go tool vet ./ytypes
+        - go tool vet ./ygot/pathtranslate
         - diff -u <(echo -n) <(gofmt -d -s ./util)
         - diff -u <(echo -n) <(gofmt -d -s ./ygot)
         - diff -u <(echo -n) <(gofmt -d -s ./ygen)
         - diff -u <(echo -n) <(gofmt -d -s ./ytypes)
-        - diff -u <(echo -n) <(gofmt -d -s .ygot/pathtranslate)
+        - diff -u <(echo -n) <(gofmt -d -s ./ygot/pathtranslate)
 after_success:
         - ./scripts/coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ script:
         - go tool vet -composites=false ./ygot
         - go tool vet ./ygen
         - go tool vet ./ytypes
+        - go tool vet ./pathtranslate
         - diff -u <(echo -n) <(gofmt -d -s ./util)
         - diff -u <(echo -n) <(gofmt -d -s ./ygot)
         - diff -u <(echo -n) <(gofmt -d -s ./ygen)
         - diff -u <(echo -n) <(gofmt -d -s ./ytypes)
+        - diff -u <(echo -n) <(gofmt -d -s ./pathtranslate)
 after_success:
         - ./scripts/coverage.sh

--- a/ygot/pathtranslate/pathtranslate.go
+++ b/ygot/pathtranslate/pathtranslate.go
@@ -1,0 +1,118 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pathtranslate exports api to transform given string slice into
+// different forms in a schema aware manner.
+package pathtranslate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openconfig/goyang/pkg/yang"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+var (
+	seperator = "/"
+)
+
+// PathTranslator stores the rules required to rewrite a given path as gNMI PathElem.
+type PathTranslator struct {
+	rules map[string][]string
+}
+
+// NewPathTranslator instantiates a PathTranslator with the given slice of schemas.
+// It returns an error if any of the keyed list schemas have the similar full path.
+func NewPathTranslator(schemaTree []*yang.Entry) (*PathTranslator, error) {
+	r := &PathTranslator{
+		rules: map[string][]string{},
+	}
+	for _, v := range schemaTree {
+		if v.Key == "" {
+			continue
+		}
+		fullPath := resolveUntilRoot(v)
+		if _, ok := r.rules[fullPath]; ok {
+			return nil, fmt.Errorf("got %v path multiple times", fullPath)
+		}
+		r.rules[fullPath] = strings.Split(v.Key, " ")
+	}
+	return r, nil
+}
+
+// resolveUntilRoot concatenates the schema names of the given schema and its
+// ancestors. '/' is used as seperator. The root schema in the tree is ignored
+// as it is an artificially inserted schema.
+func resolveUntilRoot(schema *yang.Entry) string {
+	path := []string{}
+	// The schema with nil Parent is assumed to be root schema. Root schema is't
+	// appended into string slice.
+	for e := schema; e.Parent != nil; e = e.Parent {
+		path = append(path, e.Name)
+	}
+	// Append an empty string to get a concatenated string starting with "/".
+	path = append(path, "")
+
+	// Reverse the slice.
+	for i := len(path)/2 - 1; i >= 0; i-- {
+		o := len(path) - 1 - i
+		path[i], path[o] = path[o], path[i]
+	}
+	return strings.Join(path, seperator)
+}
+
+// PathElem receives a path as string slice and generates slice of gNMI PathElem
+// based on stored rewrite rules. It returns an error if there are less elements
+// following the element's name in the path than the number of keys of the list.
+func (r *PathTranslator) PathElem(p []string) ([]*gnmipb.PathElem, error) {
+	// Keeps track of whether element in the p slice is consumed or not.
+	// When keys are consumed, they are set as true in "used" slice.
+	used := make([]bool, len(p))
+
+	// Keeps the path elements seeen so far by appending with a seperator.
+	var pathSoFar string
+
+	var res []*gnmipb.PathElem
+	for i := 0; i < len(p); i++ {
+		// this must be a key element which was considered in prior iterations.
+		if used[i] {
+			continue
+		}
+		pathSoFar = pathSoFar + seperator + p[i]
+
+		keyNames, ok := r.rules[pathSoFar]
+		// If pathSoFar isn't in rule list, this can be an arbitrary element or
+		// part of the path that constitues the full path of keyed list.
+		// Note that this isn't a check to decide whether arbitrary element is
+		// schema compliant.
+		if !ok {
+			res = append(res, &gnmipb.PathElem{Name: p[i]})
+			continue
+		}
+		keysStartPos := i + 1
+		if len(keyNames) > len(p)-keysStartPos {
+			return nil, fmt.Errorf("got %d, want %d keys for %s", len(p)-keysStartPos, len(keyNames), pathSoFar)
+		}
+		keys := map[string]string{}
+		for j, k := range keyNames {
+			used[keysStartPos+j] = true
+			keys[k] = p[keysStartPos+j]
+		}
+		res = append(res, &gnmipb.PathElem{Name: p[i], Key: keys})
+	}
+
+	return res, nil
+}

--- a/ygot/pathtranslate/pathtranslate.go
+++ b/ygot/pathtranslate/pathtranslate.go
@@ -25,9 +25,7 @@ import (
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
-var (
-	seperator = "/"
-)
+const separator = "/"
 
 // PathTranslator stores the rules required to rewrite a given path as gNMI PathElem.
 type PathTranslator struct {
@@ -54,7 +52,7 @@ func NewPathTranslator(schemaTree []*yang.Entry) (*PathTranslator, error) {
 }
 
 // resolveUntilRoot concatenates the schema names of the given schema and its
-// ancestors. '/' is used as seperator. The root schema in the tree is ignored
+// ancestors. '/' is used as separator. The root schema in the tree is ignored
 // as it is an artificially inserted schema.
 func resolveUntilRoot(schema *yang.Entry) string {
 	path := []string{}
@@ -71,7 +69,7 @@ func resolveUntilRoot(schema *yang.Entry) string {
 		o := len(path) - 1 - i
 		path[i], path[o] = path[o], path[i]
 	}
-	return strings.Join(path, seperator)
+	return strings.Join(path, separator)
 }
 
 // PathElem receives a path as string slice and generates slice of gNMI PathElem
@@ -82,7 +80,7 @@ func (r *PathTranslator) PathElem(p []string) ([]*gnmipb.PathElem, error) {
 	// When keys are consumed, they are set as true in "used" slice.
 	used := make([]bool, len(p))
 
-	// Keeps the path elements seeen so far by appending with a seperator.
+	// Keeps the path elements seeen so far by appending with a separator.
 	var pathSoFar string
 
 	var res []*gnmipb.PathElem
@@ -91,7 +89,7 @@ func (r *PathTranslator) PathElem(p []string) ([]*gnmipb.PathElem, error) {
 		if used[i] {
 			continue
 		}
-		pathSoFar = pathSoFar + seperator + p[i]
+		pathSoFar = pathSoFar + separator + p[i]
 
 		keyNames, ok := r.rules[pathSoFar]
 		// If pathSoFar isn't in rule list, this can be an arbitrary element or

--- a/ygot/pathtranslate/pathtranslate_test.go
+++ b/ygot/pathtranslate/pathtranslate_test.go
@@ -1,0 +1,246 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathtranslate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openconfig/gnmi/errdiff"
+	"github.com/openconfig/goyang/pkg/yang"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func TestInstantiationOfTranslator(t *testing.T) {
+	simpleSchema := &yang.Entry{
+		Name: "simpleKeyedList",
+		Key:  "k1",
+		Parent: &yang.Entry{
+			Name: "simpleKeyedLists",
+			Parent: &yang.Entry{
+				Name: "b",
+				Parent: &yang.Entry{
+					Name:   "a",
+					Parent: &yang.Entry{Name: "root"},
+				},
+			},
+		},
+	}
+
+	structKeyedSchema := &yang.Entry{
+		Name: "structKeyedList",
+		Key:  "k1 k2 k3",
+		Parent: &yang.Entry{Name: "structKeyedLists",
+			Parent: &yang.Entry{
+				Name: "simpleKeyedList",
+				Key:  "k1",
+				Parent: &yang.Entry{
+					Name: "simpleKeyedLists",
+					Parent: &yang.Entry{
+						Name: "b",
+						Parent: &yang.Entry{
+							Name:   "a",
+							Parent: &yang.Entry{Name: "root"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		inDesc           string
+		inSchemas        []*yang.Entry
+		wantRules        map[string][]string
+		wantErrSubstring string
+	}{
+		{
+			inDesc:    "success with unique schema paths for keyed lists",
+			inSchemas: []*yang.Entry{simpleSchema},
+			wantRules: map[string][]string{
+				"/a/b/simpleKeyedLists/simpleKeyedList": []string{"k1"},
+			},
+		},
+		{
+			inDesc:    "success with struct keyed schema",
+			inSchemas: []*yang.Entry{simpleSchema, structKeyedSchema},
+			wantRules: map[string][]string{
+				"/a/b/simpleKeyedLists/simpleKeyedList":                                  []string{"k1"},
+				"/a/b/simpleKeyedLists/simpleKeyedList/structKeyedLists/structKeyedList": []string{"k1", "k2", "k3"},
+			},
+		},
+		{
+			inDesc:           "fail with similar schema paths for keyed lists",
+			inSchemas:        []*yang.Entry{simpleSchema, simpleSchema},
+			wantErrSubstring: "got /a/b/simpleKeyedLists/simpleKeyedList path multiple times",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			r, err := NewPathTranslator(tt.inSchemas)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("diff: %v", diff)
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(r.rules, tt.wantRules) {
+				t.Errorf("got %v, want %v", r.rules, tt.wantRules)
+			}
+		})
+	}
+}
+
+func TestPathElem(t *testing.T) {
+	schemas := []*yang.Entry{
+		{Name: "root"},
+		{
+			Name: "simpleKeyedList",
+			Key:  "k1",
+			Parent: &yang.Entry{
+				Name: "simpleKeyedLists",
+				Parent: &yang.Entry{
+					Name: "b",
+					Parent: &yang.Entry{
+						Name:   "a",
+						Parent: &yang.Entry{Name: "root"},
+					},
+				},
+			},
+		},
+		{
+			Name: "structKeyedList",
+			Key:  "k1 k2 k3",
+			Parent: &yang.Entry{Name: "structKeyedLists",
+				Parent: &yang.Entry{
+					Name: "simpleKeyedList",
+					Key:  "k1",
+					Parent: &yang.Entry{
+						Name: "simpleKeyedLists",
+						Parent: &yang.Entry{
+							Name: "b",
+							Parent: &yang.Entry{
+								Name:   "a",
+								Parent: &yang.Entry{Name: "root"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		inDesc           string
+		inPath           []string
+		wantErrSubstring string
+		wantPath         []*gnmipb.PathElem
+	}{
+		{
+			inDesc: "success empty path",
+			inPath: []string{},
+		},
+		{
+			inDesc: "success path with no keyed list(note, it doesn't exist in schema)",
+			inPath: []string{"a", "b"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "a"},
+				{Name: "b"},
+			},
+		},
+		{
+			inDesc: "success path with keyed list at the end",
+			inPath: []string{"a", "b", "simpleKeyedLists", "simpleKeyedList", "key1"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "simpleKeyedLists"},
+				{Name: "simpleKeyedList", Key: map[string]string{"k1": "key1"}},
+			},
+		},
+		{
+			inDesc: "success path with keyed list followed by arbitrary elements",
+			inPath: []string{"a", "b", "simpleKeyedLists", "simpleKeyedList", "key1", "arbitrary1", "arbitrary2"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "simpleKeyedLists"},
+				{Name: "simpleKeyedList", Key: map[string]string{"k1": "key1"}},
+				{Name: "arbitrary1"},
+				{Name: "arbitrary2"},
+			},
+		},
+		{
+			inDesc: "success, but keys aren't treated as key for a path with keyed list after arbitrary elements",
+			inPath: []string{"random1", "random2", "simpleKeyedLists", "simpleKeyedList", "NOT_TREATED_AS_KEY"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "random1"},
+				{Name: "random2"},
+				{Name: "simpleKeyedLists"},
+				{Name: "simpleKeyedList"},
+				{Name: "NOT_TREATED_AS_KEY"},
+			},
+		},
+		{
+			inDesc: "success path with keyed list in the middle",
+			inPath: []string{"a", "b", "simpleKeyedLists", "simpleKeyedList", "key1", "arbitrary"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "simpleKeyedLists"},
+				{Name: "simpleKeyedList", Key: map[string]string{"k1": "key1"}},
+				{Name: "arbitrary"},
+			},
+		},
+		{
+			inDesc: "success path with struct keyed list",
+			inPath: []string{"a", "b", "simpleKeyedLists", "simpleKeyedList", "key1", "structKeyedLists", "structKeyedList", "key1", "key2", "key3"},
+			wantPath: []*gnmipb.PathElem{
+				{Name: "a"},
+				{Name: "b"},
+				{Name: "simpleKeyedLists"},
+				{Name: "simpleKeyedList", Key: map[string]string{"k1": "key1"}},
+				{Name: "structKeyedLists"},
+				{Name: "structKeyedList", Key: map[string]string{"k1": "key1", "k2": "key2", "k3": "key3"}},
+			},
+		},
+		{
+			inDesc:           "fail path due to insuffucient keys to fill the key struct",
+			inPath:           []string{"a", "b", "simpleKeyedLists", "simpleKeyedList", "key1", "structKeyedLists", "structKeyedList", "key1", "key2"},
+			wantErrSubstring: "got 2, want 3 keys for /a/b/simpleKeyedLists/simpleKeyedList/structKeyedLists/structKeyedList",
+		},
+	}
+	r, err := NewPathTranslator(schemas)
+	if err != nil {
+		t.Errorf("failed to create path translator; %v", r)
+	}
+	for _, tt := range tests {
+		t.Run(tt.inDesc, func(t *testing.T) {
+			gotPath, err := r.PathElem(tt.inPath)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Errorf("diff: %v", diff)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(gotPath, tt.wantPath) {
+				t.Errorf("got %v, want %v", gotPath, tt.wantPath)
+			}
+		})
+	}
+}

--- a/ygot/pathtranslate/pathtranslate_test.go
+++ b/ygot/pathtranslate/pathtranslate_test.go
@@ -71,15 +71,15 @@ func TestInstantiationOfTranslator(t *testing.T) {
 			inDesc:    "success with unique schema paths for keyed lists",
 			inSchemas: []*yang.Entry{simpleSchema},
 			wantRules: map[string][]string{
-				"/a/b/simpleKeyedLists/simpleKeyedList": []string{"k1"},
+				"/a/b/simpleKeyedLists/simpleKeyedList": {"k1"},
 			},
 		},
 		{
 			inDesc:    "success with struct keyed schema",
 			inSchemas: []*yang.Entry{simpleSchema, structKeyedSchema},
 			wantRules: map[string][]string{
-				"/a/b/simpleKeyedLists/simpleKeyedList":                                  []string{"k1"},
-				"/a/b/simpleKeyedLists/simpleKeyedList/structKeyedLists/structKeyedList": []string{"k1", "k2", "k3"},
+				"/a/b/simpleKeyedLists/simpleKeyedList":                                  {"k1"},
+				"/a/b/simpleKeyedLists/simpleKeyedList/structKeyedLists/structKeyedList": {"k1", "k2", "k3"},
 			},
 		},
 		{


### PR DESCRIPTION
With gNMI Path 0.4, PathElem is used to describe a path. It discriminates name and key fields. With the utility added in this change, it will be possible to translate given string slice into PathElem slice in a schema aware way.