### PR TITLE
Fix generic comparisons on protobuf messages

### DIFF
--- a/experimental/ygotutils/getnode_test.go
+++ b/experimental/ygotutils/getnode_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -293,7 +294,7 @@ func TestGetNodeSimpleKeyedList(t *testing.T) {
 
 	for _, tt := range tests {
 		val, status := GetNode(containerWithLeafListSchema, tt.rootStruct, tt.path)
-		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+		if got, want := status, tt.wantStatus; !proto.Equal(&got, &want) {
 			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
@@ -453,7 +454,7 @@ func TestGetNodeStructKeyedList(t *testing.T) {
 
 	for _, tt := range tests {
 		val, status := GetNode(containerWithLeafListSchema, tt.rootStruct, tt.path)
-		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+		if got, want := status, tt.wantStatus; !proto.Equal(&got, &want) {
 			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
@@ -597,7 +598,7 @@ func TestNewNodeSimpleKeyedList(t *testing.T) {
 
 	for _, tt := range tests {
 		val, status := NewNode(reflect.TypeOf(tt.rootStruct), tt.path)
-		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+		if got, want := status, tt.wantStatus; !proto.Equal(&got, &want) {
 			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
@@ -731,7 +732,7 @@ func TestNewNodeStructKeyedList(t *testing.T) {
 
 	for _, tt := range tests {
 		val, status := NewNode(reflect.TypeOf(tt.rootStruct), tt.path)
-		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+		if got, want := status, tt.wantStatus; !proto.Equal(&got, &want) {
 			t.Errorf("%s: got error: %v, wanted error? %v", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))

--- a/util/gnmi_test.go
+++ b/util/gnmi_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 
@@ -661,7 +661,7 @@ func TestFindModelData(t *testing.T) {
 			continue
 		}
 
-		if diff := pretty.Compare(got, tt.want); diff != "" {
+		if diff := cmp.Diff(got, tt.want, cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%s: FindModelData(%v): did not get expected result, diff(-got,+want):\n%s", tt.name, tt.in, diff)
 		}
 	}

--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -67,7 +67,7 @@ func (p *pathSpec) Equal(o *pathSpec) bool {
 	for _, path := range p.gNMIPaths {
 		var found bool
 		for _, otherPath := range o.gNMIPaths {
-			if reflect.DeepEqual(path, otherPath) {
+			if proto.Equal(path, otherPath) {
 				found = true
 				break
 			}

--- a/ygot/pathtranslate/pathtranslate_test.go
+++ b/ygot/pathtranslate/pathtranslate_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 
@@ -238,7 +240,7 @@ func TestPathElem(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(gotPath, tt.wantPath) {
+			if !cmp.Equal(gotPath, tt.wantPath, cmp.Comparer(proto.Equal)) {
 				t.Errorf("got %v, want %v", gotPath, tt.wantPath)
 			}
 		})

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/ygot/testutil"
@@ -145,7 +146,7 @@ func TestAppendName(t *testing.T) {
 			continue
 		}
 
-		if diff := pretty.Compare(tt.inPath, tt.want); diff != "" {
+		if diff := cmp.Diff(tt.inPath, tt.want, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%s: (gnmiPath)(%#v).AppendName(%s): did not get expected path, diff(-got,+want):\n%s", tt.name, tt.inPath, tt.inName, diff)
 		}
 	}
@@ -233,7 +234,7 @@ func TestGNMIPathOps(t *testing.T) {
 			t.Errorf("%s: %v.LastPathElem(): did not get expected error, got: %v, wantErr: %v", tt.name, tt.inPath, err, tt.wantLastPathElemErr)
 		}
 
-		if err == nil && !reflect.DeepEqual(gotLast, tt.wantLastPathElem) {
+		if err == nil && !proto.Equal(gotLast, tt.wantLastPathElem) {
 			t.Errorf("%s: %v.LastPathElem(), did not get expected last element, got: %v, want: %v", tt.name, tt.inPath, gotLast, tt.wantLastPathElem)
 		}
 
@@ -243,7 +244,7 @@ func TestGNMIPathOps(t *testing.T) {
 			t.Errorf("%s: %v.SetIndex(%d, %v): did not get expected error, got: %v, wantErr: %v", tt.name, tt.inPath, tt.inIndex, tt.inValue, err, tt.wantSetIndexErr)
 		}
 
-		if err == nil && !reflect.DeepEqual(np, tt.wantPath) {
+		if err == nil && !cmp.Equal(np, tt.wantPath, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)) {
 			t.Errorf("%s: %v.SetIndex(%d, %v): did not get expected path, got: %v, want: %v", tt.name, tt.inPath, tt.inIndex, tt.inValue, np, tt.wantPath)
 		}
 	}
@@ -438,7 +439,7 @@ func TestStripPrefix(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
+		if !cmp.Equal(got, tt.want, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)) {
 			t.Errorf("%s: stripPrefix(%v, %v): did not get expected path, got: %v, want: %v", tt.name, tt.inPath, tt.inPrefix, got, tt.want)
 		}
 	}
@@ -627,7 +628,7 @@ func TestAppendGNMIPathElemKey(t *testing.T) {
 			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected error status, got: %v, want error: %v", tt.name, tt.inValue, tt.inPath, err, tt.wantErr)
 		}
 
-		if diff := pretty.Compare(got, tt.wantPath); diff != "" {
+		if diff := cmp.Diff(got, tt.wantPath, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected return path, diff(-got,+want):\n%s", tt.name, tt.inValue, tt.inPath, diff)
 		}
 	}

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 
 	"github.com/openconfig/gnmi/errdiff"
@@ -173,7 +175,7 @@ func TestStructTagToLibPaths(t *testing.T) {
 			t.Errorf("%s: structTagToLibPaths(%v, %v): did not get expected error status, got: %v, want err: %v", tt.name, tt.inField, tt.inParent, err, tt.wantErr)
 		}
 
-		if diff := pretty.Compare(got, tt.want); diff != "" {
+		if diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
 			t.Errorf("%s: structTagToLibPaths(%v, %v): did not get expected set of map paths, diff(-got,+want):\n%s", tt.name, tt.inField, tt.inParent, diff)
 		}
 	}

--- a/ytypes/schema_tests/get_test.go
+++ b/ytypes/schema_tests/get_test.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openconfig/gnmi/errdiff"
@@ -169,7 +170,7 @@ func TestGetNodeFull(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(got, tt.wantNodes, ignoreSchema, cmpopts.EquateEmpty(), sortNodes); diff != "" {
+			if diff := cmp.Diff(got, tt.wantNodes, ignoreSchema, cmpopts.EquateEmpty(), sortNodes, cmp.Comparer(proto.Equal)); diff != "" {
 				t.Fatalf("did not get expected result, diff(-got,+want):\n%s", diff)
 			}
 		})

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/openconfig/ygot/experimental/ygotutils"
 	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/util"
@@ -808,7 +809,7 @@ func TestGetNode(t *testing.T) {
 
 	for _, tt := range tests {
 		n, status := ygotutils.GetNode(oc.SchemaTree["Device"], testDevice, tt.gnmiPath)
-		if got, want := status, tt.wantStatus; !reflect.DeepEqual(got, want) {
+		if got, want := status, tt.wantStatus; !proto.Equal(&got, &want) {
 			t.Errorf("%s: got status: %v, want status: %v ", tt.desc, got, want)
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))


### PR DESCRIPTION
Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.