### PR TITLE
Fix targets to avoid unstable string comparisons

### DIFF
--- a/experimental/ygotutils/getnode_test.go
+++ b/experimental/ygotutils/getnode_test.go
@@ -259,7 +259,7 @@ func TestGetNodeSimpleKeyedList(t *testing.T) {
 				},
 			},
 			want:       nil,
-			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond schema node simple-key-list, (type *ygotutils.ListElemStruct1), remaining path elem:<name:"bad-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `),
+			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond schema node simple-key-list, (type *ygotutils.ListElemStruct1), remaining path `+(&gpb.Path{Elem: []*gpb.PathElem{{Name: "bad-element"}, {Name: "inner"}, {Name: "leaf-field"}}}).String()),
 		},
 		{
 			desc:       "nil field",
@@ -287,7 +287,7 @@ func TestGetNodeSimpleKeyedList(t *testing.T) {
 				},
 			},
 			want:       nil,
-			wantStatus: toStatus(scpb.Code_INVALID_ARGUMENT, `nil data element type *ygotutils.OuterContainerType1, remaining path elem:<name:"inner" > elem:<name:"leaf-field" > `),
+			wantStatus: toStatus(scpb.Code_INVALID_ARGUMENT, `nil data element type *ygotutils.OuterContainerType1, remaining path `+(&gpb.Path{Elem: []*gpb.PathElem{{Name: "inner"}, {Name: "leaf-field"}}}).String()),
 		},
 	}
 
@@ -591,7 +591,7 @@ func TestNewNodeSimpleKeyedList(t *testing.T) {
 				},
 			},
 			want:       nil,
-			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond type *ygotutils.ListElemStruct3, remaining path elem:<name:"bad-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `),
+			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond type *ygotutils.ListElemStruct3, remaining path `+(&gpb.Path{Elem: []*gpb.PathElem{{Name: "bad-element"}, {Name: "inner"}, {Name: "leaf-field"}}}).String()),
 		},
 	}
 
@@ -725,7 +725,7 @@ func TestNewNodeStructKeyedList(t *testing.T) {
 				},
 			},
 			want:       nil,
-			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond type *ygotutils.ListElemStruct4, remaining path elem:<name:"bad-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `),
+			wantStatus: toStatus(scpb.Code_NOT_FOUND, `could not find path in tree beyond type *ygotutils.ListElemStruct4, remaining path `+(&gpb.Path{Elem: []*gpb.PathElem{{Name: "bad-element"}, {Name: "inner"}, {Name: "leaf-field"}}}).String()),
 		},
 	}
 

--- a/testcmp/cmp_test.go
+++ b/testcmp/cmp_test.go
@@ -220,7 +220,7 @@ func TestGNMIUpdateComparer(t *testing.T) {
 			Val:  jsonIETF(`"value"`),
 		},
 		inSpec:           commonSpec,
-		wantErrSubstring: `cannot retrieve struct for path elem:<name:"system" > elem:<name:"config" > elem:<name:"fish" >`,
+		wantErrSubstring: `cannot retrieve struct for path ` + (&gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "system"}, {Name: "config"}, {Name: "fish"}}}).String(),
 	}, {
 		desc: "error: invalid path in B",
 		inA: &gnmipb.Update{
@@ -232,7 +232,7 @@ func TestGNMIUpdateComparer(t *testing.T) {
 			Val:  jsonIETF(`"value"`),
 		},
 		inSpec:           commonSpec,
-		wantErrSubstring: `cannot retrieve struct for path elem:<name:"system" > elem:<name:"config" > elem:<name:"chips" >`,
+		wantErrSubstring: `cannot retrieve struct for path ` + (&gnmipb.Path{Elem: []*gnmipb.PathElem{{Name: "system"}, {Name: "config"}, {Name: "chips"}}}).String(),
 	}, {
 		desc:             "error: nil spec",
 		inA:              &gnmipb.Update{},

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -1687,7 +1687,7 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: `could not find path in tree beyond schema node simple-key-list, (type *util.ListElemStruct1), remaining path elem:<name:"bad-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `,
+			wantErr: `could not find path in tree beyond schema node simple-key-list, (type *util.ListElemStruct1), remaining path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "bad-element"}, {Name: "inner"}, {Name: "leaf-field"}}}).String(),
 		},
 		{
 			desc:       "nil source field",
@@ -1742,7 +1742,7 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 				},
 			},
 			want:    []interface{}(nil),
-			wantErr: `gnmi path elem:<name:"simple-key-list" key:<key:"bad-key" value:"forty-two" > > elem:<name:"outer2" > elem:<name:"inner" > elem:<name:"leaf-field" >  does not contain a map entry for the schema key field name key1, parent type map[string]*util.ListElemStruct1`,
+			wantErr: `gnmi path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "simple-key-list", Key: map[string]string{"bad-key": "forty-two"}}, {Name: "outer2"}, {Name: "inner"}, {Name: "leaf-field"}}}).String() + ` does not contain a map entry for the schema key field name key1, parent type map[string]*util.ListElemStruct1`,
 		},
 		{
 			desc:       "missing key value",
@@ -2040,7 +2040,7 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 					},
 				},
 			},
