### PR TITLE
Honour enum package name.

### DIFF
--- a/proto_generator/protogenerator.go
+++ b/proto_generator/protogenerator.go
@@ -108,6 +108,7 @@ func main() {
 			AnnotateSchemaPaths: *annotateSchemaPaths,
 			AnnotateEnumNames:   *annotateEnumNames,
 			NestedMessages:      !*packageHierarchy,
+			EnumPackageName:     *enumPackageName,
 		},
 		ExcludeState: *excludeState,
 	})


### PR DESCRIPTION
```
 * (M) proto_generator/protogenerator.go
  - Fix bug whereby we did not honour the enum package name supplied
    to us -- fixes #271.
```