### PR TITLE
Implementation of getNodes, to handle also wildcards in the path.

### DIFF
--- a/experimental/ygotutils/getnodes.go
+++ b/experimental/ygotutils/getnodes.go
@@ -1,0 +1,236 @@
+// Package ygotutils implements utility functions for users of
+// github.com/openconfig/ygot.
+package ygotutils
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygot"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	scpb "google.golang.org/genproto/googleapis/rpc/code"
+)
+
+// GetNodes returns the nodes in the data tree at the indicated path via the callback function, relative to
+// the supplied root struct. If the root struct is the tree root, the path may
+// be absolute.
+// It returns an error if the path is not found in the tree, or an element along
+// the path is nil.
+func GetNodes(schema *yang.Entry, rootStruct ygot.GoStruct, path *gpb.Path, callback func(interface{})) {
+	// node, _, status :=
+	getNodesInternal(schema, rootStruct, path, callback)
+	//return node, status
+}
+
+// getNodesInternal is the internal implementation of GetNode. In
+// addition to GetNode functionality, it can accept non GoStruct types e.g.
+// map for a keyed list, or a leaf.
+func getNodesInternal(schema *yang.Entry, rootStruct interface{}, path *gpb.Path, callback func(interface{})) {
+	if len(path.GetElem()) == 0 {
+		zeroIndent()
+		callback(rootStruct)
+		return
+		//return rootStruct, schema, statusOK
+	}
+	if isNil(rootStruct) {
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("nil data element type %T, remaining path %v", rootStruct, path)))
+		return
+		// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("nil data element type %T, remaining path %v", rootStruct, path))
+	}
+	if schema == nil {
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("nil schema for data element type %T, remaining path %v", rootStruct, path)))
+		return
+		// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("nil schema for data element type %T, remaining path %v", rootStruct, path))
+	}
+	// Strip off the absolute path prefix since the relative and absolute paths
+	// are assumed to be equal.
+	if path.GetElem()[0].GetName() == "" {
+		path.Elem = path.GetElem()[1:]
+	}
+
+	indent()
+	dbgPrintln("GetNode next path %v, value %v", path.GetElem()[0], valueStr(rootStruct))
+
+	switch {
+	case schema.IsContainer() || (schema.IsList() && IsTypeStructPtr(reflect.TypeOf(rootStruct))):
+		// Either a container or list schema with struct data node (which could
+		// be an element of a list).
+		getNodesContainer(schema, rootStruct, path, callback)
+		return
+	case schema.IsList():
+		// A list schema with the list data node. Must find the element selected
+		// by the path.
+		getNodesList(schema, rootStruct, path, callback)
+		return
+	}
+	callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("bad schema type for %s, struct type %T", schema.Name, rootStruct)))
+	//return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("bad schema type for %s, struct type %T", schema.Name, rootStruct))
+}
+
+// getNodeContainer traverses the container rootStruct, which must be a
+// struct ptr type and matches each field against the first path element in
+// path. If a field matches, it recurses into that field with the remaining
+// path.
+func getNodesContainer(schema *yang.Entry, rootStruct interface{}, path *gpb.Path, callback func(interface{})) {
+	dbgPrintln("getNodeContainer: schema %s, next path %v, value %v", schema.Name, path.GetElem()[0], valueStr(rootStruct))
+
+	rv := reflect.ValueOf(rootStruct)
+	if !IsValueStructPtr(rv) {
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeContainer: rootStruct has type %T, expect struct ptr", rootStruct)))
+		return
+		//	return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeContainer: rootStruct has type %T, expect struct ptr", rootStruct))
+	}
+
+	v := rv.Elem()
+
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		ft := v.Type().Field(i)
+
+		// Skip ygot Annotation fields since they do not have a schema.
+		if util.IsYgotAnnotation(ft) {
+			continue
+		}
+
+		cschema, err := childSchema(schema, ft)
+		if err != nil {
+			callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("error for schema for type %T, field name %s: %s", rootStruct, ft.Name, err)))
+			return
+			// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("error for schema for type %T, field name %s: %s", rootStruct, ft.Name, err))
+		}
+		if cschema == nil {
+			callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("could not find schema for type %T, field name %s", rootStruct, ft.Name)))
+			return
+			// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("could not find schema for type %T, field name %s", rootStruct, ft.Name))
+		}
+		cschema, err = resolveLeafRef(cschema)
+		if err != nil {
+			callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("error for schema for type %T, field name %s: %s", rootStruct, ft.Name, err)))
+			return
+			//return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("error for schema for type %T, field name %s: %s", rootStruct, ft.Name, err))
+		}
+
+		dbgPrintln("check field name %s", cschema.Name)
+		ps, err := schemaPaths(ft)
+		if err != nil {
+			callback(errToStatus(err))
+			return
+			// return nil, nil, errToStatus(err)
+		}
+		for _, p := range ps {
+			if pathMatchesPrefix(path, p) {
+				// don't trim whole prefix  for keyed list since name and key
+				// are a in the same element.
+				to := len(p)
+				if IsTypeMap(ft.Type) {
+					to--
+				}
+				getNodesInternal(cschema, f.Interface(), trimGNMIPathPrefix(path, p[0:to]), callback)
+				return
+			}
+		}
+	}
+	callback(toStatus(scpb.Code_NOT_FOUND, fmt.Sprintf("could not find path in tree beyond schema node %s, (type %T), remaining path %v", schema.Name, rootStruct, path)))
+	// return nil, nil, toStatus(scpb.Code_NOT_FOUND, fmt.Sprintf("could not find path in tree beyond schema node %s, (type %T), remaining path %v", schema.Name, rootStruct, path))
+}
+
+// getNodeList traverses the list rootStruct, which must be a map of struct
+// type and matches each map key against the first path element in path. If the
+// key matches completely, it recurses into that field with the remaining path.
+func getNodesList(schema *yang.Entry, rootStruct interface{}, path *gpb.Path, callback func(interface{})) {
+	dbgPrintln("getNodeList: schema %s, next path %v, value %v", schema.Name, path.GetElem()[0], valueStr(rootStruct))
+
+	rv := reflect.ValueOf(rootStruct)
+	if schema.Key == "" {
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: path %v cannot traverse unkeyed list type %T", path, rootStruct)))
+		return
+		// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: path %v cannot traverse unkeyed list type %T", path, rootStruct))
+	}
+	if path.GetElem()[0].GetKey() == nil {
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: path %v at %T points to list but does not specify a key element", path, rootStruct)))
+		return
+		// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: path %v at %T points to list but does not specify a key element", path, rootStruct))
+	}
+	if !IsValueMap(rv) {
+		// Only keyed lists can be traversed with a path.
+		callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: rootStruct has type %T, expect map", rootStruct)))
+		return
+		// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("getNodeList: rootStruct has type %T, expect map", rootStruct))
+	}
+
+	listElementType := rv.Type().Elem().Elem()
+	listKeyType := rv.Type().Key()
+	// Iterate through all the map keys to see if any match the path.
+	for _, k := range rv.MapKeys() {
+		ev := rv.MapIndex(k)
+		dbgPrintln("checking key %v, value %v", k.Interface(), valueStr(ev.Interface()))
+		match := true
+		if !IsValueStruct(k) {
+			// Compare just the single value of the key represented as a string.
+			pathKey, ok := path.GetElem()[0].GetKey()[schema.Key]
+			if !ok {
+				callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("gnmi path %v does not contain a map entry for the schema key field name %s, parent type %T",
+					path, schema.Key, rootStruct)))
+				return
+				// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("gnmi path %v does not contain a map entry for the schema key field name %s, parent type %T",
+				// 	path, schema.Key, rootStruct))
+			}
+			kv, err := getKeyValue(ev.Elem(), schema.Key)
+			if err != nil {
+				callback(errToStatus(err))
+				return
+				// return nil, nil, errToStatus(err)
+			}
+			dbgPrintln("check simple key value %s", pathKey)
+			match = (pathKey == "*") || (fmt.Sprint(kv) == pathKey)
+		} else {
+			// Must compare all the key fields.
+			for i := 0; i < k.NumField(); i++ {
+				kfn := listKeyType.Field(i).Name
+				fv := ev.Elem().FieldByName(kfn)
+				if !fv.IsValid() {
+					callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("element struct type %s does not contain key field %s", k.Type(), kfn)))
+					return
+					// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("element struct type %s does not contain key field %s", k.Type(), kfn))
+				}
+				nv := fv
+				if fv.Type().Kind() == reflect.Ptr {
+					// Ptr values are deferenced in key struct.
+					nv = nv.Elem()
+				}
+				kf, ok := listElementType.FieldByName(kfn)
+				if !ok {
+					callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("element struct type %s does not contain key field %s", k.Type(), kfn)))
+					return
+					// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("element struct type %s does not contain key field %s", k.Type(), kfn))
+				}
+				pathKey, ok := path.GetElem()[0].GetKey()[pathStructTagKey(kf)]
+				if !ok {
+					callback(toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("gnmi path %v does not contain a map entry for the schema key field name %s, parent type %T",
+						path, schema.Key, rootStruct)))
+					return
+					// return nil, nil, toStatus(scpb.Code_INVALID_ARGUMENT, fmt.Sprintf("gnmi path %v does not contain a map entry for the schema key field name %s, parent type %T",
+					// 	path, schema.Key, rootStruct))
+				}
+				if pathKey != fmt.Sprint(k.Field(i).Interface()) {
+					match = false
+					break
+				}
+				dbgPrintln("key field value %s matches", pathKey)
+			}
+		}
+
+		if match {
+			// Pass in the list schema, but the actual selected element
+			// rather than the whole list.
+			dbgPrintln("whole key matches")
+			getNodesInternal(schema, ev.Interface(), popGNMIPath(path), callback)
+			//return
+		}
+	}
+
+	//return nil, nil, toStatus(scpb.Code_NOT_FOUND, fmt.Sprintf("could not find path in tree beyond schema node %s, (type %T), remaining path %v", schema.Name, rootStruct, path))
+}

