### PR TITLE
Add memoization for datanode search during leafref validation

### DIFF
--- a/ytypes/schema_tests/leafref_benchmark_test.go
+++ b/ytypes/schema_tests/leafref_benchmark_test.go
@@ -1,0 +1,43 @@
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	oc "github.com/openconfig/ygot/exampleoc"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func benchmarkIntsSubints(b *testing.B, ints, subints int) {
+	d := &oc.Device{}
+	for i := 0; i < ints; i++ {
+		for j := 0; j < subints; j++ {
+			d.GetOrCreateInterface(fmt.Sprintf("eth%d", i)).GetOrCreateSubinterface(uint32(j))
+		}
+	}
+
+	// Create a reference just to ensure that we're validating leafrefs.
+	d.GetOrCreateLldp().GetOrCreateInterface(fmt.Sprintf("eth%d", ints-1))
+
+	r := d.GetOrCreateNetworkInstance("DEFAULT").GetOrCreateInterface("customerA")
+	r.Interface = ygot.String(fmt.Sprintf("eth%d", ints-1))
+	r.Subinterface = ygot.Uint32(uint32(subints) - 1)
+
+	b.ResetTimer()
+	if err := d.Validate(); err != nil {
+		b.FailNow()
+	}
+}
+
+// Each of the following benchmarks has roughly the same number of subinterfaces.
+func BenchmarkInterfaceLeafrefs1(b *testing.B) {
+	benchmarkIntsSubints(b, 1000, 3)
+}
+
+func BenchmarkInterfaceLeafrefs2(b *testing.B) {
+	benchmarkIntsSubints(b, 55, 55)
+}
+
+func BenchmarkInterfaceLeafrefs3(b *testing.B) {
+	benchmarkIntsSubints(b, 3, 1000)
+}


### PR DESCRIPTION
Leafref validation currently takes too long. Turns out just by
memoizing datanode searches, performance can be greatly improved.
A benchmark with the following timings is also added, testing
different interface/subinterface configurations.

BenchmarkInterfaceLeafrefs1-12                 1        3291651711 ns/op
BenchmarkInterfaceLeafrefs2-12                 1        2371589139 ns/op
BenchmarkInterfaceLeafrefs3-12                 1        2410086282 ns/op

comparing with master branch:
BenchmarkInterfaceLeafrefs1-12                 1        199058379412 ns/op
BenchmarkInterfaceLeafrefs2-12                 1        9990951263 ns/op
BenchmarkInterfaceLeafrefs3-12                 1        2937779011 ns/op