### PR TITLE
Update scripts/coverage.sh to exclude tests.

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -2,7 +2,7 @@
 
 go get github.com/go-playground/overalls && go get github.com/mattn/goveralls
 
-overalls -project=github.com/openconfig/ygot -covermode=count -ignore=".git,vendor,demo,experimental/ygotutils,generator,ytypes/schema_tests"
+overalls -project=github.com/openconfig/ygot -covermode=count -ignore=".git,vendor,integration_tests,ygot/schema_tests,ygen/schema_tests,demo,experimental/ygotutils,generator,ytypes/schema_tests"
 goveralls -coverprofile=overalls.coverprofile -service travis-ci
 
 


### PR DESCRIPTION
```
 * (M) scripts/coverage.sh
  - Avoid testing coverage for test packages that are themselves
    tests.
```

This is just some internal housekeeping, since we track the coverage and report on it in PRs where it decreases significantly (as a blocking check), then we want to avoid checking files where we don't expect coverage.