--- a/experimental/ygotutils/getnodes_test.go
+++ b/experimental/ygotutils/getnodes_test.go
@@ -1,0 +1,427 @@
+package ygotutils
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	scpb "google.golang.org/genproto/googleapis/rpc/code"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+func TestGetNodesSimpleKeyedList(t *testing.T) {
+	containerWithLeafListSchema := &yang.Entry{
+		Name: "container",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"config": &yang.Entry{
+				Name: "config",
+				Kind: yang.DirectoryEntry,
+				Dir: map[string]*yang.Entry{
+					"simple-key-list": &yang.Entry{
+						Name:     "simple-key-list",
+						Kind:     yang.DirectoryEntry,
+						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						Key:      "key1",
+						Config:   yang.TSTrue,
+						Dir: map[string]*yang.Entry{
+							"key1": {
+								Name: "key1",
+								Kind: yang.LeafEntry,
+								Type: &yang.YangType{Kind: yang.Ystring},
+							},
+							"outer": {
+								Name: "outer",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"inner": &yang.Entry{
+										Name: "inner",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"leaf-field": &yang.Entry{
+												Name: "leaf-field",
+												Kind: yang.LeafEntry,
+												Type: &yang.YangType{
+													Kind: yang.Yleafref,
+													Path: "../../config/inner/leaf-field",
+												},
+											},
+										},
+									},
+									"config": &yang.Entry{
+										Name: "config",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"inner": &yang.Entry{
+												Name: "inner",
+												Kind: yang.DirectoryEntry,
+												Dir: map[string]*yang.Entry{
+													"leaf-field": &yang.Entry{
+														Name: "leaf-field",
+														Kind: yang.LeafEntry,
+														Type: &yang.YangType{Kind: yang.Yint32},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"outer2": {
+								Name: "outer2",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"inner": &yang.Entry{
+										Name: "inner",
+										Kind: yang.DirectoryEntry,
+										Dir: map[string]*yang.Entry{
+											"leaf-field": &yang.Entry{
+												Name: "leaf-field",
+												Kind: yang.LeafEntry,
+												Type: &yang.YangType{Kind: yang.Yint32},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c1 := &ContainerStruct1{
+		StructKeyList: map[string]*ListElemStruct1{
+			"forty-two": &ListElemStruct1{
+				Key1:  ygot.String("forty-two"),
+				Outer: &OuterContainerType1{Inner: &InnerContainerType1{LeafName: ygot.Int32(1234)}},
+			},
+		},
+	}
+
+	tests := []struct {
+		desc       string
+		rootStruct ygot.GoStruct
+		path       *gpb.Path
+		want       []interface{}
+		wantStatus []spb.Status
+	}{
+		{
+			desc:       "success leaf-ref",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "config",
+					},
+					{
+						Name: "simple-key-list",
+						Key: map[string]string{
+							"key1": "*",
+						},
+					},
+					{
+						Name: "outer",
+					},
+					{
+						Name: "inner",
+					},
+					{
+						Name: "leaf-field",
+					},
+				},
+			},
+			want:       []interface{}{c1.StructKeyList["forty-two"].Outer.Inner.LeafName},
+			wantStatus: nil,
+		},
+		{
+			desc:       "success leaf full path",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "config",
+					},
+					{
+						Name: "simple-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+						},
+					},
+					{
+						Name: "outer",
+					},
+					{
+						Name: "config",
+					},
+					{
+						Name: "inner",
+					},
+					{
+						Name: "leaf-field",
+					},
+				},
+			},
+			want:       []interface{}{c1.StructKeyList["forty-two"].Outer.Inner.LeafName},
+			wantStatus: nil,
+		},
+		{
+			desc:       "bad path",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "config",
+					},
+					{
+						Name: "simple-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+						},
+					},
+					{
+						Name: "bad-element",
+					},
+					{
+						Name: "inner",
+					},
+					{
+						Name: "leaf-field",
+					},
+				},
+			},
+			want:       nil,
+			wantStatus: []spb.Status{toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond schema node simple-key-list, (type *ygotutils.ListElemStruct1), remaining path elem:<name:"bad-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `)},
+		},
+		{
+			desc:       "nil field",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "config",
+					},
+					{
+						Name: "simple-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+						},
+					},
+					{
+						Name: "outer2",
+					},
+					{
+						Name: "inner",
+					},
+					{
+						Name: "leaf-field",
+					},
+				},
+			},
+			want:       nil,
+			wantStatus: []spb.Status{toStatus(scpb.Code_INVALID_ARGUMENT, `nil data element type *ygotutils.OuterContainerType1, remaining path elem:<name:"inner" > elem:<name:"leaf-field" > `)},
+		},
+	}
+
+	for _, tt := range tests {
+		var val []interface{}
+		var status []spb.Status
+		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(g interface{}) {
+			switch v := g.(type) {
+			case spb.Status:
+				// fmt.Println("got status", v)
+				status = append(status, v)
+			case interface{}:
+				// fmt.Println("got value", v)
+				val = append(val, v)
+			default:
+				fmt.Println("got unknown element", g)
+			}
+		})
+		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+			fmt.Println(isNil(got), isNil(want))
+			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
+		}
+		//testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
+		if len(status) == 0 {
+			if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
+				t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+			}
+		}
+	}
+}
+func TestGetNodesStructKeyedList(t *testing.T) {
+	containerWithLeafListSchema := &yang.Entry{
+		Name: "container",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"struct-key-list": &yang.Entry{
+				Name:     "struct-key-list",
+				Kind:     yang.DirectoryEntry,
+				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				Key:      "key1 key2 key3",
+				Config:   yang.TSTrue,
+				Dir: map[string]*yang.Entry{
+					"key1": {
+						Name: "key1",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Ystring},
+					},
+					"key2": {
+						Name: "key2",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Yint32},
+					},
+					"key3": {
+						Name: "key3",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Yenum},
+					},
+					"outer": {
+						Name: "outer",
+						Kind: yang.DirectoryEntry,
+						Dir: map[string]*yang.Entry{
+							"inner": &yang.Entry{
+								Name: "inner",
+								Kind: yang.DirectoryEntry,
+								Dir: map[string]*yang.Entry{
+									"leaf-field": &yang.Entry{
+										Name: "leaf-field",
+										Kind: yang.LeafEntry,
+										Type: &yang.YangType{Kind: yang.Yint32},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c1 := &ContainerStruct2{
+		StructKeyList: map[KeyStruct2]*ListElemStruct2{
+			{"forty-two", 42, 43}: &ListElemStruct2{
+				Key1:    ygot.String("forty-two"),
+				Key2:    ygot.Int32(42),
+				EnumKey: 43,
+				Outer:   &OuterContainerType2{Inner: &InnerContainerType2{LeafName: ygot.Int32(1234)}},
+			},
+		},
+	}
+
+	tests := []struct {
+		desc       string
+		rootStruct ygot.GoStruct
+		path       *gpb.Path
+		want       []interface{}
+		wantStatus []spb.Status
+	}{
+		{
+			desc:       "success leaf",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "struct-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+							"key2": "42",
+							"key3": "43",
+						},
+					},
+					{
+						Name: "outer",
+					},
+					{
+						Name: "inner",
+					},
+					{
+						Name: "leaf-field",
+					},
+				},
+			},
+			want:       []interface{}{c1.StructKeyList[KeyStruct2{"forty-two", 42, 43}].Outer.Inner.LeafName},
+			wantStatus: nil,
+		},
+		{
+			desc:       "success container",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "struct-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+							"key2": "42",
+							"key3": "43",
+						},
+					},
+					{
+						Name: "outer",
+					},
+					{
+						Name: "inner",
+					},
+				},
+			},
+			want:       []interface{}{c1.StructKeyList[KeyStruct2{"forty-two", 42, 43}].Outer.Inner},
+			wantStatus: nil,
+		}, {
+			desc:       "success container",
+			rootStruct: c1,
+			path: &gpb.Path{
+				Elem: []*gpb.PathElem{
+					{
+						Name: "struct-key-list",
+						Key: map[string]string{
+							"key1": "forty-two",
+							"key2": "42",
+							"key3": "*",
+						},
+					},
+					{
+						Name: "outer",
+					},
+					{
+						Name: "inner",
+					},
+				},
+			},
+			want:       []interface{}{c1.StructKeyList[KeyStruct2{"forty-two", 42, 43}].Outer.Inner},
+			wantStatus: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		var val []interface{}
+		var status []spb.Status
+		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(g interface{}) {
+			switch v := g.(type) {
+			case spb.Status:
+				// fmt.Println("got status", v)
+				status = append(status, v)
+			case interface{}:
+				// fmt.Println("got value", v)
+				val = append(val, v)
+			default:
+				fmt.Println("got unknown element", g)
+			}
+		})
+		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
+		}
+		//testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
+		if len(status) > 0 {
+			if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
+				t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+			}
+		}
+	}
+}

