### PR TITLE
Update retrieveNode to return paths.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -476,6 +476,22 @@ func appendgNMIPathElemKey(v reflect.Value, p *gnmiPath) (*gnmiPath, error) {
 		return nil, fmt.Errorf("nil value received for element %v", p)
 	}
 
+	k, err := PathKeyFromStruct(v)
+	if err != nil {
+		return nil, fmt.Errorf("cannot extract keys: %v", err)
+	}
+	newElem.Key = k
+
+	if err := np.SetIndex(np.Len()-1, &newElem); err != nil {
+		return nil, err
+	}
+	return np, nil
+}
+
+// PathKeyFromStruct returns a map[string]string which represents the keys for a YANG
+// list element. The provided reflect.Value must implement the KeyHelperGoStruct interface,
+// and hence be a struct which represents a list member within the schema.
+func PathKeyFromStruct(v reflect.Value) (map[string]string, error) {
 	gs, ok := v.Interface().(KeyHelperGoStruct)
 	if !ok {
 		return nil, fmt.Errorf("cannot render to gNMI PathElem for structs that do not implement KeyHelperGoStruct, got: %T (%s)", v.Type().Name(), v.Interface())
@@ -490,12 +506,7 @@ func appendgNMIPathElemKey(v reflect.Value, p *gnmiPath) (*gnmiPath, error) {
 	if err != nil {
 		return nil, err
 	}
-	newElem.Key = k
-
-	if err := np.SetIndex(np.Len()-1, &newElem); err != nil {
-		return nil, err
-	}
-	return np, nil
+	return k, nil
 }
 
 // keyMapAsStrings takes an input map[string]interface{}, keyed by the name of

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
@@ -19,30 +20,51 @@ type InnerContainerType1 struct {
 	EnumLeafName   EnumType `path:"enum-leaf-field"`
 	Annotation     *string  `ygotAnnotation:"true"`
 }
+
+func (*InnerContainerType1) IsYANGGoStruct() {}
+
 type OuterContainerType1 struct {
 	Inner *InnerContainerType1 `path:"inner|config/inner"`
 }
+
+func (*OuterContainerType1) IsYANGGoStruct() {}
+
 type ListElemStruct1 struct {
 	Key1       *string              `path:"key1"`
 	Outer      *OuterContainerType1 `path:"outer"`
 	Annotation *string              `ygotAnnotation:"true"`
 }
+
+func (l *ListElemStruct1) ΛListKeyMap() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"key1":  l.Key1,
+		"outer": l.Outer,
+	}, nil
+}
+func (*ListElemStruct1) IsYANGGoStruct() {}
+
 type ContainerStruct1 struct {
 	StructKeyList map[string]*ListElemStruct1 `path:"config/simple-key-list"`
 }
+
+func (*ContainerStruct1) IsYANGGoStruct() {}
+
 type ListElemStruct2 struct {
 	Key1       *uint32              `path:"key1"`
 	Outer      *OuterContainerType1 `path:"outer"`
 	Annotation *string              `ygotAnnotation:"true"`
 }
+
+func (l *ListElemStruct2) ΛListKeyMap() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"key1":  l.Key1,
+		"outer": l.Outer,
+	}, nil
+}
+
 type ContainerStruct2 struct {
 	StructKeyList map[uint32]*ListElemStruct2 `path:"config/simple-key-list"`
 }