-			wantErr: `could not find path in tree beyond schema node struct-key-list, (type *util.ListElemStruct2), remaining path elem:<name:"bad-path-element" > elem:<name:"inner" > elem:<name:"leaf-field" > `,
+			wantErr: `could not find path in tree beyond schema node struct-key-list, (type *util.ListElemStruct2), remaining path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "bad-path-element"}, {Name: "inner"}, {Name: "leaf-field"}}}).String(),
 		},
 	}
 

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -290,7 +290,7 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 					},
 				},
 			}},
-			wantErr: "could not find suitable union type to unmarshal value int_val:42",
+			wantErr: "could not find suitable union type to unmarshal value " + (&gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 42}}).String(),
 		},
 		{
 			desc: "bad array element",

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -1351,7 +1351,7 @@ func TestSetNode(t *testing.T) {
 			inParent:         &ListElemStruct1{},
 			inPath:           mustPath("/outer"),
 			inVal:            &gpb.TypedValue{},
-			wantErrSubstring: `path elem:<name:"outer" >  points to a node with non-leaf schema`,
+			wantErrSubstring: `path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "outer"}}}).String() + ` points to a node with non-leaf schema`,
 		},
 		{
 			inDesc:   "success setting annotation in top node",

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -667,7 +667,7 @@ func TestNewNode(t *testing.T) {
 			gnmiPath: toGNMIPath([]string{"bad", "path"}),
 			wantStatus: spb.Status{
 				Code:    int32(scpb.Code_NOT_FOUND),
-				Message: `could not find path in tree beyond type *exampleoc.Device, remaining path elem:<name:"bad" > elem:<name:"path" > `,
+				Message: `could not find path in tree beyond type *exampleoc.Device, remaining path ` + toGNMIPath([]string{"bad", "path"}).String(),
 			},
 		},
 	}
@@ -767,7 +767,7 @@ func TestGetNode(t *testing.T) {
 			},
 			wantStatus: spb.Status{
 				Code:    int32(scpb.Code_INVALID_ARGUMENT),
-				Message: `gnmi path elem:<name:"neighbor" key:<key:"bad-key-field" value:"address1" > > elem:<name:"apply-policy" >  does not contain a map entry for the schema key field name neighbor-address, parent type map[string]*exampleoc.Bgp_Neighbor`,
+				Message: `gnmi path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "neighbor", Key: map[string]string{"bad-key-field": "address1"}}, {Name: "apply-policy"}}}).String() + ` does not contain a map entry for the schema key field name neighbor-address, parent type map[string]*exampleoc.Bgp_Neighbor`,
 			},
 		},
 		{
@@ -793,7 +793,7 @@ func TestGetNode(t *testing.T) {
 			},
 			wantStatus: spb.Status{
 				Code:    int32(scpb.Code_NOT_FOUND),
-				Message: `could not find path in tree beyond schema node neighbor, (type map[string]*exampleoc.Bgp_Neighbor), remaining path elem:<name:"neighbor" key:<key:"neighbor-address" value:"bad key value" > > elem:<name:"apply-policy" > `,
+				Message: `could not find path in tree beyond schema node neighbor, (type map[string]*exampleoc.Bgp_Neighbor), remaining path ` + (&gpb.Path{Elem: []*gpb.PathElem{{Name: "neighbor", Key: map[string]string{"neighbor-address": "bad key value"}}, {Name: "apply-policy"}}}).String(),
 			},
 		},
 		{
@@ -801,7 +801,7 @@ func TestGetNode(t *testing.T) {
 			gnmiPath: toGNMIPath([]string{"bad", "path"}),
 			wantStatus: spb.Status{
 				Code:    int32(scpb.Code_NOT_FOUND),
-				Message: `could not find path in tree beyond schema node device, (type *exampleoc.Device), remaining path elem:<name:"bad" > elem:<name:"path" > `,
+				Message: `could not find path in tree beyond schema node device, (type *exampleoc.Device), remaining path ` + toGNMIPath([]string{"bad", "path"}).String(),
 			},
 		},
 	}


### PR DESCRIPTION
Syncing changes. Description below:

The Message.String method is intended for debugging and does not guarantee
output stability. Code that relies on the output being stable for all time is
brittle and has unintentionally become a change detector for the proto package.