--- a/experimental/ygotutils/getnodes_test.go
+++ b/experimental/ygotutils/getnodes_test.go
@@ -101,6 +101,9 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 			"forty-two": &ListElemStruct1{
 				Key1:  ygot.String("forty-two"),
 				Outer: &OuterContainerType1{Inner: &InnerContainerType1{LeafName: ygot.Int32(1234)}},
+			}, "forty-three": &ListElemStruct1{
+				Key1:  ygot.String("forty-three"),
+				Outer: &OuterContainerType1{Inner: &InnerContainerType1{LeafName: ygot.Int32(1234)}},
 			},
 		},
 	}
@@ -137,7 +140,7 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 					},
 				},
 			},
-			want:       []interface{}{c1.StructKeyList["forty-two"].Outer.Inner.LeafName},
+			want:       []interface{}{c1.StructKeyList["forty-two"].Outer.Inner.LeafName, c1.StructKeyList["forty-two"].Outer.Inner.LeafName},
 			wantStatus: nil,
 		},
 		{
@@ -232,13 +235,15 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 	for _, tt := range tests {
 		var val []interface{}
 		var status []spb.Status
-		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(g interface{}) {
+		fmt.Println("query")
+		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(p *gpb.Path, g interface{}) {
 			switch v := g.(type) {
 			case spb.Status:
 				// fmt.Println("got status", v)
 				status = append(status, v)
 			case interface{}:
 				// fmt.Println("got value", v)
+				fmt.Println(v)
 				val = append(val, v)
 			default:
 				fmt.Println("got unknown element", g)
@@ -312,6 +317,11 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 				Key2:    ygot.Int32(42),
 				EnumKey: 43,
 				Outer:   &OuterContainerType2{Inner: &InnerContainerType2{LeafName: ygot.Int32(1234)}},
+			}, {"forty-two", 43, 43}: &ListElemStruct2{
+				Key1:    ygot.String("forty-two"),
+				Key2:    ygot.Int32(43),
+				EnumKey: 43,
+				Outer:   &OuterContainerType2{Inner: &InnerContainerType2{LeafName: ygot.Int32(1234)}},
 			},
 		},
 	}
@@ -382,7 +392,7 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 						Name: "struct-key-list",
 						Key: map[string]string{
 							"key1": "forty-two",
-							"key2": "42",
+							"key2": "*",
 							"key3": "*",
 						},
 					},
@@ -402,13 +412,14 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 	for _, tt := range tests {
 		var val []interface{}
 		var status []spb.Status
-		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(g interface{}) {
+		fmt.Println("Query")
+		GetNodes(containerWithLeafListSchema, tt.rootStruct, tt.path, func(p *gpb.Path, g interface{}) {
 			switch v := g.(type) {
 			case spb.Status:
 				// fmt.Println("got status", v)
 				status = append(status, v)
 			case interface{}:
-				// fmt.Println("got value", v)
+				fmt.Println("got value", v)
 				val = append(val, v)
 			default:
 				fmt.Println("got unknown element", g)


### PR DESCRIPTION
I need to get the nodes for path with wildcards as also the gnmi spec states.
e.g. interfaces/interface[name=*]
Therefore I implemented the piece of code.