### PR TITLE
Add a generated Schema function to return schema details.

### DIFF
--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -323,7 +323,15 @@ func (cg *YANGCodeGenerator) GenerateGoCode(yangFiles, includePaths []string) (*
 		return nil, errs
 	}
 
-	commonHeader, oneoffHeader, err := writeGoHeader(yangFiles, includePaths, cg.Config)
+	var rootName string
+	if rootName = resolveRootName(cg.Config.FakeRootName, defaultRootName, cg.Config.GenerateFakeRoot); rootName != "" {
+		if r, ok := goStructs[fmt.Sprintf("/%s", rootName)]; ok {
+			rootName = r.name
+		}
+	}
+
+	commonHeader, oneoffHeader, err := writeGoHeader(yangFiles, includePaths, cg.Config, rootName)
+
 	if err != nil {
 		return nil, util.AppendErr(util.Errors{}, err)
 	}

--- a/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress-fakeroot.formatted-txt
@@ -43,6 +43,20 @@ func init() {
 	}
 }
 
+// Schema returns the details of the generated schema.
+func Schema() (*ytypes.Schema, error) {
+	uzp, err := UnzipSchema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot unzip schema, %v", err)
+	}
+
+	return &ytypes.Schema{
+		Root: &Device{},
+		SchemaTree: uzp,
+		Unmarshal: Unmarshal,
+	}, nil
+}
+
 // UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
 // keyed by the name of the struct that the yang.Entry describes the schema for.
 func UnzipSchema() (map[string]*yang.Entry, error) {

--- a/ygen/testdata/schema/openconfig-options-compress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-compress.formatted-txt
@@ -43,6 +43,20 @@ func init() {
 	}
 }
 
+// Schema returns the details of the generated schema.
+func Schema() (*ytypes.Schema, error) {
+	uzp, err := UnzipSchema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot unzip schema, %v", err)
+	}
+
+	return &ytypes.Schema{
+		Root: nil,
+		SchemaTree: uzp,
+		Unmarshal: Unmarshal,
+	}, nil
+}
+
 // UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
 // keyed by the name of the struct that the yang.Entry describes the schema for.
 func UnzipSchema() (map[string]*yang.Entry, error) {

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -43,6 +43,20 @@ func init() {
 	}
 }
 
+// Schema returns the details of the generated schema.
+func Schema() (*ytypes.Schema, error) {
+	uzp, err := UnzipSchema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot unzip schema, %v", err)
+	}
+
+	return &ytypes.Schema{
+		Root: &FakeRoot{},
+		SchemaTree: uzp,
+		Unmarshal: Unmarshal,
+	}, nil
+}
+
 // UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
 // keyed by the name of the struct that the yang.Entry describes the schema for.
 func UnzipSchema() (map[string]*yang.Entry, error) {

--- a/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-explicit.formatted-txt
@@ -51,7 +51,7 @@ func Schema() (*ytypes.Schema, error) {
 	}
 
 	return &ytypes.Schema{
-		Root: &FakeRoot{},
+		Root: &Fakeroot{},
 		SchemaTree: uzp,
 		Unmarshal: Unmarshal,
 	}, nil

--- a/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress-fakeroot.formatted-txt
@@ -43,6 +43,20 @@ func init() {
 	}
 }
 
+// Schema returns the details of the generated schema.
+func Schema() (*ytypes.Schema, error) {
+	uzp, err := UnzipSchema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot unzip schema, %v", err)
+	}
+
+	return &ytypes.Schema{
+		Root: &Device{},
+		SchemaTree: uzp,
+		Unmarshal: Unmarshal,
+	}, nil
+}
+
 // UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
 // keyed by the name of the struct that the yang.Entry describes the schema for.
 func UnzipSchema() (map[string]*yang.Entry, error) {

--- a/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
+++ b/ygen/testdata/schema/openconfig-options-nocompress.formatted-txt
@@ -43,6 +43,20 @@ func init() {
 	}
 }
 
