### PR TITLE
Fix for panic when validating choice/container with enum/empty leaf

### DIFF
--- a/ytypes/choice.go
+++ b/ytypes/choice.go
@@ -61,7 +61,7 @@ func validateChoice(schema *yang.Entry, structValue ygot.GoStruct) (selected []s
 func IsCaseSelected(schema *yang.Entry, value interface{}) (selected []string, errors []error) {
 	v := reflect.ValueOf(value).Elem()
 	for i := 0; i < v.NumField(); i++ {
-		if !v.Field(i).IsNil() {
+		if !util.IsValueNilOrDefault(v.Field(i).Interface()) {
 			fieldType := v.Type().Field(i)
 			cs, err := childSchema(schema, fieldType)
 			if err != nil {

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -71,7 +71,7 @@ func validateContainer(schema *yang.Entry, value ygot.GoStruct) util.Errors {
 				if errs := Validate(cschema, fieldValue); errs != nil {
 					errors = util.AppendErrs(errors, util.PrefixErrors(errs, cschema.Path()))
 				}
-			case !structElems.Field(i).IsNil():
+			case !util.IsValueNilOrDefault(structElems.Field(i).Interface()):
 				// Either an element in choice schema subtree, or bad field.
 				// If the former, it will be found in the choice check below.
 				extraFields[fieldName] = nil


### PR DESCRIPTION
Fixes #189 

Assumes default type value for scalars should be considered "unset", e.g.:
* enum => uint64(0)
* empty => false
