### PR TITLE
Optimise nil checking in rendering structs to Notifications.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -323,18 +323,18 @@ func findUpdatedLeaves(leaves map[*path]interface{}, s GoStruct, parent *gnmiPat
 		fval := sval.Field(i)
 		ftype := stype.Field(i)
 
-		mapPaths, err := structTagToLibPaths(ftype, parent)
-		if err != nil {
-			errs.Add(fmt.Errorf("%v->%s: %v", parent, ftype.Name, err))
-			continue
-		}
-
 		// Handle nil values, and enumerations specifically.
 		switch fval.Kind() {
 		case reflect.Map, reflect.Slice, reflect.Ptr, reflect.Interface:
 			if fval.IsNil() {
 				continue
 			}
+		}
+
+		mapPaths, err := structTagToLibPaths(ftype, parent)
+		if err != nil {
+			errs.Add(fmt.Errorf("%v->%s: %v", parent, ftype.Name, err))
+			continue
 		}
 
 		switch fval.Kind() {


### PR DESCRIPTION
```
 * (M) ygot/render.go
  - Before this change, we calculate the paths that a field should be
    mapped to before we check whether it is nil or not, we can avoid
    doing any check of a struct field's path at all if we check whether
    it was nil *before*.
```

Before this change (with lsdbparse updates made):
```
▶ go test -test.bench BenchmarkRenderLSP -cpuprofile cpu.out
goos: darwin
goarch: amd64
pkg: github.com/openconfig/lsdbparse
BenchmarkRenderLSP/simple_example/usePathElem=false-12         	   30000	     49375 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=false-12         	    5000	    329816 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=false-12 	   50000	     39262 ns/op
BenchmarkRenderLSP/simple_example/usePathElem=true-12          	   20000	     66246 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=true-12          	    5000	    360262 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=true-12  	   30000	     54186 ns/op
```

After this change:
```
BenchmarkRenderLSP/simple_example/usePathElem=false-12         	   50000	     30090 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=false-12         	   10000	    166432 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=false-12 	  100000	     18568 ns/op
BenchmarkRenderLSP/simple_example/usePathElem=true-12          	   30000	     45786 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=true-12          	   10000	    206441 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=true-12  	   50000	     32374 ns/op
```

This gives us an improvement from 362262 ns/op to 206441 ns/op - this is a further 43% gain.

(For those keeping count, we've gone from 490654 to 206441 = 58% gain for the day.)
