### PR TITLE
GetResponse check in testutil, nil struct check.

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -24,9 +24,16 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/value"
+
+	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
+
+// GetResponseEqual compares the contents of a and b and returns true if they
+// are equal. Extensions in the GetResponse are ignored.
+func GetResponseEqual(a, b *gnmipb.GetResponse) bool {
+	return NotificationSetEqual(a.Notification, b.Notification)
+}
 
 // NotificationSetEqual compares the contents of a and b and returns true if
 // they are equal. Order of the slices is ignored.

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -20,6 +20,49 @@ import (
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
+func TestGetResponseEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		inA  *gnmipb.GetResponse
+		inB  *gnmipb.GetResponse
+		want bool
+	}{{
+		name: "equal notifications",
+		inA: &gnmipb.GetResponse{
+			Notification: []*gnmipb.Notification{{
+				Timestamp: 42,
+			}},
+		},
+		inB: &gnmipb.GetResponse{
+			Notification: []*gnmipb.Notification{{
+				Timestamp: 42,
+			}},
+		},
+		want: true,
+	}, {
+		name: "unequal notifications",
+		inA: &gnmipb.GetResponse{
+			Notification: []*gnmipb.Notification{{
+				Timestamp: 42,
+			}},
+		},
+		inB: &gnmipb.GetResponse{
+			Notification: []*gnmipb.Notification{{
+				Timestamp: 84,
+			}},
+		},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetResponseEqual(tt.inA, tt.inB); got != tt.want {
+				t.Fatalf("did not get expected result, got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNotificationSetEqual(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -656,6 +656,10 @@ func EncodeTypedValue(val interface{}, enc gnmipb.Encoding) (*gnmipb.TypedValue,
 // marshalStruct encodes the struct s according to the encoding specified by enc. It
 // is returned as a TypedValue gNMI message.
 func marshalStruct(s GoStruct, enc gnmipb.Encoding) (*gnmipb.TypedValue, error) {
+	if reflect.ValueOf(s).IsNil() {
+		return nil, nil
+	}
+
 	var (
 		j     map[string]interface{}
 		err   error

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2560,6 +2560,11 @@ func TestEncodeTypedValue(t *testing.T) {
 		inVal:            &ietfRenderExample{},
 		inEnc:            gnmipb.Encoding_PROTO,
 		wantErrSubstring: "invalid encoding",
+	}, {
+		name:  "nil struct",
+		inVal: (*ietfRenderExample)(nil),
+		inEnc: gnmipb.Encoding_JSON_IETF,
+		want:  nil,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
  * (M) testutil/testutil.go
  * (M) testutil/testutil_test.go
   -  Add support for checking equality of GetResponse.
  * (M) ygot/render.go
  * (M) ygot/render_test.go
    - Cleanly handle a nil struct in marshalStruct.
```

Porting change into GitHub.