### PR TITLE
Update IgnoreTimestamp to be a non-ptr argument.

### DIFF
--- a/testcmp/cmp_test.go
+++ b/testcmp/cmp_test.go
@@ -333,7 +333,7 @@ func TestIntegration(t *testing.T) {
 		inB: &gnmipb.Notification{
 			Timestamp: 84,
 		},
-		inOpts: []testutil.ComparerOpt{&testutil.IgnoreTimestamp{}},
+		inOpts: []testutil.ComparerOpt{testutil.IgnoreTimestamp{}},
 		want:   true,
 	}, {
 		desc: "Notification Set with OC comparer",

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -40,13 +40,13 @@ type ComparerOpt interface {
 type IgnoreTimestamp struct{}
 
 // IsComparerOpt marks IgnoreTimestamp as a ComparerOpt.
-func (*IgnoreTimestamp) IsComparerOpt() {}
+func (IgnoreTimestamp) IsComparerOpt() {}
 
 // hasIgnoreTimestamp determines whether the opt slice contains at least one
 // instance of the IgnoreTimestamp option.
 func hasIgnoreTimestamp(opts []ComparerOpt) bool {
 	for _, o := range opts {
-		if _, ok := o.(*IgnoreTimestamp); ok {
+		if _, ok := o.(IgnoreTimestamp); ok {
 			return true
 		}
 	}

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -459,7 +459,7 @@ func TestNotificationSetEqual(t *testing.T) {
 		inB: []*gnmipb.Notification{{
 			Timestamp: 84,
 		}},
-		inOpts: []ComparerOpt{&IgnoreTimestamp{}},
+		inOpts: []ComparerOpt{IgnoreTimestamp{}},
 		want:   true,
 	}, {
 		name: "integration example - same order",


### PR DESCRIPTION
```
 * (M) testutil/testutil.go
  - Avoid issues with a ptr being used for IgnoreTimestamp. This
    is not needed since the struct is empty, and the argument is
    always immutable. Generally, we should prefer non-ptr argument
    types.
```