### PR TITLE
Fix unmarshal of empty type leaf value for gNMI encoding

### DIFF
--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -854,7 +854,7 @@ func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *
 	}
 
 	switch ykind {
-	case yang.Ybool:
+	case yang.Ybool, yang.Yempty:
 		return tv.GetBoolVal(), nil
 	case yang.Ystring:
 		return tv.GetStringVal(), nil
@@ -902,7 +902,7 @@ func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *
 func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue) bool {
 	var ok bool
 	switch ykind {
-	case yang.Ybool:
+	case yang.Ybool, yang.Yempty:
 		_, ok = tv.GetValue().(*gpb.TypedValue_BoolVal)
 	case yang.Ystring, yang.Yenum, yang.Yidentityref:
 		_, ok = tv.GetValue().(*gpb.TypedValue_StringVal)

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1658,6 +1658,16 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantVal: &LeafContainerStruct{BoolLeaf: ygot.Bool(true)},
 		},
 		{
+			desc:     "success gNMI BoolVal to Yempty",
+			inSchema: typeToLeafSchema("empty-leaf", yang.Yempty),
+			inVal: &gpb.TypedValue{
+				Value: &gpb.TypedValue_BoolVal{
+					BoolVal: true,
+				},
+			},
+			wantVal: &LeafContainerStruct{EmptyLeaf: YANGEmpty(true)},
+		},
+		{
 			desc:     "success gNMI StringVal to Ystring",
 			inSchema: typeToLeafSchema("string-leaf", yang.Ystring),
 			inVal: &gpb.TypedValue{


### PR DESCRIPTION
Possible fix for #291 

Need to confirm if any special handling of `bool_val:false` for empty type since YANG empty type really only has 2 possible states ([1]doesn't exist, or [2]true) while YANG boolean type has 3 possible states ([1]doesn't exist, [2]true, or [3]false)