### PR TITLE
testutil enhancements; render panic fixes; error updates.

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -35,6 +35,37 @@ func GetResponseEqual(a, b *gnmipb.GetResponse) bool {
 	return NotificationSetEqual(a.Notification, b.Notification)
 }
 
+// SubscribeResponseEqual compares the contents of a and b and returns true if
+// they are equal. Extensions in the SubscribeResponse are ignored.
+func SubscribeResponseEqual(a, b *gnmipb.SubscribeResponse) bool {
+	switch {
+	case a.GetUpdate() != nil && b.GetUpdate() == nil, b.GetUpdate() != nil && a.GetUpdate() == nil:
+		return false
+	case a.GetUpdate() != nil && b.GetUpdate() != nil:
+		return NotificationSetEqual([]*gnmipb.Notification{a.GetUpdate()}, []*gnmipb.Notification{b.GetUpdate()})
+	default:
+		return a.GetSyncResponse() == b.GetSyncResponse()
+	}
+}
+
+// SubscribeResponseSetEqual compares the contents of the slices of SubscribeResponse
+// messages in a and b and returns true if they are equal. Order of the slices is
+// ignored.
+func SubscribeResponseSetEqual(a, b []*gnmipb.SubscribeResponse) bool {
+	for _, ar := range a {
+		var matched bool
+		for _, br := range b {
+			if SubscribeResponseEqual(ar, br) {
+				matched = true
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
 // NotificationSetEqual compares the contents of a and b and returns true if
 // they are equal. Order of the slices is ignored.
 func NotificationSetEqual(a, b []*gnmipb.Notification) bool {

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -63,6 +63,284 @@ func TestGetResponseEqual(t *testing.T) {
 	}
 }
 
+func TestSubscribeResponseEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		inA  *gnmipb.SubscribeResponse
+		inB  *gnmipb.SubscribeResponse
+		want bool
+	}{{
+		name: "unequal - sync response",
+		inA: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_SyncResponse{true},
+		},
+		inB: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_SyncResponse{false},
+		},
+		want: false,
+	}, {
+		name: "equal - sync response",
+		inA: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_SyncResponse{true},
+		},
+		inB: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_SyncResponse{true},
+		},
+		want: true,
+	}, {
+		name: "unequal - sync response cf. update",
+		inA: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_SyncResponse{true},
+		},
+		inB: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_Update{},
+		},
+		want: false,
+	}, {
+		name: "equal - updates equal",
+		inA: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		},
+		inB: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		},
+		want: true,
+	}, {
+		name: "unequal - updates",
+		inA: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		},
+		inB: &gnmipb.SubscribeResponse{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubscribeResponseEqual(tt.inA, tt.inB); got != tt.want {
+				t.Fatalf("did not get expected result, got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubscribeResponseSetEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		inA  []*gnmipb.SubscribeResponse
+		inB  []*gnmipb.SubscribeResponse
+		want bool
+	}{{
+		name: "equal, same order",
+		inA: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		inB: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		want: true,
+	}, {
+		name: "equal - different order",
+		inA: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		inB: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		want: true,
+	}, {
+		name: "not equal",
+		inA: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p2",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		inB: []*gnmipb.SubscribeResponse{{
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "p1",
+							}},
+						},
+					}},
+				},
+			},
+		}, {
+			Response: &gnmipb.SubscribeResponse_Update{
+				&gnmipb.Notification{
+					Update: []*gnmipb.Update{{
+						Path: &gnmipb.Path{
+							Elem: []*gnmipb.PathElem{{
+								Name: "NOT EQUAL",
+							}},
+						},
+					}},
+				},
+			},
+		}},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SubscribeResponseSetEqual(tt.inA, tt.inB); got != tt.want {
+				t.Fatalf("did not get expected result, got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNotificationSetEqual(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -311,12 +311,13 @@ func findUpdatedLeaves(leaves map[*path]interface{}, s GoStruct, parent *gnmiPat
 		return fmt.Errorf("invalid parent specified: %v", parent)
 	}
 
-	if s == nil {
-		errs.Add(fmt.Errorf("input struct for %v was nil", parent))
+	sval := reflect.ValueOf(s)
+	if s == nil || util.IsValueNil(sval) || !sval.IsValid() || !util.IsValueStructPtr(sval) {
+		errs.Add(fmt.Errorf("input struct for %v was not valid", parent))
 		return errs.Err()
 	}
+	sval = sval.Elem()
 
-	sval := reflect.ValueOf(s).Elem()
 	stype := sval.Type()
 
 	for i := 0; i < sval.NumField(); i++ {

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -926,6 +926,11 @@ func TestTogNMINotifications(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name:        "nil value",
+		inTimestamp: 42,
+		inStruct:    nil,
+		wantErr:     true,
+	}, {
 		name:        "no path tags on struct",
 		inTimestamp: 42,
 		inStruct:    &invalidGoStructEntity{NoPath: String("foo")},

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -98,7 +98,7 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 			case err != nil:
 				return nil, status.Errorf(codes.Unknown, "failed to get child schema for %T, field %s: %s", root, ft.Name, err)
 			case cschema == nil:
-				return nil, status.Errorf(codes.NotFound, "could not find schema for type %T, field %s", root, ft.Name)
+				return nil, status.Errorf(codes.InvalidArgument, "could not find schema for type %T, field %s", root, ft.Name)
 			default:
 				if cschema, err = resolveLeafRef(cschema); err != nil {
 					return nil, status.Errorf(codes.Unknown, "failed to resolve schema for %T, field %s: %s", root, ft.Name, err)
@@ -144,7 +144,7 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 		}
 	}
 
-	return nil, status.Errorf(codes.NotFound, "no match found in %T, for path %v", root, path)
+	return nil, status.Errorf(codes.InvalidArgument, "no match found in %T, for path %v", root, path)
 }
 
 // retrieveNodeList is an internal function and operates on a map. It returns the nodes matching


### PR DESCRIPTION
This PR updates the behaviour of the return arguments for some retrieval
functions to allow Subscribe implementation, adds further test util
helpers and fixes a panic in findUpdatedLeaves.

```
 * (M) testutil/testutil(_test)?.go
  - Add support for checking the equality of two slices of
    SubscribeResponse messages, and individual SubscribeResponse
    messages.
 * (M) ygot/render(_test)?.go
  - Fix a panic which occurred when a nil GoStruct was provided to
    TogNMINotifications.
 * (M) ytypes/node.go
  - Ensure that we comply with the gNMI specification as to when to
    return NotFound vs. InvalidArgument.
```