### PR TITLE
Fix rendering feature gap used with diff.

### DIFF
--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -1254,6 +1254,28 @@ func TestDiff(t *testing.T) {
 				}},
 			}},
 		},
+	}, {
+		desc:   "leaf-list of enumerations change",
+		inOrig: &renderExample{},
+		inMod:  &renderExample{EnumLeafList: []EnumTest{EnumTestVALONE}},
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: &gnmipb.Path{
+					Elem: []*gnmipb.PathElem{{
+						Name: "enum-leaflist",
+					}},
+				},
+				Val: &gnmipb.TypedValue{
+					Value: &gnmipb.TypedValue_LeaflistVal{
+						&gnmipb.ScalarArray{
+							Element: []*gnmipb.TypedValue{{
+								Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"},
+							}},
+						},
+					},
+				},
+			}},
+		},
 	}}
 
 	for _, tt := range tests {

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -705,6 +705,7 @@ type renderExample struct {
 	InvalidMap    map[string]*invalidGoStruct         `path:"invalid-gostruct-map"`
 	InvalidPtr    *invalidGoStruct                    `path:"invalid-gostruct"`
 	Empty         YANGEmpty                           `path:"empty"`
+	EnumLeafList  []EnumTest                          `path:"enum-leaflist"`
 }
 
 // IsYANGGoStruct ensures that the renderExample type implements the GoStruct
@@ -2518,9 +2519,39 @@ func TestEncodeTypedValue(t *testing.T) {
 		inVal: EnumTestVALONE,
 		want:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"}},
 	}, {
+		name:  "leaf-list of enumeration",
+		inVal: []EnumTest{EnumTestVALONE},
+		want: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_LeaflistVal{
+			&gnmipb.ScalarArray{
+				Element: []*gnmipb.TypedValue{{
+					Value: &gnmipb.TypedValue_StringVal{"VAL_ONE"},
+				}},
+			},
+		}},
+	}, {
+		name:  "leaf-list of string",
+		inVal: []string{"one", "two"},
+		want: &gnmipb.TypedValue{Value: &gnmipb.TypedValue_LeaflistVal{
+			&gnmipb.ScalarArray{
+				Element: []*gnmipb.TypedValue{{
+					Value: &gnmipb.TypedValue_StringVal{"one"},
+				}, {
+					Value: &gnmipb.TypedValue_StringVal{"two"},
+				}},
+			},
+		}},
+	}, {
+		name:             "invalid enum",
+		inVal:            int64(42),
+		wantErrSubstring: "cannot represent field value 42 as TypedValue",
+	}, {
 		name:  "binary",
 		inVal: Binary([]byte{0x00, 0x01}),
 		want:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_BytesVal{[]byte{0x00, 0x01}}},
+	}, {
+		name:  "empty",
+		inVal: YANGEmpty(true),
+		want:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_BoolVal{true}},
 	}, {
 		name:  "nil scalar",
 		inVal: nil,

--- a/ygot/schema_tests/schema_test.go
+++ b/ygot/schema_tests/schema_test.go
@@ -168,6 +168,24 @@ func TestDiff(t *testing.T) {
 				Val:  mustTypedValue("EXTERNAL"),
 			}},
 		},
+	}, {
+		desc:   "diff STP",
+		inOrig: &exampleoc.Device{},
+		inMod: func() *exampleoc.Device {
+			d := &exampleoc.Device{}
+			e := d.GetOrCreateStp().GetOrCreateGlobal()
+			e.EnabledProtocol = []exampleoc.E_OpenconfigSpanningTreeTypes_STP_PROTOCOL{
+				exampleoc.OpenconfigSpanningTreeTypes_STP_PROTOCOL_MSTP,
+				exampleoc.OpenconfigSpanningTreeTypes_STP_PROTOCOL_RSTP,
+			}
+			return d
+		}(),
+		want: &gnmipb.Notification{
+			Update: []*gnmipb.Update{{
+				Path: mustPath("/stp/global/config/enabled-protocol"),
+				Val:  mustTypedValue([]string{"MSTP", "RSTP"}),
+			}},
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
 * (M) ygot/{diff,diff_test,render,render_test}.go
  - De-duplicate typed value creation code, and ensure that it
    uniformly implements the rendering of a slices to TypedValue.
 * (A) ygot/schema_tests/schema_test.go
  - Add tests that cover discovered bug.
```