### PR TITLE
Fix error formatting in Validate.

### DIFF
--- a/util/errs.go
+++ b/util/errs.go
@@ -14,6 +14,10 @@
 
 package util
 
+import (
+	"fmt"
+)
+
 // Errors is a slice of error.
 type Errors []error
 
@@ -77,4 +81,29 @@ func ToString(errors []error) string {
 		out += e.Error()
 	}
 	return out
+}
+
+// PrefixErrors prefixes each error within the supplied Errors slice with the
+// string pfx.
+func PrefixErrors(errs Errors, pfx string) Errors {
+	var nerr Errors
+	for _, err := range errs {
+		nerr = append(nerr, fmt.Errorf("%s: %s", pfx, err))
+	}
+	return nerr
+}
+
+// Unique errors returns the unique errors from the supplied Errors slice. Errors
+// are considered equal if they have equal stringified values.
+func UniqueErrors(errs Errors) Errors {
+	u := map[string]error{}
+	for _, err := range errs {
+		u[fmt.Sprintf("%v", err)] = err
+	}
+
+	var ne Errors
+	for _, err := range u {
+		ne = append(ne, err)
+	}
+	return ne
 }

--- a/util/errs_test.go
+++ b/util/errs_test.go
@@ -15,7 +15,9 @@
 package util
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -118,5 +120,55 @@ func TestAppendErrsInFunction(t *testing.T) {
 
 	if got, want := Errors(myErrorSliceFunc()).String(), wantStr; got != want {
 		t.Errorf("got: %s, want: %s", got, want)
+	}
+}
+
+func TestPrefixErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		inErrs Errors
+		inPfx  string
+		want   Errors
+	}{{
+		name: "empty",
+	}, {
+		name:   "prefixed",
+		inErrs: Errors{errors.New("one"), errors.New("two")},
+		inPfx:  "a ",
+		want:   Errors{errors.New("a one"), errors.New("a two")},
+	}}
+
+	for _, tt := range tests {
+		if got := PrefixErrors(tt.inErrs, tt.inPfx); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%s: PrefixErrors(%v, %s): did not get expected result, got: %v, want: %v", tt.name, tt.inErrs, tt.inPfx, got, tt.want)
+		}
+	}
+}
+
+func TestUniqueErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Errors
+		want Errors
+	}{{
+		name: "empty",
+	}, {
+		name: "single error",
+		in:   Errors{errors.New("one")},
+		want: Errors{errors.New("one")},
+	}, {
+		name: "deduplicated",
+		in:   Errors{errors.New("one"), errors.New("one")},
+		want: Errors{errors.New("one")},
+	}, {
+		name: "not equal",
+		in:   Errors{errors.New("one"), errors.New("two")},
+		want: Errors{errors.New("one"), errors.New("two")},
+	}}
+
+	for _, tt := range tests {
+		if got := UniqueErrors(tt.in); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%s: UniqueErrors(%v): did not get expected result, got: %v, want: %v", tt.name, tt.in, got, tt.want)
+		}
 	}
 }

--- a/util/errs_test.go
+++ b/util/errs_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -134,8 +135,8 @@ func TestPrefixErrors(t *testing.T) {
 	}, {
 		name:   "prefixed",
 		inErrs: Errors{errors.New("one"), errors.New("two")},
-		inPfx:  "a ",
-		want:   Errors{errors.New("a one"), errors.New("a two")},
+		inPfx:  "a",
+		want:   Errors{errors.New("a: one"), errors.New("a: two")},
 	}}
 
 	for _, tt := range tests {
@@ -166,8 +167,25 @@ func TestUniqueErrors(t *testing.T) {
 		want: Errors{errors.New("one"), errors.New("two")},
 	}}
 
+	sortErrors := func(errs Errors) Errors {
+		m := map[string]error{}
+		keys := []string{}
+		for _, err := range errs {
+			k := fmt.Sprintf("%v\n", err)
+			m[k] = err
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+		var n Errors
+		for _, k := range keys {
+			n = append(n, m[k])
+		}
+		return n
+	}
+
 	for _, tt := range tests {
-		if got := UniqueErrors(tt.in); !reflect.DeepEqual(got, tt.want) {
+		if got := UniqueErrors(tt.in); !reflect.DeepEqual(sortErrors(got), sortErrors(tt.want)) {
 			t.Errorf("%s: UniqueErrors(%v): did not get expected result, got: %v, want: %v", tt.name, tt.in, got, tt.want)
 		}
 	}

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -69,7 +69,7 @@ func validateContainer(schema *yang.Entry, value ygot.GoStruct) util.Errors {
 			case cschema != nil:
 				// Regular named child.
 				if errs := Validate(cschema, fieldValue); errs != nil {
-					errors = util.AppendErrs(util.AppendErr(errors, fmt.Errorf("%s/", fieldName)), errs)
+					errors = util.AppendErrs(errors, util.PrefixErrors(errs, cschema.Path()))
 				}
 			case !structElems.Field(i).IsNil():
 				// Either an element in choice schema subtree, or bad field.
@@ -101,7 +101,7 @@ func validateContainer(schema *yang.Entry, value ygot.GoStruct) util.Errors {
 		errors = util.AppendErr(errors, fmt.Errorf("fields %v are not found in the container schema %s", stringMapSetToSlice(extraFields), schema.Name))
 	}
 
-	return errors
+	return util.UniqueErrors(errors)
 }
 
 // unmarshalContainer unmarshals a JSON tree into a struct.


### PR DESCRIPTION
```
 * (M) util/errs*
  - Add functions to deduplicate util.Errors and prefix all errors in a
    supplied util.Errors.
 * (M) ytypes/{validate,container}*
  - Ensure that when an error is returned by Validate() each path
    element is not a separate error in the slice -- there was some
    re-use of the errors slice that caused this to be the case. This
    matters only to consumers that parse ytypes' return value as a
    util.Errors, string users were unaffected.
  - Ensure that where duplicate errors occur (same regexp, same schema
    path) only one error is returned. In the future, we should track the
    datatree path, but this is currently not possible without more major
    refactoring of Validate().
 * (M) ytypes/schema_tests/validate_test.go
  - Add test cases checking error output.
```