### PR TITLE
Export a helper in generated code to unzip schema

### DIFF
--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -361,9 +361,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into

--- a/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
@@ -38,9 +38,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into

--- a/ygen/testdata/schema/openconfig-options-compress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress.formatted-txt
@@ -38,9 +38,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -38,9 +38,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into

--- a/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
@@ -38,9 +38,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into

--- a/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
@@ -38,9 +38,20 @@ var (
 
 func init() {
 	var err error
-	if SchemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+	if SchemaTree, err = UnzipSchema(); err != nil {
 		panic("schema error: " +  err.Error())
 	}
+}
+
+// UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
+// keyed by the name of the struct that the yang.Entry describes the schema for.
+func UnzipSchema() (map[string]*yang.Entry, error) {
+	var schemaTree map[string]*yang.Entry
+	var err error
+	if schemaTree, err = ygot.GzipToSchema(ySchema); err != nil {
+		return nil, fmt.Errorf("could not unzip the schema; %v", err)
+	}
+	return schemaTree, nil
 }
 
 // Unmarshal unmarshals data, which must be RFC7951 JSON format, into


### PR DESCRIPTION
If there are more than one consumer of the generated code, they can interfere with each other by modifying the schema tree. By adding the helper, consumers can get a copy of the schema tree instead of using the same one.