### PR TITLE
Add duplicate path struct for each node (except the fake root)

### DIFF
--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -899,8 +899,18 @@ type ContainerWithConfig struct {
 	ygot.NodePath
 }
 
+// ContainerWithConfigΩ represents the wildcard version of the /root-module/container-with-config YANG schema element.
+type ContainerWithConfigΩ struct {
+	ygot.NodePath
+}
+
 // ContainerWithConfig_Leaf represents the /root-module/container-with-config/state/leaf YANG schema element.
 type ContainerWithConfig_Leaf struct {
+	ygot.NodePath
+}
+
+// ContainerWithConfig_LeafΩ represents the wildcard version of the /root-module/container-with-config/state/leaf YANG schema element.
+type ContainerWithConfig_LeafΩ struct {
 	ygot.NodePath
 }
 
@@ -909,8 +919,18 @@ type ContainerWithConfig_Leaflist struct {
 	ygot.NodePath
 }
 
+// ContainerWithConfig_LeaflistΩ represents the wildcard version of the /root-module/container-with-config/state/leaflist YANG schema element.
+type ContainerWithConfig_LeaflistΩ struct {
+	ygot.NodePath
+}
+
 // ContainerWithConfig_Leaflist2 represents the /root-module/container-with-config/state/leaflist2 YANG schema element.
 type ContainerWithConfig_Leaflist2 struct {
+	ygot.NodePath
+}
+
+// ContainerWithConfig_Leaflist2Ω represents the wildcard version of the /root-module/container-with-config/state/leaflist2 YANG schema element.
+type ContainerWithConfig_Leaflist2Ω struct {
 	ygot.NodePath
 }
 `,
@@ -967,6 +987,11 @@ func ForDevice(id string) *Device {
 
 // Leaf represents the /root-module/leaf YANG schema element.
 type Leaf struct {
+	ygot.NodePath
+}
+
+// LeafΩ represents the wildcard version of the /root-module/leaf YANG schema element.
+type LeafΩ struct {
 	ygot.NodePath
 }
 `,
@@ -1038,8 +1063,18 @@ type List struct {
 	ygot.NodePath
 }
 
+// ListΩ represents the wildcard version of the /root-module/list-container/list YANG schema element.
+type ListΩ struct {
+	ygot.NodePath
+}
+
 // List_Key1 represents the /root-module/list-container/list/key1 YANG schema element.
 type List_Key1 struct {
+	ygot.NodePath
+}
+
+// List_Key1Ω represents the wildcard version of the /root-module/list-container/list/key1 YANG schema element.
+type List_Key1Ω struct {
 	ygot.NodePath
 }
 
@@ -1048,8 +1083,18 @@ type List_Key2 struct {
 	ygot.NodePath
 }
 
