### PR TITLE
Export remaining MappedType fields

### DIFF
--- a/ygen/genstate.go
+++ b/ygen/genstate.go
@@ -592,7 +592,7 @@ func (s *genState) enumeratedTypedefTypeName(args resolveTypeArgs, prefix string
 
 			return &MappedType{
 				NativeType:        fmt.Sprintf("%s%s", prefix, tn),
-				isEnumeratedValue: true,
+				IsEnumeratedValue: true,
 			}, nil
 		}
 	}

--- a/ygen/goelements.go
+++ b/ygen/goelements.go
@@ -331,7 +331,7 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 //	}
 //
 // Is returned with a goType of Bar_Foo_Union (where Bar_Foo is the schema
-// path to an element). The UnionTypes are specified to be string and int8.
+// path to an element). The unionTypes are specified to be string and int8.
 //
 // The compressOCPaths argument specifies whether OpenConfig path compression
 // is enabled such that the name of enumerated types can be calculated correctly.
@@ -339,14 +339,14 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 // goUnionType returns an error if mapping is not possible.
 func (s *genState) goUnionType(args resolveTypeArgs, compressOCPaths bool) (*MappedType, error) {
 	var errs []error
-	UnionTypes := make(map[string]int)
+	unionTypes := make(map[string]int)
 
 	// Extract the subtypes that are defined into a map which is keyed on the
 	// mapped type. A map is used such that other functions that rely checking
 	// whether a particular type is valid when creating mapping code can easily
 	// check, rather than iterating the slice of strings.
 	for _, subtype := range args.yangType.Type {
-		errs = append(errs, s.goUnionSubTypes(subtype, args.contextEntry, UnionTypes, compressOCPaths)...)
+		errs = append(errs, s.goUnionSubTypes(subtype, args.contextEntry, unionTypes, compressOCPaths)...)
 	}
 
 	if errs != nil {
@@ -355,23 +355,23 @@ func (s *genState) goUnionType(args resolveTypeArgs, compressOCPaths bool) (*Map
 
 	// Zero value is set to nil, other than in cases where there is a single type in
 	// the union.
-	ZeroValue := "nil"
+	zeroValue := "nil"
 
 	NativeType := fmt.Sprintf("%s_Union", s.pathToCamelCaseName(args.contextEntry, compressOCPaths, false))
-	if len(UnionTypes) == 1 {
-		for MappedType := range UnionTypes {
+	if len(unionTypes) == 1 {
+		for MappedType := range unionTypes {
 			NativeType = MappedType
 		}
 		if zv, ok := goZeroValues[NativeType]; ok {
-			ZeroValue = zv
+			zeroValue = zv
 		}
 
 	}
 
 	return &MappedType{
 		NativeType: NativeType,
-		UnionTypes: UnionTypes,
-		ZeroValue:  ZeroValue,
+		UnionTypes: unionTypes,
+		ZeroValue:  zeroValue,
 	}, nil
 }
 

--- a/ygen/goelements.go
+++ b/ygen/goelements.go
@@ -75,7 +75,7 @@ var (
 )
 
 // MappedType is used to store the Go type that a leaf entity in YANG is
-// mapped to. The NativeType is always populated for any leaf. unionTypes is populated
+// mapped to. The NativeType is always populated for any leaf. UnionTypes is populated
 // when the type may have subtypes (i.e., is a union). enumValues is populated
 // when the type is an enumerated type.
 //
@@ -86,27 +86,27 @@ var (
 type MappedType struct {
 	// NativeType is the type which is to be used for the mapped entity.
 	NativeType string
-	// unionTypes is a map, keyed by the Go type, of the types specified
+	// UnionTypes is a map, keyed by the Go type, of the types specified
 	// as valid for a union. The value of the map indicates the order
 	// of the type, since order is important for unions in YANG. Where
 	// two types are mapped to the same Go type (e.g., string) then
 	// only the order of the first is maintained. Since the generated
 	// code from the structs maintains only type validation, this
 	// is not currently a limitation.
-	unionTypes map[string]int
-	// isEnumeratedValue specifies whether the NativeType that is returned
+	UnionTypes map[string]int
+	// IsEnumeratedValue specifies whether the NativeType that is returned
 	// is a generated enumerated value. Such entities are reflected as
 	// derived types with constant values, and are hence not represented
 	// as pointers in the output code.
-	isEnumeratedValue bool
-	// zeroValue stores the value that should be used for the type if
+	IsEnumeratedValue bool
+	// ZeroValue stores the value that should be used for the type if
 	// it is unset. This is used only in contexts where the nil pointer
 	// cannot be used, such as leaf getters.
-	zeroValue string
-	// defaultValue stores the default value for the type if is specified.
+	ZeroValue string
+	// DefaultValue stores the default value for the type if is specified.
 	// It is represented as a string pointer to ensure that default values
 	// of the empty string can be distinguished from unset defaults.
-	defaultValue *string
+	DefaultValue *string
 }
 
 // resolveTypeArgs is a structure used as an input argument to the yangTypeToGoType
@@ -205,9 +205,9 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 		// mtype is set to non-nil when this was a valid enumeration
 		// within a typedef. We explicitly set the zero and default values
 		// here.
-		mtype.zeroValue = "0"
+		mtype.ZeroValue = "0"
 		if defVal != nil {
-			mtype.defaultValue = enumDefaultValue(mtype.NativeType, *defVal, goEnumPrefix)
+			mtype.DefaultValue = enumDefaultValue(mtype.NativeType, *defVal, goEnumPrefix)
 		}
 
 		return mtype, nil
@@ -216,31 +216,31 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 	// Perform the actual mapping of the type to the Go type.
 	switch args.yangType.Kind {
 	case yang.Yint8:
-		return &MappedType{NativeType: "int8", zeroValue: goZeroValues["int8"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "int8", ZeroValue: goZeroValues["int8"], DefaultValue: defVal}, nil
 	case yang.Yint16:
-		return &MappedType{NativeType: "int16", zeroValue: goZeroValues["int16"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "int16", ZeroValue: goZeroValues["int16"], DefaultValue: defVal}, nil
 	case yang.Yint32:
-		return &MappedType{NativeType: "int32", zeroValue: goZeroValues["int32"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "int32", ZeroValue: goZeroValues["int32"], DefaultValue: defVal}, nil
 	case yang.Yint64:
-		return &MappedType{NativeType: "int64", zeroValue: goZeroValues["int64"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "int64", ZeroValue: goZeroValues["int64"], DefaultValue: defVal}, nil
 	case yang.Yuint8:
-		return &MappedType{NativeType: "uint8", zeroValue: goZeroValues["uint8"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "uint8", ZeroValue: goZeroValues["uint8"], DefaultValue: defVal}, nil
 	case yang.Yuint16:
-		return &MappedType{NativeType: "uint16", zeroValue: goZeroValues["uint16"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "uint16", ZeroValue: goZeroValues["uint16"], DefaultValue: defVal}, nil
 	case yang.Yuint32:
-		return &MappedType{NativeType: "uint32", zeroValue: goZeroValues["uint32"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "uint32", ZeroValue: goZeroValues["uint32"], DefaultValue: defVal}, nil
 	case yang.Yuint64:
-		return &MappedType{NativeType: "uint64", zeroValue: goZeroValues["uint64"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "uint64", ZeroValue: goZeroValues["uint64"], DefaultValue: defVal}, nil
 	case yang.Ybool:
-		return &MappedType{NativeType: "bool", zeroValue: goZeroValues["bool"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "bool", ZeroValue: goZeroValues["bool"], DefaultValue: defVal}, nil
 	case yang.Yempty:
 		// Empty is a YANG type that either exists or doesn't, therefore
 		// map it to a boolean to indicate its presence or not. The empty
 		// type name uses a specific name in the generated code, such that
 		// it can be identified for marshalling.
-		return &MappedType{NativeType: ygot.EmptyTypeName, zeroValue: goZeroValues[ygot.EmptyTypeName]}, nil
+		return &MappedType{NativeType: ygot.EmptyTypeName, ZeroValue: goZeroValues[ygot.EmptyTypeName]}, nil
 	case yang.Ystring:
-		return &MappedType{NativeType: "string", zeroValue: goZeroValues["string"], defaultValue: defVal}, nil
+		return &MappedType{NativeType: "string", ZeroValue: goZeroValues["string"], DefaultValue: defVal}, nil
 	case yang.Yunion:
 		// A YANG Union is a leaf that can take multiple values - its subtypes need
 		// to be extracted.
@@ -258,9 +258,9 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 		}
 		return &MappedType{
 			NativeType:        fmt.Sprintf("E_%s", n),
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      defVal,
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      defVal,
 		}, nil
 	case yang.Yidentityref:
 		// Identityref leaves are mapped according to the base identity that they
@@ -275,12 +275,12 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 		}
 		return &MappedType{
 			NativeType:        fmt.Sprintf("E_%s", n),
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      defVal,
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      defVal,
 		}, nil
 	case yang.Ydecimal64:
-		return &MappedType{NativeType: "float64", zeroValue: goZeroValues["float64"]}, nil
+		return &MappedType{NativeType: "float64", ZeroValue: goZeroValues["float64"]}, nil
 	case yang.Yleafref:
 		// This is a leafref, so we check what the type of the leaf that it
 		// references is by looking it up in the schematree.
@@ -297,13 +297,13 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 		// Map binary fields to the Binary type defined in the output code,
 		// this is used to ensure that we can distinguish a binary field from
 		// a leaf-list of uint8s which is not possible if mapping to []byte.
-		return &MappedType{NativeType: ygot.BinaryTypeName, zeroValue: goZeroValues[ygot.BinaryTypeName], defaultValue: defVal}, nil
+		return &MappedType{NativeType: ygot.BinaryTypeName, ZeroValue: goZeroValues[ygot.BinaryTypeName], DefaultValue: defVal}, nil
 	default:
 		// Return an empty interface for the types that we do not currently
 		// support. Back-end validation is required for these types.
 		// TODO(robjs): Missing types currently bits. These
 		// should be added.
-		return &MappedType{NativeType: "interface{}", zeroValue: goZeroValues["interface{}"]}, nil
+		return &MappedType{NativeType: "interface{}", ZeroValue: goZeroValues["interface{}"]}, nil
 	}
 }
 
@@ -331,7 +331,7 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 //	}
 //
 // Is returned with a goType of Bar_Foo_Union (where Bar_Foo is the schema
-// path to an element). The unionTypes are specified to be string and int8.
+// path to an element). The UnionTypes are specified to be string and int8.
 //
 // The compressOCPaths argument specifies whether OpenConfig path compression
 // is enabled such that the name of enumerated types can be calculated correctly.
@@ -339,14 +339,14 @@ func (s *genState) yangTypeToGoType(args resolveTypeArgs, compressOCPaths bool) 
 // goUnionType returns an error if mapping is not possible.
 func (s *genState) goUnionType(args resolveTypeArgs, compressOCPaths bool) (*MappedType, error) {
 	var errs []error
-	unionTypes := make(map[string]int)
+	UnionTypes := make(map[string]int)
 
 	// Extract the subtypes that are defined into a map which is keyed on the
 	// mapped type. A map is used such that other functions that rely checking
 	// whether a particular type is valid when creating mapping code can easily
 	// check, rather than iterating the slice of strings.
 	for _, subtype := range args.yangType.Type {
-		errs = append(errs, s.goUnionSubTypes(subtype, args.contextEntry, unionTypes, compressOCPaths)...)
+		errs = append(errs, s.goUnionSubTypes(subtype, args.contextEntry, UnionTypes, compressOCPaths)...)
 	}
 
 	if errs != nil {
@@ -355,23 +355,23 @@ func (s *genState) goUnionType(args resolveTypeArgs, compressOCPaths bool) (*Map
 
 	// Zero value is set to nil, other than in cases where there is a single type in
 	// the union.
-	zeroValue := "nil"
+	ZeroValue := "nil"
 
 	NativeType := fmt.Sprintf("%s_Union", s.pathToCamelCaseName(args.contextEntry, compressOCPaths, false))
-	if len(unionTypes) == 1 {
-		for MappedType := range unionTypes {
+	if len(UnionTypes) == 1 {
+		for MappedType := range UnionTypes {
 			NativeType = MappedType
 		}
 		if zv, ok := goZeroValues[NativeType]; ok {
-			zeroValue = zv
+			ZeroValue = zv
 		}
 
 	}
 
 	return &MappedType{
 		NativeType: NativeType,
-		unionTypes: unionTypes,
-		zeroValue:  zeroValue,
+		UnionTypes: UnionTypes,
+		ZeroValue:  ZeroValue,
 	}, nil
 }
 
@@ -402,7 +402,7 @@ func (s *genState) goUnionSubTypes(subtype *yang.YangType, ctx *yang.Entry, curr
 		// leaf that refers to the union, not the specific subtype that is now being examined.
 		mtype = &MappedType{
 			NativeType: fmt.Sprintf("E_%s", s.identityrefBaseTypeFromIdentity(subtype.IdentityBase, false)),
-			zeroValue:  "0",
+			ZeroValue:  "0",
 		}
 	default:
 		var err error

--- a/ygen/goelements_test.go
+++ b/ygen/goelements_test.go
@@ -174,43 +174,43 @@ func TestYangTypeToGoType(t *testing.T) {
 	}{{
 		name: "simple lookup resolution",
 		in:   &yang.YangType{Kind: yang.Yint32, Name: "int32"},
-		want: &MappedType{NativeType: "int32", zeroValue: "0"},
+		want: &MappedType{NativeType: "int32", ZeroValue: "0"},
 	}, {
 		name: "int32 with default",
 		in:   &yang.YangType{Kind: yang.Yint32, Name: "int32", Default: "42"},
-		want: &MappedType{NativeType: "int32", zeroValue: "0", defaultValue: ygot.String("42")},
+		want: &MappedType{NativeType: "int32", ZeroValue: "0", DefaultValue: ygot.String("42")},
 	}, {
 		name: "decimal64",
 		in:   &yang.YangType{Kind: yang.Ydecimal64, Name: "decimal64"},
-		want: &MappedType{NativeType: "float64", zeroValue: "0.0"},
+		want: &MappedType{NativeType: "float64", ZeroValue: "0.0"},
 	}, {
 		name: "binary lookup resolution",
 		in:   &yang.YangType{Kind: yang.Ybinary, Name: "binary"},
-		want: &MappedType{NativeType: "Binary", zeroValue: "nil"},
+		want: &MappedType{NativeType: "Binary", ZeroValue: "nil"},
 	}, {
 		name: "unknown lookup resolution",
 		in:   &yang.YangType{Kind: yang.YinstanceIdentifier, Name: "instanceIdentifier"},
-		want: &MappedType{NativeType: "interface{}", zeroValue: "nil"},
+		want: &MappedType{NativeType: "interface{}", ZeroValue: "nil"},
 	}, {
 		name: "simple empty resolution",
 		in:   &yang.YangType{Kind: yang.Yempty, Name: "empty"},
-		want: &MappedType{NativeType: "YANGEmpty", zeroValue: "false"},
+		want: &MappedType{NativeType: "YANGEmpty", ZeroValue: "false"},
 	}, {
 		name: "simple boolean resolution",
 		in:   &yang.YangType{Kind: yang.Ybool, Name: "bool"},
-		want: &MappedType{NativeType: "bool", zeroValue: "false"},
+		want: &MappedType{NativeType: "bool", ZeroValue: "false"},
 	}, {
 		name: "simple int64 resolution",
 		in:   &yang.YangType{Kind: yang.Yint64, Name: "int64"},
-		want: &MappedType{NativeType: "int64", zeroValue: "0"},
+		want: &MappedType{NativeType: "int64", ZeroValue: "0"},
 	}, {
 		name: "simple uint8 resolution",
 		in:   &yang.YangType{Kind: yang.Yuint8, Name: "uint8"},
-		want: &MappedType{NativeType: "uint8", zeroValue: "0"},
+		want: &MappedType{NativeType: "uint8", ZeroValue: "0"},
 	}, {
 		name: "simple uint16 resolution",
 		in:   &yang.YangType{Kind: yang.Yuint16, Name: "uint16"},
-		want: &MappedType{NativeType: "uint16", zeroValue: "0"},
+		want: &MappedType{NativeType: "uint16", ZeroValue: "0"},
 	}, {
 		name:    "leafref without valid path",
 		in:      &yang.YangType{Kind: yang.Yleafref, Name: "leafref"},
@@ -257,8 +257,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType: "Module_Container_Leaf_Union",
-			unionTypes: map[string]int{"string": 0, "int8": 1},
-			zeroValue:  "nil",
+			UnionTypes: map[string]int{"string": 0, "int8": 1},
+			ZeroValue:  "nil",
 		},
 	}, {
 		name: "string-only union",
@@ -271,8 +271,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType: "string",
-			unionTypes: map[string]int{"string": 0},
-			zeroValue:  `""`,
+			UnionTypes: map[string]int{"string": 0},
+			ZeroValue:  `""`,
 		},
 	}, {
 		name: "derived identityref",
@@ -291,8 +291,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_DerivedIdentityref",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
 		},
 	}, {
 		name: "derived identityref",
@@ -311,9 +311,9 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_DerivedIdentityref",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      ygot.String("BaseModule_DerivedIdentityref_AARDVARK"),
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      ygot.String("BaseModule_DerivedIdentityref_AARDVARK"),
 		},
 	}, {
 		name: "enumeration",
@@ -331,8 +331,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_EnumerationLeaf",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
 		},
 	}, {
 		name: "enumeration with default",
@@ -350,9 +350,9 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_EnumerationLeaf",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      ygot.String("BaseModule_EnumerationLeaf_BLUE"),
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      ygot.String("BaseModule_EnumerationLeaf_BLUE"),
 		},
 	}, {
 		name: "typedef enumeration",
@@ -371,8 +371,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_DerivedEnumeration",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
 		},
 	}, {
 		name: "typedef enumeration with default",
@@ -391,9 +391,9 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_BaseModule_DerivedEnumeration",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      ygot.String("BaseModule_DerivedEnumeration_FISH"),
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      ygot.String("BaseModule_DerivedEnumeration_FISH"),
 		},
 	}, {
 		name: "identityref",
@@ -417,8 +417,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_TestModule_BaseIdentity",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
 		},
 	}, {
 		name: "identityref with default",
@@ -442,9 +442,9 @@ func TestYangTypeToGoType(t *testing.T) {
 		},
 		want: &MappedType{
 			NativeType:        "E_TestModule_BaseIdentity",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
-			defaultValue:      ygot.String("TestModule_BaseIdentity_CHIPS"),
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
+			DefaultValue:      ygot.String("TestModule_BaseIdentity_CHIPS"),
 		},
 	}, {
 		name: "enumeration with compress paths",
@@ -464,8 +464,8 @@ func TestYangTypeToGoType(t *testing.T) {
 		compressPath: true,
 		want: &MappedType{
 			NativeType:        "E_BaseModule_Container_Eleaf",
-			isEnumeratedValue: true,
-			zeroValue:         "0",
+			IsEnumeratedValue: true,
+			ZeroValue:         "0",
 		},
 	}, {
 		name: "enumeration in submodule",
@@ -479,7 +479,7 @@ func TestYangTypeToGoType(t *testing.T) {
 			},
 		},
 		compressPath: true,
-		want:         &MappedType{NativeType: "E_BaseMod_Container_Eleaf", isEnumeratedValue: true, zeroValue: "0"},
+		want:         &MappedType{NativeType: "E_BaseMod_Container_Eleaf", IsEnumeratedValue: true, ZeroValue: "0"},
 	}, {
 		name: "leafref",
 		in:   &yang.YangType{Kind: yang.Yleafref, Name: "leafref", Path: "../c"},
@@ -521,7 +521,7 @@ func TestYangTypeToGoType(t *testing.T) {
 				Parent: &yang.Entry{Name: "module"},
 			},
 		},
-		want: &MappedType{NativeType: "uint32", zeroValue: "0"},
+		want: &MappedType{NativeType: "uint32", ZeroValue: "0"},
 	}}
 
 	for _, tt := range tests {
@@ -1023,8 +1023,8 @@ func TestTypeResolutionManyToOne(t *testing.T) {
 			},
 		}},
 		wantTypes: map[string]*MappedType{
-			"/test-module/leaf-one": {NativeType: "E_TestModule_BaseIdentity", isEnumeratedValue: true, zeroValue: "0"},
-			"/test-module/leaf-two": {NativeType: "E_TestModule_BaseIdentity", isEnumeratedValue: true, zeroValue: "0"},
+			"/test-module/leaf-one": {NativeType: "E_TestModule_BaseIdentity", IsEnumeratedValue: true, ZeroValue: "0"},
+			"/test-module/leaf-two": {NativeType: "E_TestModule_BaseIdentity", IsEnumeratedValue: true, ZeroValue: "0"},
 		},
 	}, {
 		name: "typedef with multiple references",
@@ -1060,8 +1060,8 @@ func TestTypeResolutionManyToOne(t *testing.T) {
 			},
 		}},
 		wantTypes: map[string]*MappedType{
-			"/base-module/leaf-one": {NativeType: "E_BaseModule_DefinedType", isEnumeratedValue: true, zeroValue: "0"},
-			"/base-module/leaf-two": {NativeType: "E_BaseModule_DefinedType", isEnumeratedValue: true, zeroValue: "0"},
+			"/base-module/leaf-one": {NativeType: "E_BaseModule_DefinedType", IsEnumeratedValue: true, ZeroValue: "0"},
+			"/base-module/leaf-two": {NativeType: "E_BaseModule_DefinedType", IsEnumeratedValue: true, ZeroValue: "0"},
 		},
 	}}
 

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -1280,10 +1280,10 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 			scalarField := true
 			fType := mtype.NativeType
 			schemapath := util.SchemaTreePathNoModule(field)
-			zeroValue := mtype.zeroValue
-			defaultValue := goLeafDefault(field, mtype)
+			ZeroValue := mtype.ZeroValue
+			DefaultValue := goLeafDefault(field, mtype)
 
-			if len(mtype.unionTypes) > 1 {
+			if len(mtype.UnionTypes) > 1 {
 				// If this is a union that has more than one subtype, then we need
 				// to ensure that we do not map this as a pointer type (since its
 				// field type is an interface), and generate the relevant interface.
@@ -1300,7 +1300,7 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 						ParentReceiver: targetStruct.Name,
 					}
 
-					for t := range mtype.unionTypes {
+					for t := range mtype.UnionTypes {
 						// If the type within the union is not a builtin type then we store
 						// it within the enumMap, since it is an enumerated type.
 						if _, builtin := validGoBuiltinTypes[t]; !builtin {
@@ -1338,8 +1338,8 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 				scalarField = false
 				// Slices have a nil zero value rather than the value of their
 				// underlying type.
-				zeroValue = "nil"
-			case mtype.isEnumeratedValue == true, mtype.NativeType == "interface{}", mtype.NativeType == ygot.BinaryTypeName, mtype.NativeType == ygot.EmptyTypeName:
+				ZeroValue = "nil"
+			case mtype.IsEnumeratedValue == true, mtype.NativeType == "interface{}", mtype.NativeType == ygot.BinaryTypeName, mtype.NativeType == ygot.EmptyTypeName:
 				// If the value is an enumerated value, then we did not represent it
 				// as a pointer within the struct, so mark it as a scalar field such
 				// that the template does not attempt to prefix it with an asterisk.
@@ -1350,7 +1350,7 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 			}
 
 			definedNameMap[fName].IsPtr = scalarField
-			if mtype.isEnumeratedValue {
+			if mtype.IsEnumeratedValue {
 				// Any enumerated type is stored in the enumMap to allow for type
 				// resolution from a schema path.
 				enumTypeMap[schemapath] = append(enumTypeMap[schemapath], mtype.NativeType)
@@ -1363,10 +1363,10 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 				associatedLeafGetters = append(associatedLeafGetters, &generatedLeafGetter{
 					Name:     fieldName,
 					Type:     fType,
-					Zero:     zeroValue,
+					Zero:     ZeroValue,
 					IsPtr:    scalarField,
 					Receiver: targetStruct.Name,
-					Default:  defaultValue,
+					Default:  DefaultValue,
 				})
 			}
 
@@ -1803,7 +1803,7 @@ func yangListFieldToGoType(listField *yang.Entry, listFieldName string, parent *
 		}
 		// All list key values should be represented as pointers, other than those that
 		// are enumerated values, and hence we mark IsScalarField as true for these.
-		if !listElem.ListAttr.Keys[keName].isEnumeratedValue && len(listElem.ListAttr.Keys[keName].unionTypes) < 2 {
+		if !listElem.ListAttr.Keys[keName].IsEnumeratedValue && len(listElem.ListAttr.Keys[keName].UnionTypes) < 2 {
 			keyField.IsScalarField = true
 		}
 		listKeys = append(listKeys, keyField)
@@ -2042,14 +2042,14 @@ func writeGoSchema(js []byte, schemaVarName string) (string, error) {
 // otherwise nil is returned to indicate no default was specified.
 func goLeafDefault(e *yang.Entry, t *MappedType) *string {
 	if e.Default != "" {
-		if t.isEnumeratedValue {
+		if t.IsEnumeratedValue {
 			return enumDefaultValue(t.NativeType, e.Default, goEnumPrefix)
 		}
 		return quoteDefault(&e.Default, t.NativeType)
 	}
 
-	if t.defaultValue != nil {
-		return quoteDefault(t.defaultValue, t.NativeType)
+	if t.DefaultValue != nil {
+		return quoteDefault(t.DefaultValue, t.NativeType)
 	}
 
 	return nil

--- a/ygen/gogen.go
+++ b/ygen/gogen.go
@@ -1280,8 +1280,8 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 			scalarField := true
 			fType := mtype.NativeType
 			schemapath := util.SchemaTreePathNoModule(field)
-			ZeroValue := mtype.ZeroValue
-			DefaultValue := goLeafDefault(field, mtype)
+			zeroValue := mtype.ZeroValue
+			defaultValue := goLeafDefault(field, mtype)
 
 			if len(mtype.UnionTypes) > 1 {
 				// If this is a union that has more than one subtype, then we need
@@ -1338,7 +1338,7 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 				scalarField = false
 				// Slices have a nil zero value rather than the value of their
 				// underlying type.
-				ZeroValue = "nil"
+				zeroValue = "nil"
 			case mtype.IsEnumeratedValue == true, mtype.NativeType == "interface{}", mtype.NativeType == ygot.BinaryTypeName, mtype.NativeType == ygot.EmptyTypeName:
 				// If the value is an enumerated value, then we did not represent it
 				// as a pointer within the struct, so mark it as a scalar field such
@@ -1363,10 +1363,10 @@ func writeGoStruct(targetStruct *Directory, goStructElements map[string]*Directo
 				associatedLeafGetters = append(associatedLeafGetters, &generatedLeafGetter{
 					Name:     fieldName,
 					Type:     fType,
-					Zero:     ZeroValue,
+					Zero:     zeroValue,
 					IsPtr:    scalarField,
 					Receiver: targetStruct.Name,
-					Default:  DefaultValue,
+					Default:  defaultValue,
 				})
 			}
 

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -2225,14 +2225,14 @@ func TestGoLeafDefault(t *testing.T) {
 	}, {
 		name:   "default in type",
 		inLeaf: &yang.Entry{},
-		inType: &MappedType{NativeType: "int32", defaultValue: ygot.String("0")},
+		inType: &MappedType{NativeType: "int32", DefaultValue: ygot.String("0")},
 		want:   ygot.String("0"),
 	}, {
 		name:   "enumerated default in leaf",
 		inLeaf: &yang.Entry{Default: "FORTY_TWO"},
 		inType: &MappedType{
 			NativeType:        fmt.Sprintf("%sEnumType", goEnumPrefix),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		},
 		want: ygot.String("EnumType_FORTY_TWO"),
 	}}

--- a/ygen/protoelements.go
+++ b/ygen/protoelements.go
@@ -205,14 +205,14 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 //
 // The MappedType's UnionTypes can be output through a template into the oneof.
 func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
-	UnionTypes := make(map[string]*yang.YangType)
-	if errs := s.protoUnionSubTypes(args.yangType, args.contextEntry, UnionTypes, pargs); errs != nil {
+	unionTypes := make(map[string]*yang.YangType)
+	if errs := s.protoUnionSubTypes(args.yangType, args.contextEntry, unionTypes, pargs); errs != nil {
 		return nil, fmt.Errorf("errors mapping element: %v", errs)
 	}
 
 	// Handle the case that there is just one protobuf type within the union.
-	if len(UnionTypes) == 1 {
-		for st, t := range UnionTypes {
+	if len(unionTypes) == 1 {
+		for st, t := range unionTypes {
 			// Handle the case whereby there is an identityref and we simply
 			// want to return the type that has been resolved.
 			if t.Kind == yang.Yidentityref || t.Kind == yang.Yenum {
@@ -250,7 +250,7 @@ func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeAr
 	// Rewrite the map to be the expected format for the MappedType return value,
 	// we sort the keys into alphabetical order to avoid test flakes.
 	keys := []string{}
-	for k := range UnionTypes {
+	for k := range unionTypes {
 		keys = append(keys, k)
 	}
 

--- a/ygen/protoelements.go
+++ b/ygen/protoelements.go
@@ -94,7 +94,7 @@ func (s *genState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoT
 		}
 		return &MappedType{
 			NativeType:        yang.CamelCase(args.contextEntry.Name),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		}, nil
 	case yang.Yidentityref:
 		// TODO(https://github.com/openconfig/ygot/issues/33) - refactor to allow
@@ -104,7 +104,7 @@ func (s *genState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoT
 		}
 		return &MappedType{
 			NativeType:        s.protoIdentityName(pargs, args.contextEntry.Type.IdentityBase),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		}, nil
 	case yang.Yunion:
 		return s.protoUnionType(args, pargs)
@@ -164,7 +164,7 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 		}
 		return &MappedType{
 			NativeType:        yang.CamelCase(args.contextEntry.Name),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		}, nil
 	case yang.Yidentityref:
 		if args.contextEntry == nil {
@@ -172,7 +172,7 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 		}
 		return &MappedType{
 			NativeType:        s.protoIdentityName(pargs, args.contextEntry.Type.IdentityBase),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		}, nil
 	case yang.Yunion:
 		return s.protoUnionType(args, pargs)
@@ -203,22 +203,22 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 //	int32 a_int32 = NN;
 // }
 //
-// The MappedType's unionTypes can be output through a template into the oneof.
+// The MappedType's UnionTypes can be output through a template into the oneof.
 func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
-	unionTypes := make(map[string]*yang.YangType)
-	if errs := s.protoUnionSubTypes(args.yangType, args.contextEntry, unionTypes, pargs); errs != nil {
+	UnionTypes := make(map[string]*yang.YangType)
+	if errs := s.protoUnionSubTypes(args.yangType, args.contextEntry, UnionTypes, pargs); errs != nil {
 		return nil, fmt.Errorf("errors mapping element: %v", errs)
 	}
 
 	// Handle the case that there is just one protobuf type within the union.
-	if len(unionTypes) == 1 {
-		for st, t := range unionTypes {
+	if len(UnionTypes) == 1 {
+		for st, t := range UnionTypes {
 			// Handle the case whereby there is an identityref and we simply
 			// want to return the type that has been resolved.
 			if t.Kind == yang.Yidentityref || t.Kind == yang.Yenum {
 				return &MappedType{
 					NativeType:        st,
-					isEnumeratedValue: true,
+					IsEnumeratedValue: true,
 				}, nil
 			}
 
@@ -250,7 +250,7 @@ func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeAr
 	// Rewrite the map to be the expected format for the MappedType return value,
 	// we sort the keys into alphabetical order to avoid test flakes.
 	keys := []string{}
-	for k := range unionTypes {
+	for k := range UnionTypes {
 		keys = append(keys, k)
 	}
 
@@ -261,7 +261,7 @@ func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeAr
 	}
 
 	return &MappedType{
-		unionTypes: rtypes,
+		UnionTypes: rtypes,
 	}, nil
 }
 
@@ -286,7 +286,7 @@ func (s *genState) protoUnionSubTypes(subtype *yang.YangType, ctx *yang.Entry, c
 		// an identityref.
 		mtype = &MappedType{
 			NativeType:        s.protoIdentityName(pargs, subtype.IdentityBase),
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		}
 	default:
 		var err error

--- a/ygen/protoelements_test.go
+++ b/ygen/protoelements_test.go
@@ -114,7 +114,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		},
-		wantWrapper: &MappedType{unionTypes: map[string]int{"string": 0, "uint64": 1}},
+		wantWrapper: &MappedType{UnionTypes: map[string]int{"string": 0, "uint64": 1}},
 		wantSame:    true,
 	}, {
 		name: "union with only strings",
@@ -151,7 +151,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 		}},
 		wantWrapper: &MappedType{
 			NativeType:        "basePackage.enumPackage.BaseModuleDerivedIdentityref",
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		},
 		wantSame: true,
 	}, {
@@ -181,7 +181,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 		}},
 		wantWrapper: &MappedType{
 			NativeType:        "EnumerationLeaf",
-			isEnumeratedValue: true,
+			IsEnumeratedValue: true,
 		},
 		wantSame: true,
 	}, {
@@ -201,7 +201,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		}},
-		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.BaseModuleDerivedEnumeration", isEnumeratedValue: true},
+		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.BaseModuleDerivedEnumeration", IsEnumeratedValue: true},
 		wantSame:    true,
 	}, {
 		name: "identityref",
@@ -225,7 +225,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		}},
-		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.TestModuleBaseIdentity", isEnumeratedValue: true},
+		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.TestModuleBaseIdentity", IsEnumeratedValue: true},
 		wantSame:    true,
 	}, {
 		name: "identityref with underscore in identity name",
@@ -249,7 +249,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		}},
-		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.TestModuleBASEIDENTITY", isEnumeratedValue: true},
+		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.TestModuleBASEIDENTITY", IsEnumeratedValue: true},
 		wantSame:    true,
 	}, {
 		name: "single type union with scalars requested",
@@ -370,7 +370,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		},
-		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.EnumModule", isEnumeratedValue: true},
+		wantWrapper: &MappedType{NativeType: "basePackage.enumPackage.EnumModule", IsEnumeratedValue: true},
 		wantSame:    true,
 	}, {
 		name: "leafref to union",
@@ -429,7 +429,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				},
 			},
 		},
-		wantWrapper: &MappedType{unionTypes: map[string]int{"bool": 0, "string": 1}},
+		wantWrapper: &MappedType{UnionTypes: map[string]int{"bool": 0, "string": 1}},
 		wantSame:    true,
 	}}
 

--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -1037,7 +1037,7 @@ func protoLeafDefinition(leafName string, args *protoDefinitionArgs) (*protoDefi
 		d.enums[d.protoType] = e
 	case util.IsEnumeratedType(args.field.Type):
 		d.globalEnum = true
-	case protoType.unionTypes != nil:
+	case protoType.UnionTypes != nil:
 		u, err := unionFieldToOneOf(leafName, args.field, protoType, args.cfg.annotateEnumNames)
 		if err != nil {
 			return nil, err
@@ -1177,7 +1177,7 @@ func genListKeyProto(listPackage string, listName string, args *protoDefinitionA
 				enumEntry = target
 			}
 
-			if scalarType.unionTypes != nil {
+			if scalarType.UnionTypes != nil {
 				unionEntry = target
 			}
 
@@ -1186,7 +1186,7 @@ func genListKeyProto(listPackage string, listName string, args *protoDefinitionA
 			}
 		case util.IsSimpleEnumerationType(kf.Type):
 			enumEntry = kf
-		case util.IsUnionType(kf.Type) && scalarType.unionTypes != nil:
+		case util.IsUnionType(kf.Type) && scalarType.UnionTypes != nil:
 			unionEntry = kf
 		}
 
@@ -1314,7 +1314,7 @@ func unionFieldToOneOf(fieldName string, e *yang.Entry, mtype *MappedType, annot
 	}
 
 	var typeNames []string
-	for tn := range mtype.unionTypes {
+	for tn := range mtype.UnionTypes {
 		typeNames = append(typeNames, tn)
 	}
 	sort.Strings(typeNames)

--- a/ygen/protogen_test.go
+++ b/ygen/protogen_test.go
@@ -1785,7 +1785,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 			},
 		},
 		inMappedType: &MappedType{
-			unionTypes: map[string]int{
+			UnionTypes: map[string]int{
 				"string": 0,
 				"sint64": 0,
 			},
@@ -1813,7 +1813,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 			},
 		},
 		inMappedType: &MappedType{
-			unionTypes: map[string]int{
+			UnionTypes: map[string]int{
 				"string":             0,
 				"ywrapper.Decimal64": 1,
 			},
@@ -1845,7 +1845,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 			},
 		},
 		inMappedType: &MappedType{
-			unionTypes: map[string]int{
+			UnionTypes: map[string]int{
 				"SomeEnumType": 0,
 				"string":       1,
 			},
@@ -1884,7 +1884,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 			ListAttr: &yang.ListAttr{},
 		},
 		inMappedType: &MappedType{
-			unionTypes: map[string]int{
+			UnionTypes: map[string]int{
 				"string": 0,
 				"uint64": 1,
 			},


### PR DESCRIPTION
While MappedType is exported, these unexported fields make this type less usable in other packages. For example, a user package can't easily check the `isEnumeratedValue` field to check whether it's an enum. While it is true that an accessor function can be used instead, you then can't set this field in tests.

My original thought behind only exporting NativeType was that these are "internal states", but since these are just accompanying properties of the type that describe it further, this argument doesn't make much sense, so this is just correcting a problem.

p.s. This change would resolve another issue you raised.