### PR TITLE
Handle nil-pointer fields in EncodeTypedValue.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -660,6 +660,9 @@ func EncodeTypedValue(val interface{}, enc gnmipb.Encoding) (*gnmipb.TypedValue,
 		vv = reflect.ValueOf(nv)
 	case util.IsValuePtr(vv):
 		vv = vv.Elem()
+		if util.IsNilOrInvalidValue(vv) {
+			return nil, nil
+		}
 	}
 
 	return value.FromScalar(vv.Interface())

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2605,6 +2605,11 @@ func TestEncodeTypedValue(t *testing.T) {
 		inVal: (*ietfRenderExample)(nil),
 		inEnc: gnmipb.Encoding_JSON_IETF,
 		want:  nil,
+	}, {
+		name:  "nil pointer",
+		inVal: (*string)(nil),
+		inEnc: gnmipb.Encoding_JSON_IETF,
+		want:  nil,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This CL ensures that EncodeTypedValue is robust to being handed
nil pointer values.