+// List_Key2Ω represents the wildcard version of the /root-module/list-container/list/key2 YANG schema element.
+type List_Key2Ω struct {
+	ygot.NodePath
+}
+
 // List_UnionKey represents the /root-module/list-container/list/union-key YANG schema element.
 type List_UnionKey struct {
+	ygot.NodePath
+}
+
+// List_UnionKeyΩ represents the wildcard version of the /root-module/list-container/list/union-key YANG schema element.
+type List_UnionKeyΩ struct {
 	ygot.NodePath
 }
 `,

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -37,13 +37,28 @@ type ChoiceCaseAnonymousCase struct {
 	ygot.NodePath
 }
 
+// ChoiceCaseAnonymousCaseΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case YANG schema element.
+type ChoiceCaseAnonymousCaseΩ struct {
+	ygot.NodePath
+}
+
 // ChoiceCaseAnonymousCase_A represents the /choice-case-example/choice-case-anonymous-case/foo/a/a YANG schema element.
 type ChoiceCaseAnonymousCase_A struct {
 	ygot.NodePath
 }
 
+// ChoiceCaseAnonymousCase_AΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/a/a YANG schema element.
+type ChoiceCaseAnonymousCase_AΩ struct {
+	ygot.NodePath
+}
+
 // ChoiceCaseAnonymousCase_B represents the /choice-case-example/choice-case-anonymous-case/foo/b/b YANG schema element.
 type ChoiceCaseAnonymousCase_B struct {
+	ygot.NodePath
+}
+
+// ChoiceCaseAnonymousCase_BΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/b/b YANG schema element.
+type ChoiceCaseAnonymousCase_BΩ struct {
 	ygot.NodePath
 }
 
@@ -74,13 +89,28 @@ type ChoiceCaseWithLeafref struct {
 	ygot.NodePath
 }
 
+// ChoiceCaseWithLeafrefΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref YANG schema element.
+type ChoiceCaseWithLeafrefΩ struct {
+	ygot.NodePath
+}
+
 // ChoiceCaseWithLeafref_Ptr represents the /choice-case-example/choice-case-with-leafref/foo/bar/ptr YANG schema element.
 type ChoiceCaseWithLeafref_Ptr struct {
 	ygot.NodePath
 }
 
+// ChoiceCaseWithLeafref_PtrΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref/foo/bar/ptr YANG schema element.
+type ChoiceCaseWithLeafref_PtrΩ struct {
+	ygot.NodePath
+}
+
 // ChoiceCaseWithLeafref_Referenced represents the /choice-case-example/choice-case-with-leafref/referenced YANG schema element.
 type ChoiceCaseWithLeafref_Referenced struct {
+	ygot.NodePath
+}
+
+// ChoiceCaseWithLeafref_ReferencedΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref/referenced YANG schema element.
+type ChoiceCaseWithLeafref_ReferencedΩ struct {
 	ygot.NodePath
 }
 
@@ -154,13 +184,28 @@ type SimpleChoiceCase struct {
 	ygot.NodePath
 }
 
+// SimpleChoiceCaseΩ represents the wildcard version of the /choice-case-example/simple-choice-case YANG schema element.
+type SimpleChoiceCaseΩ struct {
+	ygot.NodePath
+}
+
 // SimpleChoiceCase_A represents the /choice-case-example/simple-choice-case/foo/bar/a YANG schema element.
 type SimpleChoiceCase_A struct {
 	ygot.NodePath
 }
 
+// SimpleChoiceCase_AΩ represents the wildcard version of the /choice-case-example/simple-choice-case/foo/bar/a YANG schema element.
+type SimpleChoiceCase_AΩ struct {
+	ygot.NodePath
+}
+
 // SimpleChoiceCase_B represents the /choice-case-example/simple-choice-case/foo/baz/b YANG schema element.
 type SimpleChoiceCase_B struct {
+	ygot.NodePath
+}
+
+// SimpleChoiceCase_BΩ represents the wildcard version of the /choice-case-example/simple-choice-case/foo/baz/b YANG schema element.
+type SimpleChoiceCase_BΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -37,8 +37,18 @@ type AList struct {
 	ygot.NodePath
 }
 
+// AListΩ represents the wildcard version of the /enum-module/a-lists/a-list YANG schema element.
+type AListΩ struct {
+	ygot.NodePath
+}
+
 // AList_Value represents the /enum-module/a-lists/a-list/state/value YANG schema element.
 type AList_Value struct {
+	ygot.NodePath
+}
+
+// AList_ValueΩ represents the wildcard version of the /enum-module/a-lists/a-list/state/value YANG schema element.
+type AList_ValueΩ struct {
 	ygot.NodePath
 }
 
@@ -58,8 +68,18 @@ type BList struct {
 	ygot.NodePath
 }
 
+// BListΩ represents the wildcard version of the /enum-module/b-lists/b-list YANG schema element.
+type BListΩ struct {
+	ygot.NodePath
+}
+
 // BList_Value represents the /enum-module/b-lists/b-list/state/value YANG schema element.
 type BList_Value struct {
+	ygot.NodePath
+}
+
+// BList_ValueΩ represents the wildcard version of the /enum-module/b-lists/b-list/state/value YANG schema element.
+type BList_ValueΩ struct {
 	ygot.NodePath
 }
 
@@ -79,8 +99,18 @@ type C struct {
 	ygot.NodePath
 }
 
+// CΩ represents the wildcard version of the /enum-module/c YANG schema element.
+type CΩ struct {
+	ygot.NodePath
+}
+
 // C_Cl represents the /enum-module/c/cl YANG schema element.
 type C_Cl struct {
+	ygot.NodePath
+}
+
+// C_ClΩ represents the wildcard version of the /enum-module/c/cl YANG schema element.
+type C_ClΩ struct {
 	ygot.NodePath
 }
 
@@ -154,6 +184,11 @@ type Parent struct {
 	ygot.NodePath
 }
 
+// ParentΩ represents the wildcard version of the /enum-module/parent YANG schema element.
+type ParentΩ struct {
+	ygot.NodePath
+}
+
 // Child returns from Parent the path struct for its child "child".
 func (n *Parent) Child() *Parent_Child {
 	return &Parent_Child{
@@ -170,8 +205,18 @@ type Parent_Child struct {
 	ygot.NodePath
 }
 
+// Parent_ChildΩ represents the wildcard version of the /enum-module/parent/child YANG schema element.
+type Parent_ChildΩ struct {
+	ygot.NodePath
+}
+
 // Parent_Child_Id represents the /enum-module/parent/child/state/id YANG schema element.
 type Parent_Child_Id struct {
+	ygot.NodePath
+}
+
+// Parent_Child_IdΩ represents the wildcard version of the /enum-module/parent/child/state/id YANG schema element.
+type Parent_Child_IdΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -70,8 +70,18 @@ type Native struct {
 	ygot.NodePath
 }
 
+// NativeΩ represents the wildcard version of the /openconfig-simple-target/native YANG schema element.
+type NativeΩ struct {
+	ygot.NodePath
+}
+
 // Native_A represents the /openconfig-simple-target/native/state/a YANG schema element.
 type Native_A struct {
+	ygot.NodePath
+}
+
+// Native_AΩ represents the wildcard version of the /openconfig-simple-target/native/state/a YANG schema element.
+type Native_AΩ struct {
 	ygot.NodePath
 }
 
@@ -91,6 +101,11 @@ type Target struct {
 	ygot.NodePath
 }
 
+// TargetΩ represents the wildcard version of the /openconfig-simple-target/target YANG schema element.
+type TargetΩ struct {
+	ygot.NodePath
+}
+
 // Foo returns from Target the path struct for its child "foo".
 func (n *Target) Foo() *Target_Foo {
 	return &Target_Foo{
@@ -107,8 +122,18 @@ type Target_Foo struct {
 	ygot.NodePath
 }
 
+// Target_FooΩ represents the wildcard version of the /openconfig-simple-target/target/foo YANG schema element.
+type Target_FooΩ struct {
+	ygot.NodePath
+}
+
 // Target_Foo_A represents the /openconfig-simple-target/target/foo/state/a YANG schema element.
 type Target_Foo_A struct {
+	ygot.NodePath
+}
+
+// Target_Foo_AΩ represents the wildcard version of the /openconfig-simple-target/target/foo/state/a YANG schema element.
+type Target_Foo_AΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-camelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase.path-txt
@@ -37,6 +37,11 @@ type BGP struct {
 	ygot.NodePath
 }
 
+// BGPΩ represents the wildcard version of the /openconfig-camelcase/bgp YANG schema element.
+type BGPΩ struct {
+	ygot.NodePath
+}
+
 // Neighbor returns from BGP the path struct for its child "neighbor".
 func (n *BGP) Neighbor(PeerIP string) *BGP_Neighbor {
 	return &BGP_Neighbor{
@@ -53,8 +58,18 @@ type BGP_Neighbor struct {
 	ygot.NodePath
 }
 
+// BGP_NeighborΩ represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor YANG schema element.
+type BGP_NeighborΩ struct {
+	ygot.NodePath
+}
+
 // BGP_Neighbor_PeerIP represents the /openconfig-camelcase/bgp/neighbors/neighbor/state/peer-ip YANG schema element.
 type BGP_Neighbor_PeerIP struct {
+	ygot.NodePath
+}
+
+// BGP_Neighbor_PeerIPΩ represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor/state/peer-ip YANG schema element.
+type BGP_Neighbor_PeerIPΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
@@ -58,13 +58,28 @@ type Foo struct {
 	ygot.NodePath
 }
 
+// FooΩ represents the wildcard version of the /openconfig-enumcamelcase/foo YANG schema element.
+type FooΩ struct {
+	ygot.NodePath
+}
+
 // Foo_Bar represents the /openconfig-enumcamelcase/foo/bar YANG schema element.
 type Foo_Bar struct {
 	ygot.NodePath
 }
 
+// Foo_BarΩ represents the wildcard version of the /openconfig-enumcamelcase/foo/bar YANG schema element.
+type Foo_BarΩ struct {
+	ygot.NodePath
+}
+
 // Foo_Baz represents the /openconfig-enumcamelcase/foo/baz YANG schema element.
 type Foo_Baz struct {
+	ygot.NodePath
+}
+
+// Foo_BazΩ represents the wildcard version of the /openconfig-enumcamelcase/foo/baz YANG schema element.
+type Foo_BazΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -69,6 +69,11 @@ type Parent struct {
 	ygot.NodePath
 }
 
+// ParentΩ represents the wildcard version of the /openconfig-simple/parent YANG schema element.
+type ParentΩ struct {
+	ygot.NodePath
+}
+
 // Child returns from Parent the path struct for its child "child".
 func (n *Parent) Child() *Parent_Child {
 	return &Parent_Child{
@@ -85,8 +90,18 @@ type Parent_Child struct {
 	ygot.NodePath
 }
 
+// Parent_ChildΩ represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
+type Parent_ChildΩ struct {
+	ygot.NodePath
+}
+
 // Parent_Child_Four represents the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_Four struct {
+	ygot.NodePath
+}
+
+// Parent_Child_FourΩ represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
+type Parent_Child_FourΩ struct {
 	ygot.NodePath
 }
 
@@ -95,13 +110,28 @@ type Parent_Child_One struct {
 	ygot.NodePath
 }
 
+// Parent_Child_OneΩ represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
+type Parent_Child_OneΩ struct {
+	ygot.NodePath
+}
+
 // Parent_Child_Three represents the /openconfig-simple/parent/child/state/three YANG schema element.
 type Parent_Child_Three struct {
 	ygot.NodePath
 }
 
+// Parent_Child_ThreeΩ represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
+type Parent_Child_ThreeΩ struct {
+	ygot.NodePath
+}
+
 // Parent_Child_Two represents the /openconfig-simple/parent/child/state/two YANG schema element.
 type Parent_Child_Two struct {
+	ygot.NodePath
+}
+
+// Parent_Child_TwoΩ represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoΩ struct {
 	ygot.NodePath
 }
 
@@ -154,8 +184,18 @@ type RemoteContainer struct {
 	ygot.NodePath
 }
 
+// RemoteContainerΩ represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
+type RemoteContainerΩ struct {
+	ygot.NodePath
+}
+
 // RemoteContainer_ALeaf represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
 type RemoteContainer_ALeaf struct {
+	ygot.NodePath
+}
+
+// RemoteContainer_ALeafΩ represents the wildcard version of the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
+type RemoteContainer_ALeafΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -69,13 +69,28 @@ type DupEnum struct {
 	ygot.NodePath
 }
 
+// DupEnumΩ represents the wildcard version of the /openconfig-unione/dup-enum YANG schema element.
+type DupEnumΩ struct {
+	ygot.NodePath
+}
+
 // DupEnum_A represents the /openconfig-unione/dup-enum/state/A YANG schema element.
 type DupEnum_A struct {
 	ygot.NodePath
 }
 
+// DupEnum_AΩ represents the wildcard version of the /openconfig-unione/dup-enum/state/A YANG schema element.
+type DupEnum_AΩ struct {
+	ygot.NodePath
+}
+
 // DupEnum_B represents the /openconfig-unione/dup-enum/state/B YANG schema element.
 type DupEnum_B struct {
+	ygot.NodePath
+}
+
+// DupEnum_BΩ represents the wildcard version of the /openconfig-unione/dup-enum/state/B YANG schema element.
+type DupEnum_BΩ struct {
 	ygot.NodePath
 }
 
@@ -106,6 +121,11 @@ type Platform struct {
 	ygot.NodePath
 }
 
+// PlatformΩ represents the wildcard version of the /openconfig-unione/platform YANG schema element.
+type PlatformΩ struct {
+	ygot.NodePath
+}
+
 // Component returns from Platform the path struct for its child "component".
 func (n *Platform) Component() *Platform_Component {
 	return &Platform_Component{
@@ -122,8 +142,18 @@ type Platform_Component struct {
 	ygot.NodePath
 }
 
+// Platform_ComponentΩ represents the wildcard version of the /openconfig-unione/platform/component YANG schema element.
+type Platform_ComponentΩ struct {
+	ygot.NodePath
+}
+
 // Platform_Component_E1 represents the /openconfig-unione/platform/component/state/e1 YANG schema element.
 type Platform_Component_E1 struct {
+	ygot.NodePath
+}
+
+// Platform_Component_E1Ω represents the wildcard version of the /openconfig-unione/platform/component/state/e1 YANG schema element.
+type Platform_Component_E1Ω struct {
 	ygot.NodePath
 }
 
@@ -132,8 +162,18 @@ type Platform_Component_Enumerated struct {
 	ygot.NodePath
 }
 
+// Platform_Component_EnumeratedΩ represents the wildcard version of the /openconfig-unione/platform/component/state/enumerated YANG schema element.
+type Platform_Component_EnumeratedΩ struct {
+	ygot.NodePath
+}
+
 // Platform_Component_Power represents the /openconfig-unione/platform/component/state/power YANG schema element.
 type Platform_Component_Power struct {
+	ygot.NodePath
+}
+
+// Platform_Component_PowerΩ represents the wildcard version of the /openconfig-unione/platform/component/state/power YANG schema element.
+type Platform_Component_PowerΩ struct {
 	ygot.NodePath
 }
 
@@ -142,8 +182,18 @@ type Platform_Component_R1 struct {
 	ygot.NodePath
 }
 
+// Platform_Component_R1Ω represents the wildcard version of the /openconfig-unione/platform/component/state/r1 YANG schema element.
+type Platform_Component_R1Ω struct {
+	ygot.NodePath
+}
+
 // Platform_Component_Type represents the /openconfig-unione/platform/component/state/type YANG schema element.
 type Platform_Component_Type struct {
+	ygot.NodePath
+}
+
+// Platform_Component_TypeΩ represents the wildcard version of the /openconfig-unione/platform/component/state/type YANG schema element.
+type Platform_Component_TypeΩ struct {
 	ygot.NodePath
 }
 

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -58,6 +58,11 @@ type Model struct {
 	ygot.NodePath
 }
 
+// ModelΩ represents the wildcard version of the /openconfig-withlist/model YANG schema element.
+type ModelΩ struct {
+	ygot.NodePath
+}
+
 // MultiKey returns from Model the path struct for its child "multi-key".
 func (n *Model) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKey {
 	return &Model_MultiKey{
@@ -85,13 +90,28 @@ type Model_MultiKey struct {
 	ygot.NodePath
 }
 
+// Model_MultiKeyΩ represents the wildcard version of the /openconfig-withlist/model/b/multi-key YANG schema element.
+type Model_MultiKeyΩ struct {
+	ygot.NodePath
+}
+
 // Model_MultiKey_Key1 represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
 type Model_MultiKey_Key1 struct {
 	ygot.NodePath
 }
 
+// Model_MultiKey_Key1Ω represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
+type Model_MultiKey_Key1Ω struct {
+	ygot.NodePath
+}
+
 // Model_MultiKey_Key2 represents the /openconfig-withlist/model/b/multi-key/state/key2 YANG schema element.
 type Model_MultiKey_Key2 struct {
+	ygot.NodePath
+}
+
+// Model_MultiKey_Key2Ω represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key2 YANG schema element.
+type Model_MultiKey_Key2Ω struct {
 	ygot.NodePath
 }
 
@@ -122,8 +142,18 @@ type Model_SingleKey struct {
 	ygot.NodePath
 }
 
+// Model_SingleKeyΩ represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
+type Model_SingleKeyΩ struct {
+	ygot.NodePath
+}
+
 // Model_SingleKey_Key represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.
 type Model_SingleKey_Key struct {
+	ygot.NodePath
+}
+
+// Model_SingleKey_KeyΩ represents the wildcard version of the /openconfig-withlist/model/a/single-key/state/key YANG schema element.
+type Model_SingleKey_KeyΩ struct {
 	ygot.NodePath
 }
 


### PR DESCRIPTION
The duplicate path structs are called "wildcard nodes". They are to resolve to paths that contain wildcards, while the non-wildcard versions of the path structs are to resolve to paths that do not contain any wildcard.

Wildcard here means a key value wildcard -- i.e. only when a keyed list is part of the path, may the path contain a wildcard.

Since a wildcard node is created for all but the fakeroot (which has an empty path), there are wildcard nodes whose paths cannot ever contain a wildcard (since they may not contain any lists). This is an optimization that may be done later.