-
-func (*InnerContainerType1) IsYANGGoStruct() {}
-func (*OuterContainerType1) IsYANGGoStruct() {}
-func (*ListElemStruct1) IsYANGGoStruct()     {}
-func (*ContainerStruct1) IsYANGGoStruct()    {}
 
 func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 	containerWithStringKey := &yang.Entry{
@@ -334,17 +356,27 @@ type KeyStruct struct {
 	Key2    int32    `path:"key2"`
 	EnumKey EnumType `path:"key3"`
 }
+
 type ListElemStruct3 struct {
 	Key1    *string              `path:"key1"`
 	Key2    *int32               `path:"key2"`
 	EnumKey EnumType             `path:"key3"`
 	Outer   *OuterContainerType1 `path:"outer"`
 }
+
+func (*ListElemStruct3) IsYANGGoStruct() {}
+func (l *ListElemStruct3) ΛListKeyMap() (map[string]interface{}, error) {
+	return map[string]interface{}{
+		"key1": *l.Key1,
+		"key2": *l.Key2,
+		"key3": l.EnumKey,
+	}, nil
+}
+
 type ContainerStruct3 struct {
 	StructKeyList map[KeyStruct]*ListElemStruct3 `path:"struct-key-list"`
 }
 
-func (*ListElemStruct3) IsYANGGoStruct()  {}
 func (*ContainerStruct3) IsYANGGoStruct() {}
 
 func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
@@ -641,16 +673,67 @@ func treeNodesEqual(got, want []*TreeNode) error {
 	for _, w := range want {
 		match := false
 		for _, g := range got {
-			if reflect.DeepEqual(g.Data, w.Data) && reflect.DeepEqual(g.Schema, w.Schema) {
+			if reflect.DeepEqual(g.Data, w.Data) && reflect.DeepEqual(g.Schema, w.Schema) && proto.Equal(g.Path, w.Path) {
 				match = true
 				break
 			}
 		}
 		if !match {
-			return fmt.Errorf("no match for %#v in %#v", w, got)
+			return fmt.Errorf("no match for %#v (path: %s) in %v", w, proto.MarshalTextString(w.Path), got)
 		}
 	}
 	return nil
+}
+
+type listEntry struct {
+	Key *string `path:"key"`
+}
+
+func (l *listEntry) ΛListKeyMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"key": *l.Key}, nil
+}
+
+func (*listEntry) IsYANGGoStruct() {}
+
+type multiListEntry struct {
+	Keyone *uint32 `path:"keyone"`
+	Keytwo *uint32 `path:"keytwo"`
+}
+
+func (l *multiListEntry) ΛListKeyMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"keyone": *l.Keyone, "keytwo": *l.Keytwo}, nil
+}
+
+func (*multiListEntry) IsYANGGoStruct() {}
+
+type multiListKey struct {
+	Keyone uint32 `path:"keyone"`
+	Keytwo uint32 `path:"keytwo"`
+}
+
+type listChildContainer struct {
+	Value *string `path:"value"`
+}
+
+type childList struct {
+	Key            *string             `path:"key"`
+	ChildContainer *listChildContainer `path:"child-container"`
+}
+
+type childContainer struct {
+	Container *grandchildContainer `path:"grandchild"`
+}
+
+type grandchildContainer struct {
+	Val *string `path:"val"`
+}
+
+type rootStruct struct {
+	Leaf      *string                          `path:"leaf"`
+	Container *childContainer                  `path:"container"`
+	List      map[string]*listEntry            `path:"list"`
+	Multilist map[multiListKey]*multiListEntry `path:"multilist"`
+	ChildList map[string]*childList            `path:"childlist"`
 }
 
 func TestGetNode(t *testing.T) {
@@ -674,8 +757,26 @@ func TestGetNode(t *testing.T) {
 		Name:   "container",
 		Kind:   yang.DirectoryEntry,
 		Parent: rootSchema,
+		Dir:    map[string]*yang.Entry{},
 	}
 	rootSchema.Dir["container"] = childContainerSchema
+
+	grandchildContainerSchema := &yang.Entry{
+		Name:   "grandchild",
+		Kind:   yang.DirectoryEntry,
+		Parent: childContainerSchema,
+		Dir:    map[string]*yang.Entry{},
+	}
+	childContainerSchema.Dir["grandchild"] = grandchildContainerSchema
+
+	valSchema := &yang.Entry{
+		Name: "val",
+		Kind: yang.LeafEntry,
+		Type: &yang.YangType{
+			Kind: yang.Ystring,
+		},
+	}
+	grandchildContainerSchema.Dir["val"] = valSchema
 
 	simpleListSchema := &yang.Entry{
 		Name:     "list",
@@ -754,39 +855,6 @@ func TestGetNode(t *testing.T) {
 	}
 	childListContainerSchema.Dir["value"] = childListContainerValueSchema
 
-	type ChildContainer struct{}
-
-	type ListEntry struct {
-		Key *string `path:"key"`
-	}
-
-	type MultiListEntry struct {
-		Keyone *uint32 `path:"keyone"`
-		Keytwo *uint32 `path:"keytwo"`
-	}
-
-	type MultiListKey struct {
-		Keyone uint32 `path:"keyone"`
-		Keytwo uint32 `path:"keytwo"`
-	}
-
-	type ListChildContainer struct {
-		Value *string `path:"value"`
-	}
-
-	type ChildList struct {
-		Key            *string             `path:"key"`
-		ChildContainer *ListChildContainer `path:"child-container"`
-	}
-
-	type RootStruct struct {
-		Leaf      *string                          `path:"leaf"`
-		Container *ChildContainer                  `path:"container"`
-		List      map[string]*ListEntry            `path:"list"`
-		Multilist map[MultiListKey]*MultiListEntry `path:"multilist"`
-		ChildList map[string]*ChildList            `path:"childlist"`
-	}
-
 	tests := []struct {
 		desc             string
 		inSchema         *yang.Entry
@@ -798,46 +866,65 @@ func TestGetNode(t *testing.T) {
 	}{{
 		desc:     "simple get leaf",
 		inSchema: rootSchema,
-		inData: &RootStruct{
+		inData: &rootStruct{
 			Leaf: ygot.String("foo"),
 		},
 		inPath: mustPath("/leaf"),
 		wantTreeNodes: []*TreeNode{{
 			Data:   ygot.String("foo"),
 			Schema: leafSchema,
+			Path:   mustPath("/leaf"),
 		}},
 	}, {
 		desc:     "simple get container",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			Container: &ChildContainer{},
+		inData: &rootStruct{
+			Container: &childContainer{},
 		},
 		inPath: mustPath("/container"),
 		wantTreeNodes: []*TreeNode{{
-			Data:   &ChildContainer{},
+			Data:   &childContainer{},
 			Schema: childContainerSchema,
+			Path:   mustPath("/container"),
+		}},
+	}, {
+		desc:     "simple get nested container",
+		inSchema: rootSchema,
+		inData: &rootStruct{
+			Container: &childContainer{
+				Container: &grandchildContainer{
+					Val: ygot.String("forty-two"),
+				},
+			},
+		},
+		inPath: mustPath("/container/grandchild/val"),
+		wantTreeNodes: []*TreeNode{{
+			Data:   ygot.String("forty-two"),
+			Schema: valSchema,
+			Path:   mustPath("/container/grandchild/val"),
 		}},
 	}, {
 		desc:     "simple list",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			List: map[string]*ListEntry{
+		inData: &rootStruct{
+			List: map[string]*listEntry{
 				"one": {Key: ygot.String("one")},
 				"two": {Key: ygot.String("two")},
 			},
 		},
 		inPath: mustPath("/list[key=one]"),
 		wantTreeNodes: []*TreeNode{{
-			Data: &ListEntry{
+			Data: &listEntry{
 				Key: ygot.String("one"),
 			},
 			Schema: simpleListSchema,
+			Path:   mustPath("/list[key=one]"),
 		}},
 	}, {
 		desc:     "simple list, unspecified key, no partial match",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			List: map[string]*ListEntry{
+		inData: &rootStruct{
+			List: map[string]*listEntry{
 				"one": {Key: ygot.String("one")},
 			},
 		},
@@ -846,8 +933,8 @@ func TestGetNode(t *testing.T) {
 	}, {
 		desc:     "simple list, all entries",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			List: map[string]*ListEntry{
+		inData: &rootStruct{
+			List: map[string]*listEntry{
 				"one": {Key: ygot.String("one")},
 				"two": {Key: ygot.String("two")},
 			},
@@ -855,30 +942,33 @@ func TestGetNode(t *testing.T) {
 		inPath: mustPath("/list"),
 		inArgs: []GetNodeOpt{&GetPartialKeyMatch{}},
 		wantTreeNodes: []*TreeNode{{
-			Data:   &ListEntry{Key: ygot.String("one")},
+			Data:   &listEntry{Key: ygot.String("one")},
 			Schema: simpleListSchema,
+			Path:   mustPath("/list[key=one]"),
 		}, {
-			Data:   &ListEntry{Key: ygot.String("two")},
+			Data:   &listEntry{Key: ygot.String("two")},
 			Schema: simpleListSchema,
+			Path:   mustPath("/list[key=two]"),
 		}},
 	}, {
 		desc:     "multiple key list",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			Multilist: map[MultiListKey]*MultiListEntry{
+		inData: &rootStruct{
+			Multilist: map[multiListKey]*multiListEntry{
 				{Keyone: 1, Keytwo: 2}: {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 			},
 		},
 		inPath: mustPath("/multilist[keyone=1][keytwo=2]"),
 		wantTreeNodes: []*TreeNode{{
-			Data:   &MultiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
+			Data:   &multiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 			Schema: multiKeyListSchema,
+			Path:   mustPath("/multilist[keyone=1][keytwo=2]"),
 		}},
 	}, {
 		desc:     "multiple key list with >1 element",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			Multilist: map[MultiListKey]*MultiListEntry{
+		inData: &rootStruct{
+			Multilist: map[multiListKey]*multiListEntry{
 				{Keyone: 1, Keytwo: 2}:     {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 				{Keyone: 10, Keytwo: 20}:   {Keyone: ygot.Uint32(10), Keytwo: ygot.Uint32(20)},
 				{Keyone: 100, Keytwo: 200}: {Keyone: ygot.Uint32(100), Keytwo: ygot.Uint32(200)},
@@ -886,14 +976,15 @@ func TestGetNode(t *testing.T) {
 		},
 		inPath: mustPath("/multilist[keyone=1][keytwo=2]"),
 		wantTreeNodes: []*TreeNode{{
-			Data:   &MultiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
+			Data:   &multiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 			Schema: multiKeyListSchema,
+			Path:   mustPath("/multilist[keyone=1][keytwo=2]"),
 		}},
 	}, {
 		desc:     "multiple key list, partial match not allowed",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			Multilist: map[MultiListKey]*MultiListEntry{
+		inData: &rootStruct{
+			Multilist: map[multiListKey]*multiListEntry{
 				{Keyone: 1, Keytwo: 2}: {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 				{Keyone: 1, Keytwo: 3}: {Keyone: ygot.Uint32(3), Keytwo: ygot.Uint32(4)},
 			},
@@ -903,8 +994,8 @@ func TestGetNode(t *testing.T) {
 	}, {
 		desc:     "multiple key list, partial match allowed",
 		inSchema: rootSchema,
-		inData: &RootStruct{
-			Multilist: map[MultiListKey]*MultiListEntry{
+		inData: &rootStruct{
+			Multilist: map[multiListKey]*multiListEntry{
 				{Keyone: 1, Keytwo: 2}: {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 				{Keyone: 1, Keytwo: 3}: {Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(3)},
 			},
@@ -912,11 +1003,13 @@ func TestGetNode(t *testing.T) {
 		inPath: mustPath("/multilist[keyone=1]"),
 		inArgs: []GetNodeOpt{&GetPartialKeyMatch{}},
 		wantTreeNodes: []*TreeNode{{
-			Data:   &MultiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
+			Data:   &multiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(2)},
 			Schema: multiKeyListSchema,
+			Path:   mustPath("/multilist[keyone=1][keytwo=2]"),
 		}, {
-			Data:   &MultiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(3)},
+			Data:   &multiListEntry{Keyone: ygot.Uint32(1), Keytwo: ygot.Uint32(3)},
 			Schema: multiKeyListSchema,
+			Path:   mustPath("/multilist[keyone=1][keytwo=3]"),
 		}},
 	}}
 
@@ -953,7 +1046,7 @@ func TestRetrieveNodeError(t *testing.T) {
 		inSchema:         &yang.Entry{Name: "root"},
 		inRoot:           nil,
 		inPath:           &gpb.Path{Elem: []*gpb.PathElem{{Name: "foo"}}},
-		wantErrSubstring: "root is nil",
+		wantErrSubstring: "could not find children",
 	}, {
 		desc:             "non-container parent",
 		inSchema:         &yang.Entry{Name: "root"},
@@ -964,7 +1057,7 @@ func TestRetrieveNodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, _, err := retrieveNode(tt.inSchema, tt.inRoot, tt.inPath, tt.inArgs)
+			_, err := retrieveNode(tt.inSchema, tt.inRoot, tt.inPath, nil, tt.inArgs)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
 				t.Fatalf("did not get expected error, %s", diff)
 			}
@@ -1022,7 +1115,7 @@ func TestRetrieveContainerListError(t *testing.T) {
 		inRoot           interface{}
 		inPath           *gpb.Path
 		inArgs           retrieveNodeArgs
-		inTestFunc       func(*yang.Entry, interface{}, *gpb.Path, retrieveNodeArgs) ([]interface{}, []*yang.Entry, error)
+		inTestFunc       func(*yang.Entry, interface{}, *gpb.Path, *gpb.Path, retrieveNodeArgs) ([]*TreeNode, error)
 		wantErrSubstring string
 	}{{
 		desc:             "non-struct ptr root",
@@ -1087,7 +1180,7 @@ func TestRetrieveContainerListError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, _, err := tt.inTestFunc(tt.inSchema, tt.inRoot, tt.inPath, tt.inArgs)
+			_, err := tt.inTestFunc(tt.inSchema, tt.inRoot, tt.inPath, nil, tt.inArgs)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
 				t.Fatalf("did not get expected error, %s", diff)
 			}

--- a/ytypes/schema_tests/get_test.go
+++ b/ytypes/schema_tests/get_test.go
@@ -1,0 +1,151 @@
+package validate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/openconfig/gnmi/errdiff"
+	"github.com/openconfig/goyang/pkg/yang"
+	oc "github.com/openconfig/ygot/exampleoc"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func mustPath(s string) *gpb.Path {
+	p, err := ygot.StringToStructuredPath(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestGetNodeFull(t *testing.T) {
+	rootSchema := oc.SchemaTree[reflect.TypeOf(oc.Device{}).Name()]
+	tests := []struct {
+		name             string
+		inRoot           *oc.Device
+		inSchema         *yang.Entry
+		inPath           *gpb.Path
+		inOpts           []ytypes.GetNodeOpt
+		wantNodes        []*ytypes.TreeNode
+		wantErrSubstring string
+	}{{
+		name: "simple interface get",
+		inRoot: func() *oc.Device {
+			d := &oc.Device{}
+			d.GetOrCreateInterface("eth0").Description = ygot.String("an interface")
+			return d
+		}(),
+		inSchema: rootSchema,
+		inPath:   mustPath("/interfaces/interface[name=eth0]"),
+		wantNodes: []*ytypes.TreeNode{{
+			Path: mustPath("/interfaces/interface[name=eth0]"),
+			Data: &oc.Interface{
+				Name:        ygot.String("eth0"),
+				Description: ygot.String("an interface"),
+			},
+		}},
+	}, {
+		name: "interface leaf get",
+		inRoot: func() *oc.Device {
+			d := &oc.Device{}
+			d.GetOrCreateInterface("eth0").Description = ygot.String("foo")
+			return d
+		}(),
+		inSchema: rootSchema,
+		inPath:   mustPath("/interfaces/interface[name=eth0]/config/description"),
+		wantNodes: []*ytypes.TreeNode{{
+			Path: mustPath("/interfaces/interface[name=eth0]/config/description"),
+			Data: ygot.String("foo"),
+		}},
+	}, {
+		name: "bad path",
+		inRoot: func() *oc.Device {
+			d := &oc.Device{}
+			d.GetOrCreateSystem().Hostname = ygot.String("a value")
+			return d
+		}(),
+		inSchema:         rootSchema,
+		inPath:           mustPath("/does-not-exist"),
+		wantErrSubstring: "no match found",
+	}, {
+		name:             "uninitialised path",
+		inRoot:           &oc.Device{},
+		inSchema:         rootSchema,
+		inPath:           mustPath("/interfaces/interface[name=eth1]"),
+		wantNodes:        []*ytypes.TreeNode{},
+		wantErrSubstring: "could not find children",
+	}, {
+		name: "multiple leaves",
+		inRoot: func() *oc.Device {
+			d := &oc.Device{}
+			d.GetOrCreateInterface("eth0").Description = ygot.String("eth0")
+			d.GetOrCreateInterface("eth1").Description = ygot.String("eth1")
+			return d
+		}(),
+		inSchema: rootSchema,
+		inPath:   mustPath("/interfaces/interface/config/description"),
+		inOpts:   []ytypes.GetNodeOpt{&ytypes.GetPartialKeyMatch{}},
+		wantNodes: []*ytypes.TreeNode{{
+			Path: mustPath("/interfaces/interface[name=eth0]/config/description"),
+			Data: ygot.String("eth0"),
+		}, {
+			Path: mustPath("/interfaces/interface[name=eth1]/config/description"),
+			Data: ygot.String("eth1"),
+		}},
+	}, {
+		name: "multiple containers",
+		inRoot: func() *oc.Device {
+			d := &oc.Device{}
+			d.GetOrCreateInterface("eth0").Description = ygot.String("eth0")
+			d.GetOrCreateInterface("eth1").Description = ygot.String("eth1")
+			return d
+		}(),
+		inSchema: rootSchema,
+		inPath:   mustPath("/interfaces/interface"),
+		inOpts:   []ytypes.GetNodeOpt{&ytypes.GetPartialKeyMatch{}},
+		wantNodes: []*ytypes.TreeNode{{
+			Path: mustPath("/interfaces/interface[name=eth0]"),
+			Data: &oc.Interface{
+				Name:        ygot.String("eth0"),
+				Description: ygot.String("eth0"),
+			},
+		}, {
+			Path: mustPath("/interfaces/interface[name=eth1]"),
+			Data: &oc.Interface{
+				Name:        ygot.String("eth1"),
+				Description: ygot.String("eth1"),
+			},
+		}},
+	}}
+
+	ignoreSchema := cmpopts.IgnoreFields(ytypes.TreeNode{}, "Schema")
+	sortNodes := cmpopts.SortSlices(func(a, b *ytypes.TreeNode) bool {
+		an, err := ygot.PathToString(a.Path)
+		if err != nil {
+			panic(err)
+		}
+		bn, err := ygot.PathToString(b.Path)
+		if err != nil {
+			panic(err)
+		}
+		return an < bn
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ytypes.GetNode(tt.inSchema, tt.inRoot, tt.inPath, tt.inOpts...)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("did not get expected error, %v", diff)
+			}
+
+			if diff := cmp.Diff(got, tt.wantNodes, ignoreSchema, cmpopts.EquateEmpty(), sortNodes); diff != "" {
+				t.Fatalf("did not get expected result, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -645,6 +645,7 @@ func TestNewNode(t *testing.T) {
 	}
 }
 
+// TODO(robjs): Remove this testing once we have removed the ygot utils experimental package.
 func TestGetNode(t *testing.T) {
 	testDevice := &oc.Device{
 		Bgp: &oc.Bgp{


### PR DESCRIPTION
```
 * (M) ygot/render.go
   - Make PathKeyFromStruct a public function. This returns the
     map[string]string required in a gNMI Notification to an
     external caller.
 * (M) ytypes/node.go
   - Update retrieveNode (and hence Get/GetOrCreateNode) to store
     the path to a retrieved node when it returns the value. This
     increases the utility of the function when in use within a
     gNMI implementation.
 * (M) ytypes/.../*test.go
   - Add test coverage for the retrieveNode function against
     crafted and generated schemas.
```