+// Schema returns the details of the generated schema.
+func Schema() (*ytypes.Schema, error) {
+	uzp, err := UnzipSchema()
+	if err != nil {
+		return nil, fmt.Errorf("cannot unzip schema, %v", err)
+	}
+
+	return &ytypes.Schema{
+		Root: nil,
+		SchemaTree: uzp,
+		Unmarshal: Unmarshal,
+	}, nil
+}
+
 // UnzipSchema unzips the zipped schema and returns a map of yang.Entry nodes,
 // keyed by the name of the struct that the yang.Entry describes the schema for.
 func UnzipSchema() (map[string]*yang.Entry, error) {

--- a/ygen/yang_helpers.go
+++ b/ygen/yang_helpers.go
@@ -437,3 +437,19 @@ func enumDefaultValue(baseName, defVal, prefix string) *string {
 
 	return ygot.String(fmt.Sprintf("%s_%s", baseName, defVal))
 }
+
+// resolveRootName resolves the name of the fakeroot by taking configuration
+// and the default values, along with a boolean indicating whether the fake
+// root is to be generated. It returns an empty string if the root is not
+// to be generated.
+func resolveRootName(name, defName string, generateRoot bool) string {
+	if !generateRoot {
+		return ""
+	}
+
+	if name == "" {
+		return defName
+	}
+
+	return name
+}

--- a/ygen/yang_helpers_test.go
+++ b/ygen/yang_helpers_test.go
@@ -766,3 +766,33 @@ func TestDirectEntryChild(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveRootName(t *testing.T) {
+	tests := []struct {
+		name           string
+		inName         string
+		inDefName      string
+		inGenerateRoot bool
+		want           string
+	}{{
+		name:           "generate root false",
+		inGenerateRoot: false,
+	}, {
+		name:           "name specified",
+		inName:         "value",
+		inDefName:      "invalid",
+		inGenerateRoot: true,
+		want:           "value",
+	}, {
+		name:           "name not specified",
+		inDefName:      "default",
+		inGenerateRoot: true,
+		want:           "default",
+	}}
+
+	for _, tt := range tests {
+		if got := resolveRootName(tt.inName, tt.inDefName, tt.inGenerateRoot); got != tt.want {
+			t.Errorf("%s: resolveRootName(%s, %s, %v): did not get expected result, got: %s, want: %s", tt.name, tt.inName, tt.inDefName, tt.inGenerateRoot, got, tt.want)
+		}
+	}
+}

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -650,6 +650,10 @@ func EncodeTypedValue(val interface{}, enc gnmipb.Encoding) (*gnmipb.TypedValue,
 		vv = vv.Elem()
 	}
 
+	if util.IsValueNil(vv) || !vv.IsValid() {
+		return nil, nil
+	}
+
 	return value.FromScalar(vv.Interface())
 }
 

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2522,6 +2522,10 @@ func TestEncodeTypedValue(t *testing.T) {
 		inVal: Binary([]byte{0x00, 0x01}),
 		want:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_BytesVal{[]byte{0x00, 0x01}}},
 	}, {
+		name:  "nil scalar",
+		inVal: nil,
+		want:  nil,
+	}, {
 		name:  "leaf-list",
 		inVal: []string{"one", "two"},
 		want: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_LeaflistVal{

--- a/ytypes/types.go
+++ b/ytypes/types.go
@@ -1,5 +1,10 @@
 package ytypes
 
+import (
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+)
+
 // Schema specifies the common types that are part of a generated ygot schema, such that
 // it can be referenced and handled in calling application code.
 type Schema struct {

--- a/ytypes/types.go
+++ b/ytypes/types.go
@@ -1,16 +1,11 @@
 package ytypes
 
-import (
-	"google3/third_party/golang/goyang/pkg/yang/yang"
-	"google3/third_party/golang/ygot/ygot/ygot"
-)
-
 // Schema specifies the common types that are part of a generated ygot schema, such that
 // it can be referenced and handled in calling application code.
 type Schema struct {
-  Root       ygot.ValidatedGoStruct // Root is the ValidatedGoStruct that acts as the root for a schema, it is nil if there is no generated fakeroot.
-  SchemaTree map[string]*yang.Entry // SchemaTree is the extracted schematree for the generated schema.
-  Unmarshal  UnmarshalFunc          // Unmarshal is a function that can unmarshal RFC7951 JSON into the specified Root type.
+	Root       ygot.ValidatedGoStruct // Root is the ValidatedGoStruct that acts as the root for a schema, it is nil if there is no generated fakeroot.
+	SchemaTree map[string]*yang.Entry // SchemaTree is the extracted schematree for the generated schema.
+	Unmarshal  UnmarshalFunc          // Unmarshal is a function that can unmarshal RFC7951 JSON into the specified Root type.
 }
 
 // UnmarshalFunc defines a common signature for an RFC7951 to GoStruct unmarshalling function

--- a/ytypes/types.go
+++ b/ytypes/types.go
@@ -1,0 +1,17 @@
+package ytypes
+
+import (
+	"google3/third_party/golang/goyang/pkg/yang/yang"
+	"google3/third_party/golang/ygot/ygot/ygot"
+)
+
+// Schema specifies the common types that are part of a generated ygot schema, such that
+// it can be referenced and handled in calling application code.
+type Schema struct {
+  Root       ygot.ValidatedGoStruct // Root is the ValidatedGoStruct that acts as the root for a schema, it is nil if there is no generated fakeroot.
+  SchemaTree map[string]*yang.Entry // SchemaTree is the extracted schematree for the generated schema.
+  Unmarshal  UnmarshalFunc          // Unmarshal is a function that can unmarshal RFC7951 JSON into the specified Root type.
+}
+
+// UnmarshalFunc defines a common signature for an RFC7951 to GoStruct unmarshalling function
+type UnmarshalFunc func([]byte, ygot.GoStruct, ...UnmarshalOpt) error


### PR DESCRIPTION
This PR adds a new function into generated code that produces a representation of the schema that is being used. It gives a reusable mechanism to get the root, schema tree, and the unmarshal function for a calling application.