### PR TITLE
Autogenerate child constructor methods for wildcard nodes.

### DIFF
--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -617,6 +617,97 @@ func getSchemaAndDirs() (*yang.Entry, map[string]*ygen.Directory, map[string]map
 	return schema, directories, leafTypeMap
 }
 
+// wantListMethods is the expected child constructor methods for the list node.
+const wantListMethods = `
+// ListAny returns from Device the path struct for its child "list".
+func (n *Device) ListAny() *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": "*", "key2": "*", "union-key": "*"},
+			n,
+		),
+	}
+}
+
+// ListAnyKey2AnyUnionKey returns from Device the path struct for its child "list".
+func (n *Device) ListAnyKey2AnyUnionKey(Key1 string) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": Key1, "key2": "*", "union-key": "*"},
+			n,
+		),
+	}
+}
+
+// ListAnyKey1AnyUnionKey returns from Device the path struct for its child "list".
+func (n *Device) ListAnyKey1AnyUnionKey(Key2 oc.Binary) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": "*", "key2": Key2, "union-key": "*"},
+			n,
+		),
+	}
+}
+
+// ListAnyUnionKey returns from Device the path struct for its child "list".
+func (n *Device) ListAnyUnionKey(Key1 string, Key2 oc.Binary) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": Key1, "key2": Key2, "union-key": "*"},
+			n,
+		),
+	}
+}
+
+// ListAnyKey1AnyKey2 returns from Device the path struct for its child "list".
+func (n *Device) ListAnyKey1AnyKey2(UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": "*", "key2": "*", "union-key": UnionKey},
+			n,
+		),
+	}
+}
+
+// ListAnyKey2 returns from Device the path struct for its child "list".
+func (n *Device) ListAnyKey2(Key1 string, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": Key1, "key2": "*", "union-key": UnionKey},
+			n,
+		),
+	}
+}
+
+// ListAnyKey1 returns from Device the path struct for its child "list".
+func (n *Device) ListAnyKey1(Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+	return &ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": "*", "key2": Key2, "union-key": UnionKey},
+			n,
+		),
+	}
+}
+
+// List returns from Device the path struct for its child "list".
+func (n *Device) List(Key1 string, Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *List {
+	return &List{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key1": Key1, "key2": Key2, "union-key": UnionKey},
+			n,
+		),
+	}
+}
+`
+
 func TestGetNodeDataMap(t *testing.T) {
 	_, directories, leafTypeMap := getSchemaAndDirs()
 
@@ -899,8 +990,8 @@ type ContainerWithConfig struct {
 	ygot.NodePath
 }
 
-// ContainerWithConfigΩ represents the wildcard version of the /root-module/container-with-config YANG schema element.
-type ContainerWithConfigΩ struct {
+// ContainerWithConfigAny represents the wildcard version of the /root-module/container-with-config YANG schema element.
+type ContainerWithConfigAny struct {
 	ygot.NodePath
 }
 
@@ -909,8 +1000,8 @@ type ContainerWithConfig_Leaf struct {
 	ygot.NodePath
 }
 
-// ContainerWithConfig_LeafΩ represents the wildcard version of the /root-module/container-with-config/state/leaf YANG schema element.
-type ContainerWithConfig_LeafΩ struct {
+// ContainerWithConfig_LeafAny represents the wildcard version of the /root-module/container-with-config/state/leaf YANG schema element.
+type ContainerWithConfig_LeafAny struct {
 	ygot.NodePath
 }
 
@@ -919,8 +1010,8 @@ type ContainerWithConfig_Leaflist struct {
 	ygot.NodePath
 }
 
-// ContainerWithConfig_LeaflistΩ represents the wildcard version of the /root-module/container-with-config/state/leaflist YANG schema element.
-type ContainerWithConfig_LeaflistΩ struct {
+// ContainerWithConfig_LeaflistAny represents the wildcard version of the /root-module/container-with-config/state/leaflist YANG schema element.
+type ContainerWithConfig_LeaflistAny struct {
 	ygot.NodePath
 }
 
@@ -929,8 +1020,8 @@ type ContainerWithConfig_Leaflist2 struct {
 	ygot.NodePath
 }
 
-// ContainerWithConfig_Leaflist2Ω represents the wildcard version of the /root-module/container-with-config/state/leaflist2 YANG schema element.
-type ContainerWithConfig_Leaflist2Ω struct {
+// ContainerWithConfig_Leaflist2Any represents the wildcard version of the /root-module/container-with-config/state/leaflist2 YANG schema element.
+type ContainerWithConfig_Leaflist2Any struct {
 	ygot.NodePath
 }
 `,
@@ -938,6 +1029,17 @@ type ContainerWithConfig_Leaflist2Ω struct {
 // Leaf returns from ContainerWithConfig the path struct for its child "leaf".
 func (n *ContainerWithConfig) Leaf() *ContainerWithConfig_Leaf {
 	return &ContainerWithConfig_Leaf{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "leaf"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Leaf returns from ContainerWithConfigAny the path struct for its child "leaf".
+func (n *ContainerWithConfigAny) Leaf() *ContainerWithConfig_LeafAny {
+	return &ContainerWithConfig_LeafAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "leaf"},
 			map[string]interface{}{},
@@ -957,9 +1059,31 @@ func (n *ContainerWithConfig) Leaflist() *ContainerWithConfig_Leaflist {
 	}
 }
 
+// Leaflist returns from ContainerWithConfigAny the path struct for its child "leaflist".
+func (n *ContainerWithConfigAny) Leaflist() *ContainerWithConfig_LeaflistAny {
+	return &ContainerWithConfig_LeaflistAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "leaflist"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Leaflist2 returns from ContainerWithConfig the path struct for its child "leaflist2".
 func (n *ContainerWithConfig) Leaflist2() *ContainerWithConfig_Leaflist2 {
 	return &ContainerWithConfig_Leaflist2{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "leaflist2"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Leaflist2 returns from ContainerWithConfigAny the path struct for its child "leaflist2".
+func (n *ContainerWithConfigAny) Leaflist2() *ContainerWithConfig_Leaflist2Any {
+	return &ContainerWithConfig_Leaflist2Any{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "leaflist2"},
 			map[string]interface{}{},
@@ -990,8 +1114,8 @@ type Leaf struct {
 	ygot.NodePath
 }
 
-// LeafΩ represents the wildcard version of the /root-module/leaf YANG schema element.
-type LeafΩ struct {
+// LeafAny represents the wildcard version of the /root-module/leaf YANG schema element.
+type LeafAny struct {
 	ygot.NodePath
 }
 `,
@@ -1028,13 +1152,13 @@ func (n *Device) Leaf() *Leaf {
 		),
 	}
 }
-
-// List returns from Device the path struct for its child "list".
-func (n *Device) List(Key1 string, Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *List {
-	return &List{
+` + wantListMethods + `
+// ListWithStateAny returns from Device the path struct for its child "list-with-state".
+func (n *Device) ListWithStateAny() *ListWithStateAny {
+	return &ListWithStateAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"list-container", "list"},
-			map[string]interface{}{"key1": Key1, "key2": Key2, "union-key": UnionKey},
+			[]string{"list-container-with-state", "list-with-state"},
+			map[string]interface{}{"key": "*"},
 			n,
 		),
 	}
@@ -1063,8 +1187,8 @@ type List struct {
 	ygot.NodePath
 }
 
-// ListΩ represents the wildcard version of the /root-module/list-container/list YANG schema element.
-type ListΩ struct {
+// ListAny represents the wildcard version of the /root-module/list-container/list YANG schema element.
+type ListAny struct {
 	ygot.NodePath
 }
 
@@ -1073,8 +1197,8 @@ type List_Key1 struct {
 	ygot.NodePath
 }
 
-// List_Key1Ω represents the wildcard version of the /root-module/list-container/list/key1 YANG schema element.
-type List_Key1Ω struct {
+// List_Key1Any represents the wildcard version of the /root-module/list-container/list/key1 YANG schema element.
+type List_Key1Any struct {
 	ygot.NodePath
 }
 
@@ -1083,8 +1207,8 @@ type List_Key2 struct {
 	ygot.NodePath
 }
 
-// List_Key2Ω represents the wildcard version of the /root-module/list-container/list/key2 YANG schema element.
-type List_Key2Ω struct {
+// List_Key2Any represents the wildcard version of the /root-module/list-container/list/key2 YANG schema element.
+type List_Key2Any struct {
 	ygot.NodePath
 }
 
@@ -1093,8 +1217,8 @@ type List_UnionKey struct {
 	ygot.NodePath
 }
 
-// List_UnionKeyΩ represents the wildcard version of the /root-module/list-container/list/union-key YANG schema element.
-type List_UnionKeyΩ struct {
+// List_UnionKeyAny represents the wildcard version of the /root-module/list-container/list/union-key YANG schema element.
+type List_UnionKeyAny struct {
 	ygot.NodePath
 }
 `,
@@ -1102,6 +1226,17 @@ type List_UnionKeyΩ struct {
 // Key1 returns from List the path struct for its child "key1".
 func (n *List) Key1() *List_Key1 {
 	return &List_Key1{
+		NodePath: ygot.NewNodePath(
+			[]string{"key1"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key1 returns from ListAny the path struct for its child "key1".
+func (n *ListAny) Key1() *List_Key1Any {
+	return &List_Key1Any{
 		NodePath: ygot.NewNodePath(
 			[]string{"key1"},
 			map[string]interface{}{},
@@ -1121,9 +1256,31 @@ func (n *List) Key2() *List_Key2 {
 	}
 }
 
+// Key2 returns from ListAny the path struct for its child "key2".
+func (n *ListAny) Key2() *List_Key2Any {
+	return &List_Key2Any{
+		NodePath: ygot.NewNodePath(
+			[]string{"key2"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // UnionKey returns from List the path struct for its child "union-key".
 func (n *List) UnionKey() *List_UnionKey {
 	return &List_UnionKey{
+		NodePath: ygot.NewNodePath(
+			[]string{"union-key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// UnionKey returns from ListAny the path struct for its child "union-key".
+func (n *ListAny) UnionKey() *List_UnionKeyAny {
+	return &List_UnionKeyAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"union-key"},
 			map[string]interface{}{},
@@ -1152,16 +1309,114 @@ func (n *List) UnionKey() *List_UnionKey {
 func TestGenerateChildConstructor(t *testing.T) {
 	_, directories, _ := getSchemaAndDirs()
 
+	deepSchema := &yang.Entry{
+		Name: "root-module",
+		Kind: yang.DirectoryEntry,
+		Dir: map[string]*yang.Entry{
+			"container": {
+				Name: "container",
+				Kind: yang.DirectoryEntry,
+				Dir: map[string]*yang.Entry{
+					"leaf": {
+						Name: "leaf",
+						Kind: yang.LeafEntry,
+						Type: &yang.YangType{Kind: yang.Yint32},
+					},
+					"list-container": {
+						Name: "list-container",
+						Kind: yang.DirectoryEntry,
+						Dir: map[string]*yang.Entry{
+							"list": {
+								Name:     "list",
+								Kind:     yang.DirectoryEntry,
+								ListAttr: &yang.ListAttr{},
+								Dir: map[string]*yang.Entry{
+									"key": {
+										Name: "key",
+										Kind: yang.LeafEntry,
+										Type: &yang.YangType{Kind: yang.Ystring},
+									},
+								},
+							},
+						},
+					},
+					"inner-container": {
+						Name: "inner-container",
+						Kind: yang.DirectoryEntry,
+						Dir: map[string]*yang.Entry{
+							"inner-leaf": {
+								Name: "inner-leaf",
+								Kind: yang.LeafEntry,
+								Type: &yang.YangType{Kind: yang.Yint32},
+							},
+						},
+					},
+				},
+			},
+		},
+		Annotation: map[string]interface{}{"isCompressedSchema": true},
+	}
+	addParents(deepSchema)
+
+	// Build fake root.
+	fakeRoot := ygen.MakeFakeRoot("device")
+	for k, v := range deepSchema.Dir {
+		fakeRoot.Dir[k] = v
+	}
+
+	deepSchemaDirectories := map[string]*ygen.Directory{
+		"/device": {
+			Name: "Device",
+			Fields: map[string]*yang.Entry{
+				"container": deepSchema.Dir["container"],
+			},
+			Path:  []string{"", "device"},
+			Entry: fakeRoot,
+		},
+		"/root-module/container": {
+			Name: "Container",
+			Fields: map[string]*yang.Entry{
+				"list":            deepSchema.Dir["container"].Dir["list-container"].Dir["list"],
+				"inner-container": deepSchema.Dir["container"].Dir["inner-container"],
+			},
+			Path:  []string{"", "root-module", "container"},
+			Entry: deepSchema.Dir["container"],
+		},
+		"/root-module/container/list-container/list": {
+			Name: "Container_List",
+			ListAttr: &ygen.YangListAttr{
+				Keys: map[string]*ygen.MappedType{
+					"key": {NativeType: "string"},
+				},
+				KeyElems: []*yang.Entry{{Name: "key"}},
+			},
+			Fields: map[string]*yang.Entry{
+				"key": deepSchema.Dir["container"].Dir["list-container"].Dir["list"].Dir["key"],
+			},
+			Path:  []string{"", "root-module", "container", "list-container", "list"},
+			Entry: deepSchema.Dir["container"].Dir["list-container"],
+		},
+		"/root-module/container/inner-container": {
+			Name: "Container_InnerContainer",
+			Fields: map[string]*yang.Entry{
+				"leaf": deepSchema.Dir["container"].Dir["inner-container"].Dir["leaf"],
+			},
+			Path:  []string{"", "root-module", "container", "inner-container"},
+			Entry: deepSchema.Dir["container"].Dir["inner-container"],
+		},
+	}
+
 	tests := []struct {
 		name              string
 		inDirectory       *ygen.Directory
+		inDirectories     map[string]*ygen.Directory
 		inFieldName       string
 		inUniqueFieldName string
-		wantErrSubstr     string
 		want              string
 	}{{
 		name:              "container method",
 		inDirectory:       directories["/device"],
+		inDirectories:     directories,
 		inFieldName:       "container",
 		inUniqueFieldName: "Container",
 		want: `
@@ -1179,6 +1434,7 @@ func (n *Device) Container() *Container {
 	}, {
 		name:              "container leaf method",
 		inDirectory:       directories["/root-module/container"],
+		inDirectories:     directories,
 		inFieldName:       "leaf",
 		inUniqueFieldName: "Leaf",
 		want: `
@@ -1192,10 +1448,22 @@ func (n *Container) Leaf() *Container_Leaf {
 		),
 	}
 }
+
+// Leaf returns from ContainerAny the path struct for its child "leaf".
+func (n *ContainerAny) Leaf() *Container_LeafAny {
+	return &Container_LeafAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"leaf"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
 `,
 	}, {
 		name:              "top-level leaf method",
 		inDirectory:       directories["/device"],
+		inDirectories:     directories,
 		inFieldName:       "leaf",
 		inUniqueFieldName: "Leaf",
 		want: `
@@ -1213,6 +1481,7 @@ func (n *Device) Leaf() *Leaf {
 	}, {
 		name:              "container-with-config leaf method",
 		inDirectory:       directories["/root-module/container-with-config"],
+		inDirectories:     directories,
 		inFieldName:       "leaf",
 		inUniqueFieldName: "Leaf",
 		want: `
@@ -1226,30 +1495,123 @@ func (n *ContainerWithConfig) Leaf() *ContainerWithConfig_Leaf {
 		),
 	}
 }
-`,
-	}, {
-		name:              "list method",
-		inDirectory:       directories["/device"],
-		inFieldName:       "list",
-		inUniqueFieldName: "List",
-		want: `
-// List returns from Device the path struct for its child "list".
-func (n *Device) List(Key1 string, Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *List {
-	return &List{
+
+// Leaf returns from ContainerWithConfigAny the path struct for its child "leaf".
+func (n *ContainerWithConfigAny) Leaf() *ContainerWithConfig_LeafAny {
+	return &ContainerWithConfig_LeafAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"list-container", "list"},
-			map[string]interface{}{"key1": Key1, "key2": Key2, "union-key": UnionKey},
+			[]string{"state", "leaf"},
+			map[string]interface{}{},
 			n,
 		),
 	}
 }
 `,
 	}, {
+		name:              "2nd-level list methods",
+		inDirectory:       deepSchemaDirectories["/root-module/container"],
+		inDirectories:     deepSchemaDirectories,
+		inFieldName:       "list",
+		inUniqueFieldName: "List",
+		want: `
+// ListAny returns from Container the path struct for its child "list".
+func (n *Container) ListAny() *Container_ListAny {
+	return &Container_ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// ListAny returns from ContainerAny the path struct for its child "list".
+func (n *ContainerAny) ListAny() *Container_ListAny {
+	return &Container_ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// List returns from Container the path struct for its child "list".
+func (n *Container) List(Key string) *Container_List {
+	return &Container_List{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// List returns from ContainerAny the path struct for its child "list".
+func (n *ContainerAny) List(Key string) *Container_ListAny {
+	return &Container_ListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container", "list"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+`,
+	}, {
+		name:              "inner container",
+		inDirectory:       deepSchemaDirectories["/root-module/container"],
+		inDirectories:     deepSchemaDirectories,
+		inFieldName:       "inner-container",
+		inUniqueFieldName: "InnerContainer",
+		want: `
+// InnerContainer returns from Container the path struct for its child "inner-container".
+func (n *Container) InnerContainer() *Container_InnerContainer {
+	return &Container_InnerContainer{
+		NodePath: ygot.NewNodePath(
+			[]string{"inner-container"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// InnerContainer returns from ContainerAny the path struct for its child "inner-container".
+func (n *ContainerAny) InnerContainer() *Container_InnerContainerAny {
+	return &Container_InnerContainerAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"inner-container"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+`,
+	}, {
+		name:              "list method",
+		inDirectory:       directories["/device"],
+		inDirectories:     directories,
+		inFieldName:       "list",
+		inUniqueFieldName: "List",
+		want:              wantListMethods,
+	}, {
 		name:              "list with state method",
 		inDirectory:       directories["/device"],
+		inDirectories:     directories,
 		inFieldName:       "list-with-state",
 		inUniqueFieldName: "ListWithState",
 		want: `
+// ListWithStateAny returns from Device the path struct for its child "list-with-state".
+func (n *Device) ListWithStateAny() *ListWithStateAny {
+	return &ListWithStateAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"list-container-with-state", "list-with-state"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
 // ListWithState returns from Device the path struct for its child "list-with-state".
 func (n *Device) ListWithState(Key float64) *ListWithState {
 	return &ListWithState{
@@ -1266,25 +1628,23 @@ func (n *Device) ListWithState(Key float64) *ListWithState {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			var gotErr error
-			gotErr = generateChildConstructor(&buf, tt.inDirectory, tt.inFieldName, tt.inUniqueFieldName, directories, "oc")
-			if diff := errdiff.Check(gotErr, tt.wantErrSubstr); diff != "" {
-				t.Fatalf("func generateChildConstructor, %v", diff)
+			if errs := generateChildConstructors(&buf, tt.inDirectory, tt.inFieldName, tt.inUniqueFieldName, tt.inDirectories, "oc"); errs != nil {
+				t.Fatal(errs)
 			}
 
 			if got, want := buf.String(), tt.want; got != want {
 				diff, _ := testutil.GenerateUnifiedDiff(got, want)
-				t.Errorf("func generateChildConstructor returned incorrect code, diff:\n%s", diff)
+				t.Errorf("func generateChildConstructors returned incorrect code, diff:\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestGenerateParamListStr(t *testing.T) {
+func TestGenerateParamListStrs(t *testing.T) {
 	tests := []struct {
 		name             string
 		in               *ygen.YangListAttr
-		want             string
+		want             []string
 		wantErrSubstring string
 	}{{
 		name:             "empty listattr",
@@ -1296,14 +1656,14 @@ func TestGenerateParamListStr(t *testing.T) {
 			Keys:     map[string]*ygen.MappedType{"fluorine": {NativeType: "string"}},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}},
 		},
-		want: "Fluorine string",
+		want: []string{"Fluorine string"},
 	}, {
 		name: "simple int param, also testing camel-case",
 		in: &ygen.YangListAttr{
 			Keys:     map[string]*ygen.MappedType{"cl-cl": {NativeType: "int"}},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}},
 		},
-		want: "ClCl int",
+		want: []string{"ClCl int"},
 	}, {
 		name: "name uniquification",
 		in: &ygen.YangListAttr{
@@ -1313,14 +1673,14 @@ func TestGenerateParamListStr(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}, {Name: "clCl"}},
 		},
-		want: "ClCl int, ClCl_ int",
+		want: []string{"ClCl int", "ClCl_ int"},
 	}, {
 		name: "unsupported type",
 		in: &ygen.YangListAttr{
 			Keys:     map[string]*ygen.MappedType{"fluorine": {NativeType: "interface{}"}},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}},
 		},
-		want: "Fluorine string",
+		want: []string{"Fluorine string"},
 	}, {
 		name: "keyElems doesn't match keys",
 		in: &ygen.YangListAttr{
@@ -1346,7 +1706,7 @@ func TestGenerateParamListStr(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}, {Name: "cl-cl"}, {Name: "bromine"}, {Name: "iodine"}},
 		},
-		want: "Fluorine string, ClCl int, Bromine complex128, Iodine float64",
+		want: []string{"Fluorine string", "ClCl int", "Bromine complex128", "Iodine float64"},
 	}, {
 		name: "enumerated and union parameters",
 		in: &ygen.YangListAttr{
@@ -1356,7 +1716,7 @@ func TestGenerateParamListStr(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "astatine"}, {Name: "tennessine"}},
 		},
-		want: "Astatine oc.Halogen, Tennessine oc.Ununseptium",
+		want: []string{"Astatine oc.Halogen", "Tennessine oc.Ununseptium"},
 	}, {
 		name: "Binary and Empty",
 		in: &ygen.YangListAttr{
@@ -1366,18 +1726,51 @@ func TestGenerateParamListStr(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}, {Name: "bromine"}},
 		},
-		want: "ClCl oc.YANGEmpty, Bromine oc.Binary",
+		want: []string{"ClCl oc.YANGEmpty", "Bromine oc.Binary"},
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeParamListStr(tt.in, "oc")
-			if got != tt.want {
-				t.Errorf("func makeParamListStr\nwant: %s\ngot: %s", tt.want, got)
+			got, err := makeParamListStrs(tt.in, "oc")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 
 			if diff := errdiff.Check(err, tt.wantErrSubstring); diff != "" {
-				t.Errorf("func makeParamListStr, %v", diff)
+				t.Errorf("func makeParamListStrs, %v", diff)
+			}
+		})
+	}
+}
+
+func TestCombinations(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want [][]int
+	}{{
+		name: "n = 0",
+		in:   0,
+		want: [][]int{{}},
+	}, {
+		name: "n = 1",
+		in:   1,
+		want: [][]int{{}, {0}},
+	}, {
+		name: "n = 2",
+		in:   2,
+		want: [][]int{{}, {0}, {1}, {0, 1}},
+	}, {
+		name: "n = 3",
+		in:   3,
+		want: [][]int{{}, {0}, {1}, {0, 1}, {2}, {0, 2}, {1, 2}, {0, 1, 2}},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := combinations(tt.in)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -37,8 +37,8 @@ type ChoiceCaseAnonymousCase struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseAnonymousCaseΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case YANG schema element.
-type ChoiceCaseAnonymousCaseΩ struct {
+// ChoiceCaseAnonymousCaseAny represents the wildcard version of the /choice-case-example/choice-case-anonymous-case YANG schema element.
+type ChoiceCaseAnonymousCaseAny struct {
 	ygot.NodePath
 }
 
@@ -47,8 +47,8 @@ type ChoiceCaseAnonymousCase_A struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseAnonymousCase_AΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/a/a YANG schema element.
-type ChoiceCaseAnonymousCase_AΩ struct {
+// ChoiceCaseAnonymousCase_AAny represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/a/a YANG schema element.
+type ChoiceCaseAnonymousCase_AAny struct {
 	ygot.NodePath
 }
 
@@ -57,14 +57,25 @@ type ChoiceCaseAnonymousCase_B struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseAnonymousCase_BΩ represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/b/b YANG schema element.
-type ChoiceCaseAnonymousCase_BΩ struct {
+// ChoiceCaseAnonymousCase_BAny represents the wildcard version of the /choice-case-example/choice-case-anonymous-case/foo/b/b YANG schema element.
+type ChoiceCaseAnonymousCase_BAny struct {
 	ygot.NodePath
 }
 
 // A returns from ChoiceCaseAnonymousCase the path struct for its child "a".
 func (n *ChoiceCaseAnonymousCase) A() *ChoiceCaseAnonymousCase_A {
 	return &ChoiceCaseAnonymousCase_A{
+		NodePath: ygot.NewNodePath(
+			[]string{"a"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// A returns from ChoiceCaseAnonymousCaseAny the path struct for its child "a".
+func (n *ChoiceCaseAnonymousCaseAny) A() *ChoiceCaseAnonymousCase_AAny {
+	return &ChoiceCaseAnonymousCase_AAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"a"},
 			map[string]interface{}{},
@@ -84,13 +95,24 @@ func (n *ChoiceCaseAnonymousCase) B() *ChoiceCaseAnonymousCase_B {
 	}
 }
 
+// B returns from ChoiceCaseAnonymousCaseAny the path struct for its child "b".
+func (n *ChoiceCaseAnonymousCaseAny) B() *ChoiceCaseAnonymousCase_BAny {
+	return &ChoiceCaseAnonymousCase_BAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // ChoiceCaseWithLeafref represents the /choice-case-example/choice-case-with-leafref YANG schema element.
 type ChoiceCaseWithLeafref struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseWithLeafrefΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref YANG schema element.
-type ChoiceCaseWithLeafrefΩ struct {
+// ChoiceCaseWithLeafrefAny represents the wildcard version of the /choice-case-example/choice-case-with-leafref YANG schema element.
+type ChoiceCaseWithLeafrefAny struct {
 	ygot.NodePath
 }
 
@@ -99,8 +121,8 @@ type ChoiceCaseWithLeafref_Ptr struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseWithLeafref_PtrΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref/foo/bar/ptr YANG schema element.
-type ChoiceCaseWithLeafref_PtrΩ struct {
+// ChoiceCaseWithLeafref_PtrAny represents the wildcard version of the /choice-case-example/choice-case-with-leafref/foo/bar/ptr YANG schema element.
+type ChoiceCaseWithLeafref_PtrAny struct {
 	ygot.NodePath
 }
 
@@ -109,8 +131,8 @@ type ChoiceCaseWithLeafref_Referenced struct {
 	ygot.NodePath
 }
 
-// ChoiceCaseWithLeafref_ReferencedΩ represents the wildcard version of the /choice-case-example/choice-case-with-leafref/referenced YANG schema element.
-type ChoiceCaseWithLeafref_ReferencedΩ struct {
+// ChoiceCaseWithLeafref_ReferencedAny represents the wildcard version of the /choice-case-example/choice-case-with-leafref/referenced YANG schema element.
+type ChoiceCaseWithLeafref_ReferencedAny struct {
 	ygot.NodePath
 }
 
@@ -125,9 +147,31 @@ func (n *ChoiceCaseWithLeafref) Ptr() *ChoiceCaseWithLeafref_Ptr {
 	}
 }
 
+// Ptr returns from ChoiceCaseWithLeafrefAny the path struct for its child "ptr".
+func (n *ChoiceCaseWithLeafrefAny) Ptr() *ChoiceCaseWithLeafref_PtrAny {
+	return &ChoiceCaseWithLeafref_PtrAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"ptr"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Referenced returns from ChoiceCaseWithLeafref the path struct for its child "referenced".
 func (n *ChoiceCaseWithLeafref) Referenced() *ChoiceCaseWithLeafref_Referenced {
 	return &ChoiceCaseWithLeafref_Referenced{
+		NodePath: ygot.NewNodePath(
+			[]string{"referenced"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Referenced returns from ChoiceCaseWithLeafrefAny the path struct for its child "referenced".
+func (n *ChoiceCaseWithLeafrefAny) Referenced() *ChoiceCaseWithLeafref_ReferencedAny {
+	return &ChoiceCaseWithLeafref_ReferencedAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"referenced"},
 			map[string]interface{}{},
@@ -184,8 +228,8 @@ type SimpleChoiceCase struct {
 	ygot.NodePath
 }
 
-// SimpleChoiceCaseΩ represents the wildcard version of the /choice-case-example/simple-choice-case YANG schema element.
-type SimpleChoiceCaseΩ struct {
+// SimpleChoiceCaseAny represents the wildcard version of the /choice-case-example/simple-choice-case YANG schema element.
+type SimpleChoiceCaseAny struct {
 	ygot.NodePath
 }
 
@@ -194,8 +238,8 @@ type SimpleChoiceCase_A struct {
 	ygot.NodePath
 }
 
-// SimpleChoiceCase_AΩ represents the wildcard version of the /choice-case-example/simple-choice-case/foo/bar/a YANG schema element.
-type SimpleChoiceCase_AΩ struct {
+// SimpleChoiceCase_AAny represents the wildcard version of the /choice-case-example/simple-choice-case/foo/bar/a YANG schema element.
+type SimpleChoiceCase_AAny struct {
 	ygot.NodePath
 }
 
@@ -204,8 +248,8 @@ type SimpleChoiceCase_B struct {
 	ygot.NodePath
 }
 
-// SimpleChoiceCase_BΩ represents the wildcard version of the /choice-case-example/simple-choice-case/foo/baz/b YANG schema element.
-type SimpleChoiceCase_BΩ struct {
+// SimpleChoiceCase_BAny represents the wildcard version of the /choice-case-example/simple-choice-case/foo/baz/b YANG schema element.
+type SimpleChoiceCase_BAny struct {
 	ygot.NodePath
 }
 
@@ -220,9 +264,31 @@ func (n *SimpleChoiceCase) A() *SimpleChoiceCase_A {
 	}
 }
 
+// A returns from SimpleChoiceCaseAny the path struct for its child "a".
+func (n *SimpleChoiceCaseAny) A() *SimpleChoiceCase_AAny {
+	return &SimpleChoiceCase_AAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"a"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // B returns from SimpleChoiceCase the path struct for its child "b".
 func (n *SimpleChoiceCase) B() *SimpleChoiceCase_B {
 	return &SimpleChoiceCase_B{
+		NodePath: ygot.NewNodePath(
+			[]string{"b"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// B returns from SimpleChoiceCaseAny the path struct for its child "b".
+func (n *SimpleChoiceCaseAny) B() *SimpleChoiceCase_BAny {
+	return &SimpleChoiceCase_BAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"b"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -37,8 +37,8 @@ type AList struct {
 	ygot.NodePath
 }
 
-// AListΩ represents the wildcard version of the /enum-module/a-lists/a-list YANG schema element.
-type AListΩ struct {
+// AListAny represents the wildcard version of the /enum-module/a-lists/a-list YANG schema element.
+type AListAny struct {
 	ygot.NodePath
 }
 
@@ -47,8 +47,8 @@ type AList_Value struct {
 	ygot.NodePath
 }
 
-// AList_ValueΩ represents the wildcard version of the /enum-module/a-lists/a-list/state/value YANG schema element.
-type AList_ValueΩ struct {
+// AList_ValueAny represents the wildcard version of the /enum-module/a-lists/a-list/state/value YANG schema element.
+type AList_ValueAny struct {
 	ygot.NodePath
 }
 
@@ -63,13 +63,24 @@ func (n *AList) Value() *AList_Value {
 	}
 }
 
+// Value returns from AListAny the path struct for its child "value".
+func (n *AListAny) Value() *AList_ValueAny {
+	return &AList_ValueAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "value"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // BList represents the /enum-module/b-lists/b-list YANG schema element.
 type BList struct {
 	ygot.NodePath
 }
 
-// BListΩ represents the wildcard version of the /enum-module/b-lists/b-list YANG schema element.
-type BListΩ struct {
+// BListAny represents the wildcard version of the /enum-module/b-lists/b-list YANG schema element.
+type BListAny struct {
 	ygot.NodePath
 }
 
@@ -78,8 +89,8 @@ type BList_Value struct {
 	ygot.NodePath
 }
 
-// BList_ValueΩ represents the wildcard version of the /enum-module/b-lists/b-list/state/value YANG schema element.
-type BList_ValueΩ struct {
+// BList_ValueAny represents the wildcard version of the /enum-module/b-lists/b-list/state/value YANG schema element.
+type BList_ValueAny struct {
 	ygot.NodePath
 }
 
@@ -94,13 +105,24 @@ func (n *BList) Value() *BList_Value {
 	}
 }
 
+// Value returns from BListAny the path struct for its child "value".
+func (n *BListAny) Value() *BList_ValueAny {
+	return &BList_ValueAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "value"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // C represents the /enum-module/c YANG schema element.
 type C struct {
 	ygot.NodePath
 }
 
-// CΩ represents the wildcard version of the /enum-module/c YANG schema element.
-type CΩ struct {
+// CAny represents the wildcard version of the /enum-module/c YANG schema element.
+type CAny struct {
 	ygot.NodePath
 }
 
@@ -109,14 +131,25 @@ type C_Cl struct {
 	ygot.NodePath
 }
 
-// C_ClΩ represents the wildcard version of the /enum-module/c/cl YANG schema element.
-type C_ClΩ struct {
+// C_ClAny represents the wildcard version of the /enum-module/c/cl YANG schema element.
+type C_ClAny struct {
 	ygot.NodePath
 }
 
 // Cl returns from C the path struct for its child "cl".
 func (n *C) Cl() *C_Cl {
 	return &C_Cl{
+		NodePath: ygot.NewNodePath(
+			[]string{"cl"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Cl returns from CAny the path struct for its child "cl".
+func (n *CAny) Cl() *C_ClAny {
+	return &C_ClAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"cl"},
 			map[string]interface{}{},
@@ -135,12 +168,34 @@ func ForDevice(id string) *Device {
 	return &Device{id: id}
 }
 
+// AListAny returns from Device the path struct for its child "a-list".
+func (n *Device) AListAny() *AListAny {
+	return &AListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"a-lists", "a-list"},
+			map[string]interface{}{"value": "*"},
+			n,
+		),
+	}
+}
+
 // AList returns from Device the path struct for its child "a-list".
 func (n *Device) AList(Value oc.AList_Value_Union) *AList {
 	return &AList{
 		NodePath: ygot.NewNodePath(
 			[]string{"a-lists", "a-list"},
 			map[string]interface{}{"value": Value},
+			n,
+		),
+	}
+}
+
+// BListAny returns from Device the path struct for its child "b-list".
+func (n *Device) BListAny() *BListAny {
+	return &BListAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b-lists", "b-list"},
+			map[string]interface{}{"value": "*"},
 			n,
 		),
 	}
@@ -184,8 +239,8 @@ type Parent struct {
 	ygot.NodePath
 }
 
-// ParentΩ represents the wildcard version of the /enum-module/parent YANG schema element.
-type ParentΩ struct {
+// ParentAny represents the wildcard version of the /enum-module/parent YANG schema element.
+type ParentAny struct {
 	ygot.NodePath
 }
 
@@ -200,13 +255,24 @@ func (n *Parent) Child() *Parent_Child {
 	}
 }
 
+// Child returns from ParentAny the path struct for its child "child".
+func (n *ParentAny) Child() *Parent_ChildAny {
+	return &Parent_ChildAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"child"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Parent_Child represents the /enum-module/parent/child YANG schema element.
 type Parent_Child struct {
 	ygot.NodePath
 }
 
-// Parent_ChildΩ represents the wildcard version of the /enum-module/parent/child YANG schema element.
-type Parent_ChildΩ struct {
+// Parent_ChildAny represents the wildcard version of the /enum-module/parent/child YANG schema element.
+type Parent_ChildAny struct {
 	ygot.NodePath
 }
 
@@ -215,14 +281,25 @@ type Parent_Child_Id struct {
 	ygot.NodePath
 }
 
-// Parent_Child_IdΩ represents the wildcard version of the /enum-module/parent/child/state/id YANG schema element.
-type Parent_Child_IdΩ struct {
+// Parent_Child_IdAny represents the wildcard version of the /enum-module/parent/child/state/id YANG schema element.
+type Parent_Child_IdAny struct {
 	ygot.NodePath
 }
 
 // Id returns from Parent_Child the path struct for its child "id".
 func (n *Parent_Child) Id() *Parent_Child_Id {
 	return &Parent_Child_Id{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "id"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Id returns from Parent_ChildAny the path struct for its child "id".
+func (n *Parent_ChildAny) Id() *Parent_Child_IdAny {
+	return &Parent_Child_IdAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "id"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -70,8 +70,8 @@ type Native struct {
 	ygot.NodePath
 }
 
-// NativeΩ represents the wildcard version of the /openconfig-simple-target/native YANG schema element.
-type NativeΩ struct {
+// NativeAny represents the wildcard version of the /openconfig-simple-target/native YANG schema element.
+type NativeAny struct {
 	ygot.NodePath
 }
 
@@ -80,8 +80,8 @@ type Native_A struct {
 	ygot.NodePath
 }
 
-// Native_AΩ represents the wildcard version of the /openconfig-simple-target/native/state/a YANG schema element.
-type Native_AΩ struct {
+// Native_AAny represents the wildcard version of the /openconfig-simple-target/native/state/a YANG schema element.
+type Native_AAny struct {
 	ygot.NodePath
 }
 
@@ -96,13 +96,24 @@ func (n *Native) A() *Native_A {
 	}
 }
 
+// A returns from NativeAny the path struct for its child "a".
+func (n *NativeAny) A() *Native_AAny {
+	return &Native_AAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "a"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Target represents the /openconfig-simple-target/target YANG schema element.
 type Target struct {
 	ygot.NodePath
 }
 
-// TargetΩ represents the wildcard version of the /openconfig-simple-target/target YANG schema element.
-type TargetΩ struct {
+// TargetAny represents the wildcard version of the /openconfig-simple-target/target YANG schema element.
+type TargetAny struct {
 	ygot.NodePath
 }
 
@@ -117,13 +128,24 @@ func (n *Target) Foo() *Target_Foo {
 	}
 }
 
+// Foo returns from TargetAny the path struct for its child "foo".
+func (n *TargetAny) Foo() *Target_FooAny {
+	return &Target_FooAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"foo"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Target_Foo represents the /openconfig-simple-target/target/foo YANG schema element.
 type Target_Foo struct {
 	ygot.NodePath
 }
 
-// Target_FooΩ represents the wildcard version of the /openconfig-simple-target/target/foo YANG schema element.
-type Target_FooΩ struct {
+// Target_FooAny represents the wildcard version of the /openconfig-simple-target/target/foo YANG schema element.
+type Target_FooAny struct {
 	ygot.NodePath
 }
 
@@ -132,14 +154,25 @@ type Target_Foo_A struct {
 	ygot.NodePath
 }
 
-// Target_Foo_AΩ represents the wildcard version of the /openconfig-simple-target/target/foo/state/a YANG schema element.
-type Target_Foo_AΩ struct {
+// Target_Foo_AAny represents the wildcard version of the /openconfig-simple-target/target/foo/state/a YANG schema element.
+type Target_Foo_AAny struct {
 	ygot.NodePath
 }
 
 // A returns from Target_Foo the path struct for its child "a".
 func (n *Target_Foo) A() *Target_Foo_A {
 	return &Target_Foo_A{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "a"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// A returns from Target_FooAny the path struct for its child "a".
+func (n *Target_FooAny) A() *Target_Foo_AAny {
+	return &Target_Foo_AAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "a"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-camelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase.path-txt
@@ -37,9 +37,31 @@ type BGP struct {
 	ygot.NodePath
 }
 
-// BGPΩ represents the wildcard version of the /openconfig-camelcase/bgp YANG schema element.
-type BGPΩ struct {
+// BGPAny represents the wildcard version of the /openconfig-camelcase/bgp YANG schema element.
+type BGPAny struct {
 	ygot.NodePath
+}
+
+// NeighborAny returns from BGP the path struct for its child "neighbor".
+func (n *BGP) NeighborAny() *BGP_NeighborAny {
+	return &BGP_NeighborAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"neighbors", "neighbor"},
+			map[string]interface{}{"peer-ip": "*"},
+			n,
+		),
+	}
+}
+
+// NeighborAny returns from BGPAny the path struct for its child "neighbor".
+func (n *BGPAny) NeighborAny() *BGP_NeighborAny {
+	return &BGP_NeighborAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"neighbors", "neighbor"},
+			map[string]interface{}{"peer-ip": "*"},
+			n,
+		),
+	}
 }
 
 // Neighbor returns from BGP the path struct for its child "neighbor".
@@ -53,13 +75,24 @@ func (n *BGP) Neighbor(PeerIP string) *BGP_Neighbor {
 	}
 }
 
+// Neighbor returns from BGPAny the path struct for its child "neighbor".
+func (n *BGPAny) Neighbor(PeerIP string) *BGP_NeighborAny {
+	return &BGP_NeighborAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"neighbors", "neighbor"},
+			map[string]interface{}{"peer-ip": PeerIP},
+			n,
+		),
+	}
+}
+
 // BGP_Neighbor represents the /openconfig-camelcase/bgp/neighbors/neighbor YANG schema element.
 type BGP_Neighbor struct {
 	ygot.NodePath
 }
 
-// BGP_NeighborΩ represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor YANG schema element.
-type BGP_NeighborΩ struct {
+// BGP_NeighborAny represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor YANG schema element.
+type BGP_NeighborAny struct {
 	ygot.NodePath
 }
 
@@ -68,14 +101,25 @@ type BGP_Neighbor_PeerIP struct {
 	ygot.NodePath
 }
 
-// BGP_Neighbor_PeerIPΩ represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor/state/peer-ip YANG schema element.
-type BGP_Neighbor_PeerIPΩ struct {
+// BGP_Neighbor_PeerIPAny represents the wildcard version of the /openconfig-camelcase/bgp/neighbors/neighbor/state/peer-ip YANG schema element.
+type BGP_Neighbor_PeerIPAny struct {
 	ygot.NodePath
 }
 
 // PeerIP returns from BGP_Neighbor the path struct for its child "peer-ip".
 func (n *BGP_Neighbor) PeerIP() *BGP_Neighbor_PeerIP {
 	return &BGP_Neighbor_PeerIP{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "peer-ip"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// PeerIP returns from BGP_NeighborAny the path struct for its child "peer-ip".
+func (n *BGP_NeighborAny) PeerIP() *BGP_Neighbor_PeerIPAny {
+	return &BGP_Neighbor_PeerIPAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "peer-ip"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
@@ -58,8 +58,8 @@ type Foo struct {
 	ygot.NodePath
 }
 
-// FooΩ represents the wildcard version of the /openconfig-enumcamelcase/foo YANG schema element.
-type FooΩ struct {
+// FooAny represents the wildcard version of the /openconfig-enumcamelcase/foo YANG schema element.
+type FooAny struct {
 	ygot.NodePath
 }
 
@@ -68,8 +68,8 @@ type Foo_Bar struct {
 	ygot.NodePath
 }
 
-// Foo_BarΩ represents the wildcard version of the /openconfig-enumcamelcase/foo/bar YANG schema element.
-type Foo_BarΩ struct {
+// Foo_BarAny represents the wildcard version of the /openconfig-enumcamelcase/foo/bar YANG schema element.
+type Foo_BarAny struct {
 	ygot.NodePath
 }
 
@@ -78,8 +78,8 @@ type Foo_Baz struct {
 	ygot.NodePath
 }
 
-// Foo_BazΩ represents the wildcard version of the /openconfig-enumcamelcase/foo/baz YANG schema element.
-type Foo_BazΩ struct {
+// Foo_BazAny represents the wildcard version of the /openconfig-enumcamelcase/foo/baz YANG schema element.
+type Foo_BazAny struct {
 	ygot.NodePath
 }
 
@@ -94,9 +94,31 @@ func (n *Foo) Bar() *Foo_Bar {
 	}
 }
 
+// Bar returns from FooAny the path struct for its child "bar".
+func (n *FooAny) Bar() *Foo_BarAny {
+	return &Foo_BarAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"bar"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Baz returns from Foo the path struct for its child "baz".
 func (n *Foo) Baz() *Foo_Baz {
 	return &Foo_Baz{
+		NodePath: ygot.NewNodePath(
+			[]string{"baz"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Baz returns from FooAny the path struct for its child "baz".
+func (n *FooAny) Baz() *Foo_BazAny {
+	return &Foo_BazAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"baz"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -69,8 +69,8 @@ type Parent struct {
 	ygot.NodePath
 }
 
-// ParentΩ represents the wildcard version of the /openconfig-simple/parent YANG schema element.
-type ParentΩ struct {
+// ParentAny represents the wildcard version of the /openconfig-simple/parent YANG schema element.
+type ParentAny struct {
 	ygot.NodePath
 }
 
@@ -85,13 +85,24 @@ func (n *Parent) Child() *Parent_Child {
 	}
 }
 
+// Child returns from ParentAny the path struct for its child "child".
+func (n *ParentAny) Child() *Parent_ChildAny {
+	return &Parent_ChildAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"child"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Parent_Child represents the /openconfig-simple/parent/child YANG schema element.
 type Parent_Child struct {
 	ygot.NodePath
 }
 
-// Parent_ChildΩ represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
-type Parent_ChildΩ struct {
+// Parent_ChildAny represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
+type Parent_ChildAny struct {
 	ygot.NodePath
 }
 
@@ -100,8 +111,8 @@ type Parent_Child_Four struct {
 	ygot.NodePath
 }
 
-// Parent_Child_FourΩ represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
-type Parent_Child_FourΩ struct {
+// Parent_Child_FourAny represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
+type Parent_Child_FourAny struct {
 	ygot.NodePath
 }
 
@@ -110,8 +121,8 @@ type Parent_Child_One struct {
 	ygot.NodePath
 }
 
-// Parent_Child_OneΩ represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
-type Parent_Child_OneΩ struct {
+// Parent_Child_OneAny represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
+type Parent_Child_OneAny struct {
 	ygot.NodePath
 }
 
@@ -120,8 +131,8 @@ type Parent_Child_Three struct {
 	ygot.NodePath
 }
 
-// Parent_Child_ThreeΩ represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
-type Parent_Child_ThreeΩ struct {
+// Parent_Child_ThreeAny represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
+type Parent_Child_ThreeAny struct {
 	ygot.NodePath
 }
 
@@ -130,14 +141,25 @@ type Parent_Child_Two struct {
 	ygot.NodePath
 }
 
-// Parent_Child_TwoΩ represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
-type Parent_Child_TwoΩ struct {
+// Parent_Child_TwoAny represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoAny struct {
 	ygot.NodePath
 }
 
 // Four returns from Parent_Child the path struct for its child "four".
 func (n *Parent_Child) Four() *Parent_Child_Four {
 	return &Parent_Child_Four{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "four"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Four returns from Parent_ChildAny the path struct for its child "four".
+func (n *Parent_ChildAny) Four() *Parent_Child_FourAny {
+	return &Parent_Child_FourAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "four"},
 			map[string]interface{}{},
@@ -157,9 +179,31 @@ func (n *Parent_Child) One() *Parent_Child_One {
 	}
 }
 
+// One returns from Parent_ChildAny the path struct for its child "one".
+func (n *Parent_ChildAny) One() *Parent_Child_OneAny {
+	return &Parent_Child_OneAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "one"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Three returns from Parent_Child the path struct for its child "three".
 func (n *Parent_Child) Three() *Parent_Child_Three {
 	return &Parent_Child_Three{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "three"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Three returns from Parent_ChildAny the path struct for its child "three".
+func (n *Parent_ChildAny) Three() *Parent_Child_ThreeAny {
+	return &Parent_Child_ThreeAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "three"},
 			map[string]interface{}{},
@@ -179,13 +223,24 @@ func (n *Parent_Child) Two() *Parent_Child_Two {
 	}
 }
 
+// Two returns from Parent_ChildAny the path struct for its child "two".
+func (n *Parent_ChildAny) Two() *Parent_Child_TwoAny {
+	return &Parent_Child_TwoAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "two"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // RemoteContainer represents the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainer struct {
 	ygot.NodePath
 }
 
-// RemoteContainerΩ represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
-type RemoteContainerΩ struct {
+// RemoteContainerAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
+type RemoteContainerAny struct {
 	ygot.NodePath
 }
 
@@ -194,14 +249,25 @@ type RemoteContainer_ALeaf struct {
 	ygot.NodePath
 }
 
-// RemoteContainer_ALeafΩ represents the wildcard version of the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
-type RemoteContainer_ALeafΩ struct {
+// RemoteContainer_ALeafAny represents the wildcard version of the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
+type RemoteContainer_ALeafAny struct {
 	ygot.NodePath
 }
 
 // ALeaf returns from RemoteContainer the path struct for its child "a-leaf".
 func (n *RemoteContainer) ALeaf() *RemoteContainer_ALeaf {
 	return &RemoteContainer_ALeaf{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "a-leaf"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// ALeaf returns from RemoteContainerAny the path struct for its child "a-leaf".
+func (n *RemoteContainerAny) ALeaf() *RemoteContainer_ALeafAny {
+	return &RemoteContainer_ALeafAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "a-leaf"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -69,8 +69,8 @@ type DupEnum struct {
 	ygot.NodePath
 }
 
-// DupEnumΩ represents the wildcard version of the /openconfig-unione/dup-enum YANG schema element.
-type DupEnumΩ struct {
+// DupEnumAny represents the wildcard version of the /openconfig-unione/dup-enum YANG schema element.
+type DupEnumAny struct {
 	ygot.NodePath
 }
 
@@ -79,8 +79,8 @@ type DupEnum_A struct {
 	ygot.NodePath
 }
 
-// DupEnum_AΩ represents the wildcard version of the /openconfig-unione/dup-enum/state/A YANG schema element.
-type DupEnum_AΩ struct {
+// DupEnum_AAny represents the wildcard version of the /openconfig-unione/dup-enum/state/A YANG schema element.
+type DupEnum_AAny struct {
 	ygot.NodePath
 }
 
@@ -89,14 +89,25 @@ type DupEnum_B struct {
 	ygot.NodePath
 }
 
-// DupEnum_BΩ represents the wildcard version of the /openconfig-unione/dup-enum/state/B YANG schema element.
-type DupEnum_BΩ struct {
+// DupEnum_BAny represents the wildcard version of the /openconfig-unione/dup-enum/state/B YANG schema element.
+type DupEnum_BAny struct {
 	ygot.NodePath
 }
 
 // A returns from DupEnum the path struct for its child "A".
 func (n *DupEnum) A() *DupEnum_A {
 	return &DupEnum_A{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "A"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// A returns from DupEnumAny the path struct for its child "A".
+func (n *DupEnumAny) A() *DupEnum_AAny {
+	return &DupEnum_AAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "A"},
 			map[string]interface{}{},
@@ -116,13 +127,24 @@ func (n *DupEnum) B() *DupEnum_B {
 	}
 }
 
+// B returns from DupEnumAny the path struct for its child "B".
+func (n *DupEnumAny) B() *DupEnum_BAny {
+	return &DupEnum_BAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "B"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Platform represents the /openconfig-unione/platform YANG schema element.
 type Platform struct {
 	ygot.NodePath
 }
 
-// PlatformΩ represents the wildcard version of the /openconfig-unione/platform YANG schema element.
-type PlatformΩ struct {
+// PlatformAny represents the wildcard version of the /openconfig-unione/platform YANG schema element.
+type PlatformAny struct {
 	ygot.NodePath
 }
 
@@ -137,13 +159,24 @@ func (n *Platform) Component() *Platform_Component {
 	}
 }
 
+// Component returns from PlatformAny the path struct for its child "component".
+func (n *PlatformAny) Component() *Platform_ComponentAny {
+	return &Platform_ComponentAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"component"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Platform_Component represents the /openconfig-unione/platform/component YANG schema element.
 type Platform_Component struct {
 	ygot.NodePath
 }
 
-// Platform_ComponentΩ represents the wildcard version of the /openconfig-unione/platform/component YANG schema element.
-type Platform_ComponentΩ struct {
+// Platform_ComponentAny represents the wildcard version of the /openconfig-unione/platform/component YANG schema element.
+type Platform_ComponentAny struct {
 	ygot.NodePath
 }
 
@@ -152,8 +185,8 @@ type Platform_Component_E1 struct {
 	ygot.NodePath
 }
 
-// Platform_Component_E1Ω represents the wildcard version of the /openconfig-unione/platform/component/state/e1 YANG schema element.
-type Platform_Component_E1Ω struct {
+// Platform_Component_E1Any represents the wildcard version of the /openconfig-unione/platform/component/state/e1 YANG schema element.
+type Platform_Component_E1Any struct {
 	ygot.NodePath
 }
 
@@ -162,8 +195,8 @@ type Platform_Component_Enumerated struct {
 	ygot.NodePath
 }
 
-// Platform_Component_EnumeratedΩ represents the wildcard version of the /openconfig-unione/platform/component/state/enumerated YANG schema element.
-type Platform_Component_EnumeratedΩ struct {
+// Platform_Component_EnumeratedAny represents the wildcard version of the /openconfig-unione/platform/component/state/enumerated YANG schema element.
+type Platform_Component_EnumeratedAny struct {
 	ygot.NodePath
 }
 
@@ -172,8 +205,8 @@ type Platform_Component_Power struct {
 	ygot.NodePath
 }
 
-// Platform_Component_PowerΩ represents the wildcard version of the /openconfig-unione/platform/component/state/power YANG schema element.
-type Platform_Component_PowerΩ struct {
+// Platform_Component_PowerAny represents the wildcard version of the /openconfig-unione/platform/component/state/power YANG schema element.
+type Platform_Component_PowerAny struct {
 	ygot.NodePath
 }
 
@@ -182,8 +215,8 @@ type Platform_Component_R1 struct {
 	ygot.NodePath
 }
 
-// Platform_Component_R1Ω represents the wildcard version of the /openconfig-unione/platform/component/state/r1 YANG schema element.
-type Platform_Component_R1Ω struct {
+// Platform_Component_R1Any represents the wildcard version of the /openconfig-unione/platform/component/state/r1 YANG schema element.
+type Platform_Component_R1Any struct {
 	ygot.NodePath
 }
 
@@ -192,14 +225,25 @@ type Platform_Component_Type struct {
 	ygot.NodePath
 }
 
-// Platform_Component_TypeΩ represents the wildcard version of the /openconfig-unione/platform/component/state/type YANG schema element.
-type Platform_Component_TypeΩ struct {
+// Platform_Component_TypeAny represents the wildcard version of the /openconfig-unione/platform/component/state/type YANG schema element.
+type Platform_Component_TypeAny struct {
 	ygot.NodePath
 }
 
 // E1 returns from Platform_Component the path struct for its child "e1".
 func (n *Platform_Component) E1() *Platform_Component_E1 {
 	return &Platform_Component_E1{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "e1"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// E1 returns from Platform_ComponentAny the path struct for its child "e1".
+func (n *Platform_ComponentAny) E1() *Platform_Component_E1Any {
+	return &Platform_Component_E1Any{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "e1"},
 			map[string]interface{}{},
@@ -219,9 +263,31 @@ func (n *Platform_Component) Enumerated() *Platform_Component_Enumerated {
 	}
 }
 
+// Enumerated returns from Platform_ComponentAny the path struct for its child "enumerated".
+func (n *Platform_ComponentAny) Enumerated() *Platform_Component_EnumeratedAny {
+	return &Platform_Component_EnumeratedAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "enumerated"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Power returns from Platform_Component the path struct for its child "power".
 func (n *Platform_Component) Power() *Platform_Component_Power {
 	return &Platform_Component_Power{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "power"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Power returns from Platform_ComponentAny the path struct for its child "power".
+func (n *Platform_ComponentAny) Power() *Platform_Component_PowerAny {
+	return &Platform_Component_PowerAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "power"},
 			map[string]interface{}{},
@@ -241,9 +307,31 @@ func (n *Platform_Component) R1() *Platform_Component_R1 {
 	}
 }
 
+// R1 returns from Platform_ComponentAny the path struct for its child "r1".
+func (n *Platform_ComponentAny) R1() *Platform_Component_R1Any {
+	return &Platform_Component_R1Any{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "r1"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Type returns from Platform_Component the path struct for its child "type".
 func (n *Platform_Component) Type() *Platform_Component_Type {
 	return &Platform_Component_Type{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "type"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Type returns from Platform_ComponentAny the path struct for its child "type".
+func (n *Platform_ComponentAny) Type() *Platform_Component_TypeAny {
+	return &Platform_Component_TypeAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "type"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -58,9 +58,75 @@ type Model struct {
 	ygot.NodePath
 }
 
-// ModelΩ represents the wildcard version of the /openconfig-withlist/model YANG schema element.
-type ModelΩ struct {
+// ModelAny represents the wildcard version of the /openconfig-withlist/model YANG schema element.
+type ModelAny struct {
 	ygot.NodePath
+}
+
+// MultiKeyAny returns from Model the path struct for its child "multi-key".
+func (n *Model) MultiKeyAny() *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": "*"},
+			n,
+		),
+	}
+}
+
+// MultiKeyAny returns from ModelAny the path struct for its child "multi-key".
+func (n *ModelAny) MultiKeyAny() *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": "*"},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey2 returns from Model the path struct for its child "multi-key".
+func (n *Model) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": "*"},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey2 returns from ModelAny the path struct for its child "multi-key".
+func (n *ModelAny) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": "*"},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey1 returns from Model the path struct for its child "multi-key".
+func (n *Model) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": Key2},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey1 returns from ModelAny the path struct for its child "multi-key".
+func (n *ModelAny) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": Key2},
+			n,
+		),
+	}
 }
 
 // MultiKey returns from Model the path struct for its child "multi-key".
@@ -69,6 +135,39 @@ func (n *Model) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKey {
 		NodePath: ygot.NewNodePath(
 			[]string{"b", "multi-key"},
 			map[string]interface{}{"key1": Key1, "key2": Key2},
+			n,
+		),
+	}
+}
+
+// MultiKey returns from ModelAny the path struct for its child "multi-key".
+func (n *ModelAny) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyAny {
+	return &Model_MultiKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": Key2},
+			n,
+		),
+	}
+}
+
+// SingleKeyAny returns from Model the path struct for its child "single-key".
+func (n *Model) SingleKeyAny() *Model_SingleKeyAny {
+	return &Model_SingleKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"a", "single-key"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyAny returns from ModelAny the path struct for its child "single-key".
+func (n *ModelAny) SingleKeyAny() *Model_SingleKeyAny {
+	return &Model_SingleKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"a", "single-key"},
+			map[string]interface{}{"key": "*"},
 			n,
 		),
 	}
@@ -85,13 +184,24 @@ func (n *Model) SingleKey(Key string) *Model_SingleKey {
 	}
 }
 
+// SingleKey returns from ModelAny the path struct for its child "single-key".
+func (n *ModelAny) SingleKey(Key string) *Model_SingleKeyAny {
+	return &Model_SingleKeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"a", "single-key"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKey represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKey struct {
 	ygot.NodePath
 }
 
-// Model_MultiKeyΩ represents the wildcard version of the /openconfig-withlist/model/b/multi-key YANG schema element.
-type Model_MultiKeyΩ struct {
+// Model_MultiKeyAny represents the wildcard version of the /openconfig-withlist/model/b/multi-key YANG schema element.
+type Model_MultiKeyAny struct {
 	ygot.NodePath
 }
 
@@ -100,8 +210,8 @@ type Model_MultiKey_Key1 struct {
 	ygot.NodePath
 }
 
-// Model_MultiKey_Key1Ω represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
-type Model_MultiKey_Key1Ω struct {
+// Model_MultiKey_Key1Any represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
+type Model_MultiKey_Key1Any struct {
 	ygot.NodePath
 }
 
@@ -110,14 +220,25 @@ type Model_MultiKey_Key2 struct {
 	ygot.NodePath
 }
 
-// Model_MultiKey_Key2Ω represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key2 YANG schema element.
-type Model_MultiKey_Key2Ω struct {
+// Model_MultiKey_Key2Any represents the wildcard version of the /openconfig-withlist/model/b/multi-key/state/key2 YANG schema element.
+type Model_MultiKey_Key2Any struct {
 	ygot.NodePath
 }
 
 // Key1 returns from Model_MultiKey the path struct for its child "key1".
 func (n *Model_MultiKey) Key1() *Model_MultiKey_Key1 {
 	return &Model_MultiKey_Key1{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key1"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key1 returns from Model_MultiKeyAny the path struct for its child "key1".
+func (n *Model_MultiKeyAny) Key1() *Model_MultiKey_Key1Any {
+	return &Model_MultiKey_Key1Any{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key1"},
 			map[string]interface{}{},
@@ -137,13 +258,24 @@ func (n *Model_MultiKey) Key2() *Model_MultiKey_Key2 {
 	}
 }
 
+// Key2 returns from Model_MultiKeyAny the path struct for its child "key2".
+func (n *Model_MultiKeyAny) Key2() *Model_MultiKey_Key2Any {
+	return &Model_MultiKey_Key2Any{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key2"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
 // Model_SingleKey represents the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKey struct {
 	ygot.NodePath
 }
 
-// Model_SingleKeyΩ represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
-type Model_SingleKeyΩ struct {
+// Model_SingleKeyAny represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
+type Model_SingleKeyAny struct {
 	ygot.NodePath
 }
 
@@ -152,14 +284,25 @@ type Model_SingleKey_Key struct {
 	ygot.NodePath
 }
 
-// Model_SingleKey_KeyΩ represents the wildcard version of the /openconfig-withlist/model/a/single-key/state/key YANG schema element.
-type Model_SingleKey_KeyΩ struct {
+// Model_SingleKey_KeyAny represents the wildcard version of the /openconfig-withlist/model/a/single-key/state/key YANG schema element.
+type Model_SingleKey_KeyAny struct {
 	ygot.NodePath
 }
 
 // Key returns from Model_SingleKey the path struct for its child "key".
 func (n *Model_SingleKey) Key() *Model_SingleKey_Key {
 	return &Model_SingleKey_Key{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key returns from Model_SingleKeyAny the path struct for its child "key".
+func (n *Model_SingleKeyAny) Key() *Model_SingleKey_KeyAny {
+	return &Model_SingleKey_KeyAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},


### PR DESCRIPTION
- Refactor helper functions used to create list parameters and their key values.
- New functions generateChildConstructorsForList and generateChildConstructorsForLeafOrContainer.
- Make generateChildConstructors call the above new functions during its
  execution depending on whether it's processing a list or container.