### PR TITLE
protogenerator: improve handling of disallowed characters in proto enums

### DIFF
--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -155,6 +156,8 @@ type proto3Header struct {
 	YwrapperPath           string   // YwrapperPath is the path to the ywrapper.proto file, excluding the filename.
 	YextPath               string   // YextPath is the path to the yext.proto file, excluding the filename.
 }
+
+var disallowedInProtoIDRegexp = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 var (
 	// protoHeaderTemplate is populated and output at the top of the protobuf code output.
@@ -1084,13 +1087,9 @@ func safeProtoIdentifierName(name string) string {
 	// For Protobuf they must match:
 	//	ident = letter { letter | decimalDigit | "_" }
 	//
-	// Therefore we need to ensure that the "-", and "." characters that are allowed
-	// in the YANG are replaced.
-	replacer := strings.NewReplacer(
-		".", "_",
-		"-", "_",
-	)
-	return replacer.Replace(name)
+	// Therefore we need to replace all characters in the YANG identifier that are not a
+	// letter, digit, or underscore.
+	return disallowedInProtoIDRegexp.ReplaceAllLiteralString(name, "_")
 }
 
 // protoTagForEntry returns a protobuf tag value for the entry e.

--- a/ygen/protogen_test.go
+++ b/ygen/protogen_test.go
@@ -716,6 +716,22 @@ func TestSafeProtoName(t *testing.T) {
 		in:   "with.period",
 		want: "with_period",
 	}, {
+		name: "contains plus",
+		in:   "with+plus",
+		want: "with_plus",
+	}, {
+		name: "contains slash",
+		in:   "with/slash",
+		want: "with_slash",
+	}, {
+		name: "contains space",
+		in:   "with space",
+		want: "with_space",
+	}, {
+		name: "contains numbers",
+		in:   "with1_numbers234",
+		want: "with1_numbers234",
+	}, {
 		name: "unchanged",
 		in:   "unchanged",
 		want: "unchanged",

--- a/ygen/testdata/proto/proto-enums-addid.formatted-txt
+++ b/ygen/testdata/proto/proto-enums-addid.formatted-txt
@@ -16,7 +16,7 @@ import "openconfig/enums/enums.proto";
 message A {
   enum A {
     A_UNSET = 0;
-    A_C_VAL = 1 [(yext.yang_name) = "C_VAL"];
+    A_C_VAL_D_VAL = 1 [(yext.yang_name) = "C_VAL/D_VAL"];
   }
   enum D {
     D_UNSET = 0;

--- a/ygen/testdata/proto/proto-enums.formatted-txt
+++ b/ygen/testdata/proto/proto-enums.formatted-txt
@@ -15,7 +15,7 @@ import "openconfig/enums/enums.proto";
 message A {
   enum A {
     A_UNSET = 0;
-    A_C_VAL = 1;
+    A_C_VAL_D_VAL = 1;
   }
   enum D {
     D_UNSET = 0;

--- a/ygen/testdata/proto/proto-enums.yang
+++ b/ygen/testdata/proto/proto-enums.yang
@@ -34,7 +34,7 @@ module proto-enums {
   container a {
     leaf a {
       type enumeration {
-        enum C_VAL;
+        enum "C_VAL/D_VAL";
       }
     }
 


### PR DESCRIPTION
YANG enum value names can have slashes in them. Currently, the proto generator will include any slashes in the proto enum. 

E.g. this YANG enum value:
enum "Foo/Bar";

Becomes this proto enum value, which has in invalid slash in the name:
ENUMNAME_Foo/Bar = 491 [(yext.yang_name) = "Foo/Bar"];