### PR TITLE
Add helper functions for gNMI implementation.

### DIFF
--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -201,10 +201,6 @@ func retrieveNodeList(schema *yang.Entry, root interface{}, path, traversedPath 
 			}
 
 			if fmt.Sprint(kv) == pathKey {
-				if err != nil {
-					return nil, status.Errorf(codes.Unknown, "failed to extract path element at %v: %v", traversedPath, err)
-				}
-
 				return retrieveNode(schema, listElemV.Interface(), util.PopGNMIPath(path), appendElem(traversedPath, path.GetElem()[0]), args)
 			}
 			continue

--- a/ytypes/schema_tests/get_test.go
+++ b/ytypes/schema_tests/get_test.go
@@ -143,6 +143,10 @@ func TestGetNodeFull(t *testing.T) {
 				t.Fatalf("did not get expected error, %v", diff)
 			}
 
+			if err != nil {
+				return
+			}
+
 			if diff := cmp.Diff(got, tt.wantNodes, ignoreSchema, cmpopts.EquateEmpty(), sortNodes); diff != "" {
 				t.Fatalf("did not get expected result, diff(-got,+want):\n%s", diff)
 			}


### PR DESCRIPTION
```
 * (M) util/*
   - Add helper functions for gNMI paths that allow implementation
     of prefix finding for a set of paths, and trimming a prefix
     from a path.
 * (M) ygot/render*.go
   - Add a render function which can take a struct value and return
     it as a gNMI typedvalue.
```