### PR TITLE
Remove global var generatedUnionInterfaces and use a local var instead

### DIFF
--- a/ygen/genstate.go
+++ b/ygen/genstate.go
@@ -91,12 +91,6 @@ type genState struct {
 	// where two entities re-use a union that has already been created (e.g.,
 	// a leafref to a union) then it is output only once in the generated code.
 	generatedUnions map[string]bool
-	// generatedUnionInterface stores a map of maps that store the To_XXX methods
-	// that have been built for a particular receiver struct. These methods are
-	// generated as helpers for union types, and must be output once per receiver
-	// struct in which they are used. The first map is keyed on the receiver type,
-	// whilst the latter is keyed on the interface name.
-	generatedUnionInterfaces map[string]map[string]bool
 }
 
 // newGenState creates a new genState instance, initialised with the default state
@@ -116,7 +110,6 @@ func newGenState() *genState {
 		uniqueProtoMsgNames:          make(map[string]map[string]bool),
 		uniqueProtoPackages:          make(map[string]string),
 		generatedUnions:              make(map[string]bool),
-		generatedUnionInterfaces:     make(map[string]map[string]bool),
 	}
 }
 


### PR DESCRIPTION
This is a refactoring effort. genState's numerous global state makes the code somewhat harder to understand -- this helps by removing the one that doesn't need to be a global variable.