### PR TITLE
Resolve bug with unset enum in union.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -1342,11 +1342,17 @@ func unionPtrValue(v reflect.Value, appendModuleName bool) (interface{}, error) 
 // the relevant type where required.
 func resolveUnionVal(v interface{}, appendModuleName bool) (interface{}, error) {
 	if _, isEnum := v.(GoEnum); isEnum {
-		var err error
-		v, _, err = enumFieldToString(reflect.ValueOf(v), appendModuleName)
+		val, set, err := enumFieldToString(reflect.ValueOf(v), appendModuleName)
 		if err != nil {
 			return nil, err
 		}
+
+		// If the enum isn't set, then we return a nil value
+		// such that it is not included in the output JSON.
+		if !set {
+			return nil, nil
+		}
+		v = val
 	}
 	return v, nil
 }

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -736,6 +736,12 @@ type renderExampleUnionInvalid struct {
 
 func (*renderExampleUnionInvalid) IsRenderUnionExample() {}
 
+type renderExampleUnionEnum struct {
+	Enum EnumTest
+}
+
+func (*renderExampleUnionEnum) IsRenderUnionExample() {}
+
 // renderExampleChild is a child of the renderExample struct.
 type renderExampleChild struct {
 	Val  *uint64  `path:"val"`
@@ -2109,6 +2115,23 @@ func TestConstructJSON(t *testing.T) {
 			},
 		},
 		wantErr: true,
+	}, {
+		name:     "unset enum",
+		in:       &renderExample{EnumField: EnumTestUNSET},
+		wantIETF: map[string]interface{}{},
+		wantSame: true,
+	}, {
+		name: "set enum in union",
+		in:   &renderExample{UnionVal: &renderExampleUnionEnum{EnumTestVALONE}},
+		wantIETF: map[string]interface{}{
+			"union-val": "VAL_ONE",
+		},
+		wantSame: true,
+	}, {
+		name:     "unset enum in union",
+		in:       &renderExample{UnionVal: &renderExampleUnionEnum{EnumTestUNSET}},
+		wantIETF: map[string]interface{}{},
+		wantSame: true,
 	}}
 
 	for _, tt := range tests {

--- a/ygot/schema_tests/testdata/unsetenum.json
+++ b/ygot/schema_tests/testdata/unsetenum.json
@@ -1,0 +1,26 @@
+{
+   "acl": {
+      "acl-sets": {
+         "acl-set": [
+            {
+               "acl-entries": {
+                  "acl-entry": [
+                     {
+                        "config": {
+                           "sequence-id": 100
+                        },
+                        "sequence-id": 100
+                     }
+                  ]
+               },
+               "config": {
+                  "name": "set",
+                  "type": "ACL_IPV6"
+               },
+               "name": "set",
+               "type": "ACL_IPV6"
+            }
+         ]
+      }
+   }
+}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -875,6 +875,21 @@ func TestGetNode(t *testing.T) {
 			Schema: multiKeyListSchema,
 		}},
 	}, {
+		desc:     "multiple key list with >1 element",
+		inSchema: rootSchema,
+		inData: &RootStruct{
+			Multilist: map[MultiListKey]*MultiListEntry{
+				{Keyone: 1, Keytwo: 2}:     {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
+				{Keyone: 10, Keytwo: 20}:   {Keyone: ygot.Uint32(10), Keytwo: ygot.Uint32(20)},
+				{Keyone: 100, Keytwo: 200}: {Keyone: ygot.Uint32(100), Keytwo: ygot.Uint32(200)},
+			},
+		},
+		inPath: mustPath("/multilist[keyone=1][keytwo=2]"),
+		wantTreeNodes: []*TreeNode{{
+			Data:   &MultiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
+			Schema: multiKeyListSchema,
+		}},
+	}, {
 		desc:     "multiple key list, partial match not allowed",
 		inSchema: rootSchema,
 		inData: &RootStruct{


### PR DESCRIPTION
```
 * (M) ygot/render*
   - Resolve an issue whereby a union that had the UNSET value of
     an enumeration specified explicitly within it would be rendered
     as an empty string in output JSON. This issue was due to not
     checking whether the enumeration was set to a non-zero value
     when handling such cases.
   - Added unit tests covering this bug.
 * (M) ygot/schema_tests/*
   - Added an integration test against the schema to validate the
     above issue.
```