### PR TITLE
Fix bug with relative leafrefs in uncompressed schemas.

### DIFF
--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -1968,6 +1968,10 @@ func findMapPaths(parent *yangDirectory, field *yang.Entry, compressOCPaths, abs
 		// isKey to true so that the struct field can be mapped to the
 		// leafref leaf within the schema as well as the target of the
 		// leafref.
+		if k.Parent == nil || k.Parent.Parent == nil || k.Parent.Parent.Dir[k.Name] == nil || k.Parent.Parent.Dir[k.Name].Type == nil {
+			return nil, fmt.Errorf("invalid compressed schema, could not find the key %s or the grandparent of %s", k.Name, k.Path())
+		}
+
 		if reflect.DeepEqual(traverseElementSchemaPath(k), fieldSlicePath) && k.Parent.Parent.Dir[k.Name].Type.Kind == yang.Yleafref {
 			// The path of the key element is simply the name of the leaf under the
 			// list, since the YANG specification enforces that keys are direct

--- a/ytypes/leafref.go
+++ b/ytypes/leafref.go
@@ -203,7 +203,7 @@ func dataNodesAtPath(ni *util.NodeInfo, path *gpb.Path, nodeQueryMemoPtr *nodeQu
 			if root.Parent == nil {
 				return nil, fmt.Errorf("no parent for leafref path at %v, with remaining path %s", ni.Schema.Path(), path)
 			}
-			if !util.IsCompressedSchema(root.Schema) && root.Schema.IsList() && util.IsValueMap(root.FieldValue) {
+			if !util.IsCompressedSchema(root.Schema) && root.Parent.Schema.IsList() && util.IsValueMap(root.Parent.FieldValue) {
 				// If we are in an uncompressed schema, then we have one more level of the data tree than
 				// the YANG expects, since our data tree layout is:
 				// struct (parent container)

--- a/ytypes/leafref_test.go
+++ b/ytypes/leafref_test.go
@@ -721,13 +721,13 @@ func TestLeafrefValidateCurrent(t *testing.T) {
 	}
 	rootSchema.Dir["target"] = targetListSchema
 	targetListSchema.Dir = map[string]*yang.Entry{
-		"key": &yang.Entry{
+		"key": {
 			Name:   "key",
 			Kind:   yang.LeafEntry,
 			Type:   &yang.YangType{Kind: yang.Yuint32},
 			Parent: targetListSchema,
 		},
-		"val": &yang.Entry{
+		"val": {
 			Name:   "val",
 			Kind:   yang.LeafEntry,
 			Type:   &yang.YangType{Kind: yang.Yuint32},
@@ -744,13 +744,13 @@ func TestLeafrefValidateCurrent(t *testing.T) {
 	}
 	rootSchema.Dir["ref"] = refListSchema
 	refListSchema.Dir = map[string]*yang.Entry{
-		"key": &yang.Entry{
+		"key": {
 			Name:   "key",
 			Kind:   yang.LeafEntry,
 			Type:   &yang.YangType{Kind: yang.Yuint32},
 			Parent: refListSchema,
 		},
-		"val": &yang.Entry{
+		"val": {
 			Name: "val",
 			Kind: yang.LeafEntry,
 			Type: &yang.YangType{


### PR DESCRIPTION
```
  * (M) ygen/gogen.go
    - Add a sanity check that a module is a valid OC module when
      generating rather than panic.
  * (M) ytypes/leafref.go
  * (M) ytypes/leafref_test.go
    - Ensure that we correctly detect where ".." should be consumed
      in relative paths in the case that we have leafrefs in the
      uncompressed schema.
```