### PR TITLE
Split genState into smaller generators.

### DIFF
--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -25,7 +25,6 @@ import (
 
 	log "github.com/golang/glog"
 
-	"github.com/openconfig/gnmi/ctree"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/genutil"
 	"github.com/openconfig/ygot/util"
@@ -320,7 +319,7 @@ func (cg *YANGCodeGenerator) GenerateGoCode(yangFiles, includePaths []string) (*
 	}
 
 	// Store the returned schematree within the state for this code generation.
-	gogen := newGoGenState(mdef.schemaTree)
+	gogen := newGoGenState(mdef.schematree)
 
 	directoryMap, errs := gogen.buildDirectoryDefinitions(mdef.directoryEntries, cg.Config.TransformationOptions.CompressBehaviour, cg.Config.TransformationOptions.GenerateFakeRoot)
 	if errs != nil {
@@ -446,7 +445,7 @@ func (dcg *DirectoryGenConfig) GetDirectoriesAndLeafTypes(yangFiles, includePath
 	dirsToProcess := map[string]*yang.Entry(mdef.directoryEntries)
 
 	// Store the returned schematree within the state for this code generation.
-	gogen := newGoGenState(mdef.schemaTree)
+	gogen := newGoGenState(mdef.schematree)
 
 	directoryMap, errs := gogen.buildDirectoryDefinitions(dirsToProcess, cg.TransformationOptions.CompressBehaviour, cg.TransformationOptions.GenerateFakeRoot)
 	if errs != nil {
@@ -544,7 +543,7 @@ func (cg *YANGCodeGenerator) GenerateProto3(yangFiles, includePaths []string) (*
 		return nil, errs
 	}
 
-	protogen := newProtoGenState(mdef.schemaTree)
+	protogen := newProtoGenState(mdef.schematree)
 
 	penums, errs := protogen.enumGen.findEnumSet(mdef.enumEntries, cg.Config.TransformationOptions.CompressBehaviour.CompressEnabled(), true)
 	if errs != nil {
@@ -753,9 +752,9 @@ type mappedYANGDefinitions struct {
 	// leaves that are of type enumeration, identityref, or unions that contain either of
 	// these types. The map is keyed by the string path to the entry in the YANG schema.
 	enumEntries map[string]*yang.Entry
-	// schemaTree is a ctree.Tree that stores a copy of the YANG schema tree, containing
-	// only leaf entries, such that schema paths can be referenced.
-	schemaTree *ctree.Tree
+	// schematree is a copy of the YANG schema tree, containing only leaf
+	// entries, such that schema paths can be referenced.
+	schematree *schemaTree
 	// modules is the set of parsed YANG modules that are being processed as part of the
 	// code generatio, expressed as a slice of yang.Entry pointers.
 	modules []*yang.Entry
@@ -841,7 +840,7 @@ func mappedDefinitions(yangFiles, includePaths []string, cfg *GeneratorConfig) (
 	return &mappedYANGDefinitions{
 		directoryEntries: dirs,
 		enumEntries:      enums,
-		schemaTree:       st,
+		schematree:       st,
 		modules:          ms,
 		modelData:        modelData,
 	}, nil

--- a/ygen/genstate.go
+++ b/ygen/genstate.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/openconfig/gnmi/ctree"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/genutil"
 	"github.com/openconfig/ygot/util"
@@ -545,44 +544,4 @@ func (s *enumGenState) enumeratedTypedefTypeName(args resolveTypeArgs, prefix st
 		}
 	}
 	return nil, nil
-}
-
-// genHelper contains helper functions specific to code generation.
-// Its fields must be set for full functionality.
-type genHelper struct {
-	// schematree stores a ctree.Tree structure that represents the YANG
-	// schema tree. This is used for lookups within the module set where
-	// they are required, e.g., for leafrefs.
-	schematree *ctree.Tree
-}
-
-// resolveLeafrefTarget takes an input path and context entry and
-// determines the type of the leaf that is referred to by the path, such that
-// it can be mapped to a native language type. It returns the yang.YangType that
-// is associated with the target, and the target yang.Entry, such that the
-// caller can map this to the relevant language type.
-func (h *genHelper) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
-	if h.schematree == nil {
-		// This should not be possible if the calling code generation is
-		// well structured and builds the schematree during parsing of YANG
-		// files.
-		return nil, fmt.Errorf("could not map leafref path: %v, from contextEntry: %v", path, contextEntry)
-	}
-
-	fixedPath, err := fixSchemaTreePath(path, contextEntry)
-	if err != nil {
-		return nil, err
-	}
-
-	e := h.schematree.GetLeafValue(fixedPath)
-	if e == nil {
-		return nil, fmt.Errorf("could not resolve leafref path: %v from %v, tree: %v", fixedPath, contextEntry, h.schematree)
-	}
-
-	target, ok := e.(*yang.Entry)
-	if !ok {
-		return nil, fmt.Errorf("invalid element returned from schema tree, must be a yang.Entry for path %v from %v", path, contextEntry)
-	}
-
-	return target, nil
 }

--- a/ygen/genstate.go
+++ b/ygen/genstate.go
@@ -24,27 +24,17 @@ import (
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/genutil"
 	"github.com/openconfig/ygot/util"
-	"github.com/openconfig/ygot/ygot"
 )
 
-// TODO(wenbli): Look at separating genState from its methods so that ygen's
-// internal functionality becomes more modular, and can be more accessible to
-// other generation libraries. For example, by refactoring out
-// buildDirectoryDefinitions from genState, the method, along with Directory
-// and its associated methods, can all move to genutil for general use.
-
-// genState is used to store the state that is created throughout the code
-// generation and must be shared between multiple entities.
-type genState struct {
-	// definedGlobals specifies the global Go names used during code generation.
-	definedGlobals map[string]bool
-	// uniqueDirectoryNames is a map keyed by the path of a YANG entity representing a
-	// directory in the generated code, whose value is the unique name that it
-	// was mapped to. This allows routines to determine, based on a particular YANG
-	// entry, how to refer to it when generating code.
-	uniqueDirectoryNames map[string]string
+// enumGenState contains the state and functionality for generating enum names
+// that seeks to be compatible in all supported languages. It assumes that
+// enums are all in the same namespace, guaranteeing that all enum names are
+// unique.
+type enumGenState struct {
+	// definedEnums keeps track of generated enum names to avoid conflicts.
+	definedEnums map[string]bool
 	// uniqueIdentityNames is a map which is keyed by a string in the form of
-	// definingModule/identityName which stores the Go anme of the enumerated Go type
+	// definingModule/identityName which stores the Go name of the enumerated Go type
 	// that has been created to represent the identity. This allows de-duplication
 	// between identityref leaves that reference the same underlying identity. The
 	// name used includes the defining module to avoid clashes between two identities
@@ -60,7 +50,7 @@ type genState struct {
 	// example-module defines a hierarchy of global/config/a-leaf where a-leaf
 	// is of type enumeration, then the path example-module/global/config/a-leaf
 	// is used for a-leaf in the uniqueEnumeratedLeafNames. The value of the map
-	// is the name of the Go enuerated value to which it is mapped. The path based
+	// is the name of the Go enumerated value to which it is mapped. The path based
 	// on the module is guaranteed to be unique, since we cannot have multiple
 	// modules of the same name, or multiple identical data tree paths within
 	// the same module. This path is used since a particular leaf may be re-used
@@ -72,44 +62,16 @@ type genState struct {
 	// a module such as openconfig-bgp which defines /bgp and is also used at
 	// /network-instances/network-instance/protocols/protocol/bgp.
 	uniqueEnumeratedLeafNames map[string]string
-	// schematree stores a ctree.Tree structure that represents the YANG
-	// schema tree. This is used for lookups within the module set where
-	// they are required, e.g., for leafrefs.
-	schematree *ctree.Tree
-	// uniqueProtoMsgNames is a map, keyed by a protobuf package name, that
-	// contains a map keyed by protobuf message name strings that indicates the
-	// names that are used within the generated package's context. It is used
-	// during code generation to ensure uniqueness of the generated names within
-	// the specified package.
-	uniqueProtoMsgNames map[string]map[string]bool
-	// uniqueProtoPackages is a map, keyed by a YANG schema path, that allows
-	// a path to be resolved into the calculated Protobuf package name that
-	// is to be used for it.
-	uniqueProtoPackages map[string]string
-	// generatedUnions stores a map, keyed by the output name for a union,
-	// that has already been output in the generated code. This ensures that
-	// where two entities re-use a union that has already been created (e.g.,
-	// a leafref to a union) then it is output only once in the generated code.
-	generatedUnions map[string]bool
 }
 
-// newGenState creates a new genState instance, initialised with the default state
-// required for code generation.
-func newGenState() *genState {
-	return &genState{
-		// Mark the name that is used for the binary type as a reserved name
-		// within the output structs.
-		definedGlobals: map[string]bool{
-			ygot.BinaryTypeName: true,
-			ygot.EmptyTypeName:  true,
-		},
-		uniqueDirectoryNames:         make(map[string]string),
-		uniqueEnumeratedTypedefNames: make(map[string]string),
-		uniqueIdentityNames:          make(map[string]string),
-		uniqueEnumeratedLeafNames:    make(map[string]string),
-		uniqueProtoMsgNames:          make(map[string]map[string]bool),
-		uniqueProtoPackages:          make(map[string]string),
-		generatedUnions:              make(map[string]bool),
+// newEnumGenState creates a new enumGenState instance initialised with the
+// default state required for code generation.
+func newEnumGenState() *enumGenState {
+	return &enumGenState{
+		definedEnums:                 map[string]bool{},
+		uniqueIdentityNames:          map[string]string{},
+		uniqueEnumeratedTypedefNames: map[string]string{},
+		uniqueEnumeratedLeafNames:    map[string]string{},
 	}
 }
 
@@ -120,7 +82,7 @@ func newGenState() *genState {
 // value is calculated based on the original context, whether path compression is enabled based
 // on the compressPaths boolean, and whether the name should not include underscores, as per the
 // noUnderscores boolean.
-func (s *genState) enumeratedUnionEntry(e *yang.Entry, compressPaths, noUnderscores bool) ([]*yangEnum, error) {
+func (s *enumGenState) enumeratedUnionEntry(e *yang.Entry, compressPaths, noUnderscores bool) ([]*yangEnum, error) {
 	var es []*yangEnum
 
 	for _, t := range util.EnumeratedUnionTypes(e.Type.Type) {
@@ -174,13 +136,16 @@ func (s *genState) enumeratedUnionEntry(e *yang.Entry, compressPaths, noUndersco
 // entries that need struct or message definitions built for them. It resolves
 // each non-leaf yang.Entry to a Directory which contains the elements that are
 // needed for subsequent code generation. The name of the directory entry that
-// is returned is based on the generatedLanguage that is supplied. The
-// genFakeRoot argument tells to treat differently the fakeroot entry if it's
-// part of the input map. compBehaviour determines how to set the direct
-// children of a Directory, including whether those elements within the YANG
-// schema that are marked config false (i.e., are read only) are excluded from
-// the returned directories.
-func (s *genState) buildDirectoryDefinitions(entries map[string]*yang.Entry, compBehaviour genutil.CompressBehaviour, genFakeRoot bool, lang generatedLanguage) (map[string]*Directory, []error) {
+// is returned is based on the input genDirectoryName function. The type name
+// of list keys stored as part of the ListAttr attribute of the returned
+// Directories is calculated using the input resolveKeyTypeName function.
+// compBehaviour determines how to set the direct children of a Directory,
+// including whether those elements within the YANG schema that are marked
+// config false (i.e. are read only) are excluded from the returned
+// directories.
+func buildDirectoryDefinitions(entries map[string]*yang.Entry, compBehaviour genutil.CompressBehaviour,
+	genDirectoryName func(*yang.Entry) string, resolveKeyTypeName func(keyleaf *yang.Entry) (*MappedType, error)) (map[string]*Directory, []error) {
+
 	var errs []error
 	mappedStructs := make(map[string]*Directory)
 
@@ -198,21 +163,8 @@ func (s *genState) buildDirectoryDefinitions(entries map[string]*yang.Entry, com
 				Entry: e,
 			}
 
-			// Encode the name of the struct according to the language specified
-			// within the input arguments.
-			switch lang {
-			case protobuf:
-				// In the case of protobuf the message name is simply the camel
-				// case name that is specified.
-				elem.Name = s.protoMsgName(e, compBehaviour.CompressEnabled())
-			case golang:
-				// For Go, we map the name of the struct to the path elements
-				// in CamelCase separated by underscores.
-				elem.Name = s.goStructName(e, compBehaviour.CompressEnabled(), genFakeRoot)
-			default:
-				errs = append(errs, fmt.Errorf("unknown generating language specified for %s, got: %v", e.Name, lang))
-				continue
-			}
+			// Encode the name of the struct according to the input function.
+			elem.Name = genDirectoryName(e)
 
 			// Find the elements that should be rooted on this particular entity.
 			var fieldErr []error
@@ -235,7 +187,8 @@ func (s *genState) buildDirectoryDefinitions(entries map[string]*yang.Entry, com
 			// and returning a YangListAttr structure that describes how they should
 			// be represented.
 			if e.IsList() {
-				lattr, listErr := s.buildListKey(e, compBehaviour.CompressEnabled())
+				// Resolve the type name of the key according to the input function.
+				lattr, listErr := buildListKey(e, compBehaviour.CompressEnabled(), resolveKeyTypeName)
 				if listErr != nil {
 					errs = append(errs, listErr...)
 					continue
@@ -257,7 +210,7 @@ func (s *genState) buildDirectoryDefinitions(entries map[string]*yang.Entry, com
 // It also de-dups references to the same identity base, and type definitions.
 // If noUnderscores is set to true, then underscores are omitted from the enum
 // names to reflect to the preferred style of some generated languages.
-func (s *genState) findEnumSet(entries map[string]*yang.Entry, compressPaths, noUnderscores bool) (map[string]*yangEnum, []error) {
+func (s *enumGenState) findEnumSet(entries map[string]*yang.Entry, compressPaths, noUnderscores bool) (map[string]*yangEnum, []error) {
 	validEnums := make(map[string]*yang.Entry)
 	var enumNames []string
 	var errs []error
@@ -388,7 +341,7 @@ func (s *genState) findEnumSet(entries map[string]*yang.Entry, compressPaths, no
 // identity. If the noUnderscores bool is set to true, underscores are omitted
 // from the name returned such that the enumerated type name is compliant
 // with language styles where underscores are not allowed in names.
-func (s *genState) resolveIdentityRefBaseType(idr *yang.Entry, noUnderscores bool) string {
+func (s *enumGenState) resolveIdentityRefBaseType(idr *yang.Entry, noUnderscores bool) string {
 	return s.identityrefBaseTypeFromIdentity(idr.Type.IdentityBase, noUnderscores)
 }
 
@@ -398,7 +351,7 @@ func (s *genState) resolveIdentityRefBaseType(idr *yang.Entry, noUnderscores boo
 // of the identity's name. If noUnderscores is set to false, underscores are omitted
 // from the name returned such that the enumerated type name is compliant with
 // language styles where underscores are not allowed in names.
-func (s *genState) identityrefBaseTypeFromIdentity(i *yang.Identity, noUnderscores bool) string {
+func (s *enumGenState) identityrefBaseTypeFromIdentity(i *yang.Identity, noUnderscores bool) string {
 	definingModName := genutil.ParentModulePrettyName(i)
 
 	// As per a typedef that includes an enumeration, there is a many to one
@@ -416,7 +369,7 @@ func (s *genState) identityrefBaseTypeFromIdentity(i *yang.Identity, noUnderscor
 	}
 	// The name of an identityref base type must be unique within the entire generated
 	// code, so the context of name generation is global.
-	uniqueName := genutil.MakeNameUnique(name, s.definedGlobals)
+	uniqueName := genutil.MakeNameUnique(name, s.definedEnums)
 	s.uniqueIdentityNames[identityKey] = uniqueName
 	return uniqueName
 }
@@ -427,7 +380,7 @@ func (s *genState) identityrefBaseTypeFromIdentity(i *yang.Identity, noUnderscor
 // multiple times, and hence de-duplication of unique name generation is required.
 // If noUnderscores is set to true, then underscores are omitted from the
 // output name.
-func (s *genState) resolveEnumName(e *yang.Entry, compressPaths, noUnderscores bool) string {
+func (s *enumGenState) resolveEnumName(e *yang.Entry, compressPaths, noUnderscores bool) string {
 	// It is possible, given a particular enumerated leaf, for it to appear
 	// multiple times in the schema. For example, through being defined in
 	// a grouping which is instantiated in two places. In these cases, the
@@ -486,7 +439,7 @@ func (s *genState) resolveEnumName(e *yang.Entry, compressPaths, noUnderscores b
 		if noUnderscores {
 			name = strings.Replace(name, "_", "", -1)
 		}
-		uniqueName := genutil.MakeNameUnique(name, s.definedGlobals)
+		uniqueName := genutil.MakeNameUnique(name, s.definedEnums)
 		s.uniqueEnumeratedLeafNames[identifierPath] = uniqueName
 		return uniqueName
 	}
@@ -499,7 +452,7 @@ func (s *genState) resolveEnumName(e *yang.Entry, compressPaths, noUnderscores b
 		}
 		nbuf.WriteString(yang.CamelCase(p))
 	}
-	uniqueName := genutil.MakeNameUnique(nbuf.String(), s.definedGlobals)
+	uniqueName := genutil.MakeNameUnique(nbuf.String(), s.definedEnums)
 	s.uniqueEnumeratedLeafNames[identifierPath] = uniqueName
 	return uniqueName
 }
@@ -508,7 +461,7 @@ func (s *genState) resolveEnumName(e *yang.Entry, compressPaths, noUnderscores b
 // that has an underlying enumerated type (e.g., identityref or enumeration),
 // and resolves the name of the enum that will be generated in the corresponding
 // Go code.
-func (s *genState) resolveTypedefEnumeratedName(e *yang.Entry, noUnderscores bool) (string, error) {
+func (s *enumGenState) resolveTypedefEnumeratedName(e *yang.Entry, noUnderscores bool) (string, error) {
 	typeName := e.Type.Name
 
 	// Handle the case whereby we have been handed an enumeration that is within a
@@ -551,7 +504,7 @@ func (s *genState) resolveTypedefEnumeratedName(e *yang.Entry, noUnderscores boo
 	if noUnderscores {
 		name = strings.Replace(name, "_", "", -1)
 	}
-	uniqueName := genutil.MakeNameUnique(name, s.definedGlobals)
+	uniqueName := genutil.MakeNameUnique(name, s.definedEnums)
 	s.uniqueEnumeratedTypedefNames[typedefKey] = uniqueName
 	return uniqueName, nil
 }
@@ -565,7 +518,7 @@ func (s *genState) resolveTypedefEnumeratedName(e *yang.Entry, noUnderscores boo
 // of the enumerated typedef.
 // It returns an error if the type does include an enumerated typedef, but this
 // typedef is invalid.
-func (s *genState) enumeratedTypedefTypeName(args resolveTypeArgs, prefix string, noUnderscores bool) (*MappedType, error) {
+func (s *enumGenState) enumeratedTypedefTypeName(args resolveTypeArgs, prefix string, noUnderscores bool) (*MappedType, error) {
 	// If the type that is specified is not a built-in type (i.e., one of those
 	// types which is defined in RFC6020/RFC7950) then we establish what the type
 	// that we must actually perform the mapping for is. By default, start with
@@ -594,13 +547,22 @@ func (s *genState) enumeratedTypedefTypeName(args resolveTypeArgs, prefix string
 	return nil, nil
 }
 
+// genHelper contains helper functions specific to code generation.
+// Its fields must be set for full functionality.
+type genHelper struct {
+	// schematree stores a ctree.Tree structure that represents the YANG
+	// schema tree. This is used for lookups within the module set where
+	// they are required, e.g., for leafrefs.
+	schematree *ctree.Tree
+}
+
 // resolveLeafrefTarget takes an input path and context entry and
 // determines the type of the leaf that is referred to by the path, such that
 // it can be mapped to a native language type. It returns the yang.YangType that
 // is associated with the target, and the target yang.Entry, such that the
 // caller can map this to the relevant language type.
-func (s *genState) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
-	if s.schematree == nil {
+func (h *genHelper) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
+	if h.schematree == nil {
 		// This should not be possible if the calling code generation is
 		// well structured and builds the schematree during parsing of YANG
 		// files.
@@ -612,9 +574,9 @@ func (s *genState) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (
 		return nil, err
 	}
 
-	e := s.schematree.GetLeafValue(fixedPath)
+	e := h.schematree.GetLeafValue(fixedPath)
 	if e == nil {
-		return nil, fmt.Errorf("could not resolve leafref path: %v from %v, tree: %v", fixedPath, contextEntry, s.schematree)
+		return nil, fmt.Errorf("could not resolve leafref path: %v from %v, tree: %v", fixedPath, contextEntry, h.schematree)
 	}
 
 	target, ok := e.(*yang.Entry)

--- a/ygen/genstate_test.go
+++ b/ygen/genstate_test.go
@@ -2447,8 +2447,7 @@ func TestResolveLeafrefTargetType(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: buildSchemaTree(%v): got unexpected error: %v", tt.name, tt.inEntries, err)
 		}
-		h := genHelper{schematree: st}
-		got, err := h.resolveLeafrefTarget(tt.inPath, tt.inContextEntry)
+		got, err := st.resolveLeafrefTarget(tt.inPath, tt.inContextEntry)
 		if err != nil {
 			if !tt.wantErr {
 				t.Errorf("%s: resolveLeafrefTargetPath(%v, %v): got unexpected error: %v", tt.name, tt.inPath, tt.inContextEntry, err)

--- a/ygen/genstate_test.go
+++ b/ygen/genstate_test.go
@@ -922,7 +922,7 @@ func TestFindEnumSet(t *testing.T) {
 			wantUncompressed = tt.wantUncompressed
 		}
 		for compressed, wanted := range map[bool]map[string]*yangEnum{true: tt.wantCompressed, false: wantUncompressed} {
-			state := newGenState()
+			state := newEnumGenState()
 			entries, errs := state.findEnumSet(tt.in, compressed, tt.inOmitUnderscores)
 
 			if (errs != nil) != tt.wantErr {
@@ -1092,7 +1092,7 @@ func TestStructName(t *testing.T) {
 
 	for _, tt := range tests {
 		for compress, expected := range map[bool]string{false: tt.wantUncompressed, true: tt.wantCompressed} {
-			s := newGenState()
+			s := newGoGenState(nil)
 			if out := s.goStructName(tt.inElement, compress, false); out != expected {
 				t.Errorf("%s (compress: %v): shortName output invalid - got: %s, want: %s", tt.name, compress, out, expected)
 			}
@@ -2286,13 +2286,12 @@ func TestBuildDirectoryDefinitions(t *testing.T) {
 			}
 
 			t.Run(fmt.Sprintf("%s:buildDirectoryDefinitions(CompressBehaviour:%v,Language:%s,excludeState:%v)", tt.name, c.compressBehaviour, langName(c.lang), c.excludeState), func(t *testing.T) {
-				state := newGenState()
-
 				st, err := buildSchemaTree(tt.in)
 				if err != nil {
 					t.Fatalf("buildSchemaTree(%v), got unexpected err: %v", tt.in, err)
 				}
-				state.schematree = st
+				gogen := newGoGenState(st)
+				protogen := newProtoGenState(st)
 
 				structs := make(map[string]*yang.Entry)
 				enums := make(map[string]*yang.Entry)
@@ -2307,7 +2306,13 @@ func TestBuildDirectoryDefinitions(t *testing.T) {
 					t.Fatalf("findMappableEntities(%v, %v, %v, nil, %v, nil): got unexpected error, want: nil, got: %v", tt.in, structs, enums, c.compressBehaviour.CompressEnabled(), err)
 				}
 
-				got, errs := state.buildDirectoryDefinitions(structs, c.compressBehaviour, false, c.lang)
+				var got map[string]*Directory
+				switch c.lang {
+				case golang:
+					got, errs = gogen.buildDirectoryDefinitions(structs, c.compressBehaviour, false)
+				case protobuf:
+					got, errs = protogen.buildDirectoryDefinitions(structs, c.compressBehaviour)
+				}
 				if errs != nil {
 					t.Fatal(errs)
 				}
@@ -2442,9 +2447,8 @@ func TestResolveLeafrefTargetType(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: buildSchemaTree(%v): got unexpected error: %v", tt.name, tt.inEntries, err)
 		}
-		s := newGenState()
-		s.schematree = st
-		got, err := s.resolveLeafrefTarget(tt.inPath, tt.inContextEntry)
+		h := genHelper{schematree: st}
+		got, err := h.resolveLeafrefTarget(tt.inPath, tt.inContextEntry)
 		if err != nil {
 			if !tt.wantErr {
 				t.Errorf("%s: resolveLeafrefTargetPath(%v, %v): got unexpected error: %v", tt.name, tt.inPath, tt.inContextEntry, err)

--- a/ygen/goelements_test.go
+++ b/ygen/goelements_test.go
@@ -722,7 +722,7 @@ func TestYangTypeToGoType(t *testing.T) {
 				if err != nil {
 					t.Fatalf("buildSchemaTree(%v): could not build schema tree: %v", tt.inEntries, err)
 				}
-				s.helper.schematree = st
+				s.schematree = st
 			}
 
 			args := resolveTypeArgs{
@@ -1153,7 +1153,7 @@ func TestBuildListKey(t *testing.T) {
 				t.Errorf("%s: buildSchemaTree(%v), could not build tree: %v", tt.name, tt.inEntries, err)
 				continue
 			}
-			s.helper.schematree = st
+			s.schematree = st
 		}
 
 		resolveKeyTypeName := func(keyleaf *yang.Entry) (*MappedType, error) {

--- a/ygen/goelements_test.go
+++ b/ygen/goelements_test.go
@@ -201,7 +201,7 @@ func TestUnionSubTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := newGenState()
+			s := newGoGenState(nil)
 			mtypes := make(map[int]*MappedType)
 			ctypes := make(map[string]int)
 			errs := s.goUnionSubTypes(tt.in, tt.inCtxEntry, ctypes, mtypes, false)
@@ -716,13 +716,13 @@ func TestYangTypeToGoType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := newGenState()
+			s := newGoGenState(nil)
 			if tt.inEntries != nil {
 				st, err := buildSchemaTree(tt.inEntries)
 				if err != nil {
 					t.Fatalf("buildSchemaTree(%v): could not build schema tree: %v", tt.inEntries, err)
 				}
-				s.schematree = st
+				s.helper.schematree = st
 			}
 
 			args := resolveTypeArgs{
@@ -753,12 +753,13 @@ func TestYangTypeToGoType(t *testing.T) {
 // struct is returned representing the keys of the list e.
 func TestBuildListKey(t *testing.T) {
 	tests := []struct {
-		name       string        // name is the test identifier.
-		in         *yang.Entry   // in is the yang.Entry of the test list.
-		inCompress bool          // inCompress is a boolean indicating whether CompressOCPaths should be true/false.
-		inEntries  []*yang.Entry // inEntries is used to provide context entries in the schema, particularly where a leafref key is used.
-		want       YangListAttr  // want is the expected YangListAttr output.
-		wantErr    bool          // wantErr is a boolean indicating whether errors are expected from buildListKeys
+		name                    string        // name is the test identifier.
+		in                      *yang.Entry   // in is the yang.Entry of the test list.
+		inCompress              bool          // inCompress is a boolean indicating whether CompressOCPaths should be true/false.
+		inEntries               []*yang.Entry // inEntries is used to provide context entries in the schema, particularly where a leafref key is used.
+		inResolveKeyNameFuncNil bool          // inResolveKeyNameFuncNil specifies whether the key name function is not provided.
+		want                    YangListAttr  // want is the expected YangListAttr output.
+		wantErr                 bool          // wantErr is a boolean indicating whether errors are expected from buildListKeys
 	}{{
 		name: "non-list",
 		in: &yang.Entry{
@@ -810,6 +811,28 @@ func TestBuildListKey(t *testing.T) {
 			Keys: map[string]*MappedType{
 				"keyleaf": {NativeType: "string"},
 			},
+			KeyElems: []*yang.Entry{
+				{
+					Name: "keyleaf",
+					Type: &yang.YangType{Kind: yang.Ystring},
+				},
+			},
+		},
+	}, {
+		name: "basic list key test with nil resolve key name function",
+		in: &yang.Entry{
+			Name:     "list",
+			ListAttr: &yang.ListAttr{},
+			Key:      "keyleaf",
+			Dir: map[string]*yang.Entry{
+				"keyleaf": {
+					Name: "keyleaf",
+					Type: &yang.YangType{Kind: yang.Ystring},
+				},
+			},
+		},
+		inResolveKeyNameFuncNil: true,
+		want: YangListAttr{
 			KeyElems: []*yang.Entry{
 				{
 					Name: "keyleaf",
@@ -1123,17 +1146,24 @@ func TestBuildListKey(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		s := newGenState()
+		s := newGoGenState(nil)
 		if tt.inEntries != nil {
 			st, err := buildSchemaTree(tt.inEntries)
 			if err != nil {
 				t.Errorf("%s: buildSchemaTree(%v), could not build tree: %v", tt.name, tt.inEntries, err)
 				continue
 			}
-			s.schematree = st
+			s.helper.schematree = st
 		}
 
-		got, err := s.buildListKey(tt.in, tt.inCompress)
+		resolveKeyTypeName := func(keyleaf *yang.Entry) (*MappedType, error) {
+			return s.yangTypeToGoType(resolveTypeArgs{yangType: keyleaf.Type, contextEntry: keyleaf}, tt.inCompress)
+		}
+		if tt.inResolveKeyNameFuncNil {
+			resolveKeyTypeName = nil
+		}
+
+		got, err := buildListKey(tt.in, tt.inCompress, resolveKeyTypeName)
 		if err != nil && !tt.wantErr {
 			t.Errorf("%s: could not build list key successfully %v", tt.name, err)
 		}
@@ -1256,7 +1286,7 @@ func TestTypeResolutionManyToOne(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		s := newGenState()
+		s := newGoGenState(nil)
 		gotTypes := make(map[string]*MappedType)
 		for _, leaf := range tt.inLeaves {
 			mtype, err := s.yangTypeToGoType(resolveTypeArgs{yangType: leaf.Type, contextEntry: leaf}, tt.inCompressOCPaths)

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -1706,7 +1706,7 @@ func (t *Container) ΛEnumTypeMap() map[string][]reflect.Type { return ΛEnumTyp
 				tt.wantUncompressed = tt.wantCompressed
 			}
 			for compressed, want := range map[bool]wantGoStructOut{true: tt.wantCompressed, false: tt.wantUncompressed} {
-				s := newGenState()
+				s := newGoGenState(nil)
 				s.uniqueDirectoryNames = tt.inUniqueDirectoryNames
 
 				// Always generate the JSON schema for this test.

--- a/ygen/protoelements.go
+++ b/ygen/protoelements.go
@@ -19,10 +19,67 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/openconfig/gnmi/ctree"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/genutil"
 	"github.com/openconfig/ygot/util"
 )
+
+// protoGenState contains the functionality and state for generating proto
+// names for the generated code.
+type protoGenState struct {
+	// enumGen contains functionality and state for generating enum names.
+	enumGen *enumGenState
+	// helper contains helper functions used for generation.
+	helper *genHelper
+	// definedGlobals specifies the global proto names used during code
+	// generation to avoid conflicts.
+	definedGlobals map[string]bool
+	// uniqueDirectoryNames is a map keyed by the path of a YANG entity representing a
+	// directory in the generated code whose value is the unique name that it
+	// was mapped to. This allows routines to determine, based on a particular YANG
+	// entry, how to refer to it when generating code.
+	uniqueDirectoryNames map[string]string
+	// uniqueProtoMsgNames is a map, keyed by a protobuf package name, that
+	// contains a map keyed by protobuf message name strings that indicates the
+	// names that are used within the generated package's context. It is used
+	// during code generation to ensure uniqueness of the generated names within
+	// the specified package.
+	uniqueProtoMsgNames map[string]map[string]bool
+	// uniqueProtoPackages is a map, keyed by a YANG schema path, that allows
+	// a path to be resolved into the calculated Protobuf package name that
+	// is to be used for it.
+	uniqueProtoPackages map[string]string
+}
+
+// newProtoGenState creates a new protoGenState instance, initialised with the
+// default state required for code generation.
+func newProtoGenState(schematree *ctree.Tree) *protoGenState {
+	return &protoGenState{
+		enumGen:              newEnumGenState(),
+		helper:               &genHelper{schematree: schematree},
+		definedGlobals:       map[string]bool{},
+		uniqueDirectoryNames: map[string]string{},
+		uniqueProtoMsgNames:  map[string]map[string]bool{},
+		uniqueProtoPackages:  map[string]string{},
+	}
+}
+
+// buildDirectoryDefinitions extracts the yang.Entry instances from a map of
+// entries that need struct definitions built for them. It resolves each
+// non-leaf yang.Entry to a Directory which contains the elements that are
+// needed for subsequent code generation.
+func (s *protoGenState) buildDirectoryDefinitions(entries map[string]*yang.Entry, compBehaviour genutil.CompressBehaviour) (map[string]*Directory, []error) {
+	return buildDirectoryDefinitions(entries, compBehaviour,
+		// In the case of protobuf the message name is simply the camel
+		// case name that is specified.
+		func(e *yang.Entry) string {
+			return s.protoMsgName(e, compBehaviour.CompressEnabled())
+		},
+		// protobuf's key types are handled at a different place.
+		nil,
+	)
+}
 
 // resolveProtoTypeArgs specifies input parameters required for resolving types
 // from YANG to protobuf.
@@ -51,9 +108,9 @@ type resolveProtoTypeArgs struct {
 //
 // See https://github.com/openconfig/ygot/blob/master/docs/yang-to-protobuf-transformations-spec.md
 // for additional details as to the transformation from YANG to Protobuf.
-func (s *genState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
+func (s *protoGenState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
 	// Handle typedef cases.
-	mtype, err := s.enumeratedTypedefTypeName(args, fmt.Sprintf("%s.%s.", pargs.basePackageName, pargs.enumPackageName), true)
+	mtype, err := s.enumGen.enumeratedTypedefTypeName(args, fmt.Sprintf("%s.%s.", pargs.basePackageName, pargs.enumPackageName), true)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +136,7 @@ func (s *genState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoT
 	case yang.Yleafref:
 		// We look up the leafref in the schema tree to be able to
 		// determine what type to map to.
-		target, err := s.resolveLeafrefTarget(args.yangType.Path, args.contextEntry)
+		target, err := s.helper.resolveLeafrefTarget(args.yangType.Path, args.contextEntry)
 		if err != nil {
 			return nil, err
 		}
@@ -122,9 +179,9 @@ func (s *genState) yangTypeToProtoType(args resolveTypeArgs, pargs resolveProtoT
 // yangTypeToProtoScalarType takes an input resolveTypeArgs and returns the protobuf
 // in-built type that is used to represent it. It is used within list keys where the
 // value cannot be nil/unset.
-func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
+func (s *protoGenState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
 	// Handle typedef cases.
-	mtype, err := s.enumeratedTypedefTypeName(args, fmt.Sprintf("%s.%s.", pargs.basePackageName, pargs.enumPackageName), true)
+	mtype, err := s.enumGen.enumeratedTypedefTypeName(args, fmt.Sprintf("%s.%s.", pargs.basePackageName, pargs.enumPackageName), true)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +206,7 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 		// as there is not an equivalent Protobuf type.
 		return &MappedType{NativeType: "ywrapper.Decimal64Value"}, nil
 	case yang.Yleafref:
-		target, err := s.resolveLeafrefTarget(args.yangType.Path, args.contextEntry)
+		target, err := s.helper.resolveLeafrefTarget(args.yangType.Path, args.contextEntry)
 		if err != nil {
 			return nil, err
 		}
@@ -204,7 +261,7 @@ func (s *genState) yangTypeToProtoScalarType(args resolveTypeArgs, pargs resolve
 // }
 //
 // The MappedType's UnionTypes can be output through a template into the oneof.
-func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
+func (s *protoGenState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeArgs) (*MappedType, error) {
 	unionTypes := make(map[string]*yang.YangType)
 	if errs := s.protoUnionSubTypes(args.yangType, args.contextEntry, unionTypes, pargs); errs != nil {
 		return nil, fmt.Errorf("errors mapping element: %v", errs)
@@ -270,7 +327,7 @@ func (s *genState) protoUnionType(args resolveTypeArgs, pargs resolveProtoTypeAr
 // with is required for mapping. The currentType map is updated as an in-out argument. The basePackageName and enumPackageName
 // are used to map enumerated typedefs and identityrefs to the correct type. It returns a slice of errors if they occur
 // mapping subtypes.
-func (s *genState) protoUnionSubTypes(subtype *yang.YangType, ctx *yang.Entry, currentTypes map[string]*yang.YangType, pargs resolveProtoTypeArgs) []error {
+func (s *protoGenState) protoUnionSubTypes(subtype *yang.YangType, ctx *yang.Entry, currentTypes map[string]*yang.YangType, pargs resolveProtoTypeArgs) []error {
 	var errs []error
 	if util.IsUnionType(subtype) {
 		for _, st := range subtype.Type {
@@ -308,7 +365,7 @@ func (s *genState) protoUnionSubTypes(subtype *yang.YangType, ctx *yang.Entry, c
 // protoMsgName takes a yang.Entry and converts it to its protobuf message name,
 // ensuring that the name that is returned is unique within the package that it is
 // being contained within.
-func (s *genState) protoMsgName(e *yang.Entry, compressPaths bool) string {
+func (s *protoGenState) protoMsgName(e *yang.Entry, compressPaths bool) string {
 	// Return a cached name if one has already been computed.
 	if n, ok := s.uniqueDirectoryNames[e.Path()]; ok {
 		return n
@@ -336,7 +393,7 @@ func (s *genState) protoMsgName(e *yang.Entry, compressPaths bool) string {
 // are omitted from the path, i.e., /openconfig-interfaces/interfaces/interface/config/name
 // becomes interface (since modules, surrounding containers, and config/state containers
 // are not considered with path compression enabled.
-func (s *genState) protobufPackage(e *yang.Entry, compressPaths bool) string {
+func (s *protoGenState) protobufPackage(e *yang.Entry, compressPaths bool) string {
 	if IsFakeRoot(e) {
 		return ""
 	}
@@ -383,6 +440,6 @@ func (s *genState) protobufPackage(e *yang.Entry, compressPaths bool) string {
 }
 
 // protoIdentityName returns the name that should be used for an identityref base.
-func (s *genState) protoIdentityName(pargs resolveProtoTypeArgs, i *yang.Identity) string {
-	return fmt.Sprintf("%s.%s.%s", pargs.basePackageName, pargs.enumPackageName, s.identityrefBaseTypeFromIdentity(i, true))
+func (s *protoGenState) protoIdentityName(pargs resolveProtoTypeArgs, i *yang.Identity) string {
+	return fmt.Sprintf("%s.%s.%s", pargs.basePackageName, pargs.enumPackageName, s.enumGen.identityrefBaseTypeFromIdentity(i, true))
 }

--- a/ygen/protoelements_test.go
+++ b/ygen/protoelements_test.go
@@ -553,7 +553,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 			rpt = *tt.inResolveProtoTypeArgs
 		}
 
-		s := newGenState()
+		s := newProtoGenState(nil)
 		// Seed the schema tree with the injected entries, used to ensure leafrefs can
 		// be resolved.
 		if tt.inEntries != nil {
@@ -562,7 +562,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				t.Errorf("%s: buildSchemaTree(%v): got unexpected error, got: %v, want: nil", tt.name, tt.inEntries, err)
 				continue
 			}
-			s.schematree = tree
+			s.helper.schematree = tree
 		}
 
 		for _, st := range tt.in {
@@ -673,7 +673,7 @@ func TestProtoMsgName(t *testing.T) {
 
 	for _, tt := range tests {
 		for compress, want := range map[bool]string{true: tt.wantCompress, false: tt.wantUncompress} {
-			s := newGenState()
+			s := newProtoGenState(nil)
 			// Seed the proto message names with some known input.
 			if tt.inUniqueProtoMsgNames != nil {
 				s.uniqueProtoMsgNames = tt.inUniqueProtoMsgNames
@@ -808,7 +808,7 @@ func TestProtoPackageName(t *testing.T) {
 
 	for _, tt := range tests {
 		for compress, want := range map[bool]string{true: tt.wantCompress, false: tt.wantUncompress} {
-			s := newGenState()
+			s := newProtoGenState(nil)
 			if tt.inDefinedGlobals != nil {
 				s.definedGlobals = tt.inDefinedGlobals
 			}

--- a/ygen/protoelements_test.go
+++ b/ygen/protoelements_test.go
@@ -562,7 +562,7 @@ func TestYangTypeToProtoType(t *testing.T) {
 				t.Errorf("%s: buildSchemaTree(%v): got unexpected error, got: %v, want: nil", tt.name, tt.inEntries, err)
 				continue
 			}
-			s.helper.schematree = tree
+			s.schematree = tree
 		}
 
 		for _, st := range tt.in {

--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -1167,7 +1167,7 @@ func genListKeyProto(listPackage string, listName string, args *protoDefinitionA
 		var unionEntry *yang.Entry
 		switch {
 		case kf.Type.Kind == yang.Yleafref:
-			target, err := args.protogen.helper.resolveLeafrefTarget(kf.Type.Path, kf)
+			target, err := args.protogen.schematree.resolveLeafrefTarget(kf.Type.Path, kf)
 			if err != nil {
 				return nil, fmt.Errorf("error generating type for list %s key %s: type %v", args.field.Path(), k, kf.Type)
 			}

--- a/ygen/protogen_test.go
+++ b/ygen/protogen_test.go
@@ -657,7 +657,7 @@ func TestGenProto3Msg(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		s := newGenState()
+		s := newProtoGenState(nil)
 		// Seed the state with the supplied message names that have been provided.
 		s.uniqueDirectoryNames = tt.inUniqueDirectoryNames
 
@@ -1404,7 +1404,7 @@ message MessageName {
 	for _, tt := range tests {
 		wantErr := map[bool]bool{true: tt.wantCompressErr, false: tt.wantUncompressErr}
 		for compress, want := range map[bool]*generatedProto3Message{true: tt.wantCompress, false: tt.wantUncompress} {
-			s := newGenState()
+			s := newProtoGenState(nil)
 			// Seed the message names with the supplied input.
 			s.uniqueDirectoryNames = tt.inUniqueDirectoryNames
 
@@ -1474,7 +1474,7 @@ func TestGenListKeyProto(t *testing.T) {
 				},
 			},
 			definedDirectories: map[string]*Directory{},
-			state: &genState{
+			protogen: &protoGenState{
 				uniqueDirectoryNames: map[string]string{
 					"/list": "List",
 				},
@@ -1527,7 +1527,7 @@ func TestGenListKeyProto(t *testing.T) {
 				},
 			},
 			definedDirectories: map[string]*Directory{},
-			state: &genState{
+			protogen: &protoGenState{
 				uniqueDirectoryNames: map[string]string{
 					"/list": "List",
 				},
@@ -1589,7 +1589,7 @@ func TestGenListKeyProto(t *testing.T) {
 				},
 			},
 			definedDirectories: map[string]*Directory{},
-			state: &genState{
+			protogen: &protoGenState{
 				uniqueDirectoryNames: map[string]string{
 					"/list": "List",
 				},

--- a/ygen/schematree.go
+++ b/ygen/schematree.go
@@ -24,13 +24,19 @@ import (
 	"github.com/openconfig/ygot/util"
 )
 
+// schemaTree contains a ctree.Tree that stores a copy of the YANG schema tree
+// containing only leaf entries, such that schema paths can be referenced.
+type schemaTree struct {
+	ctree.Tree
+}
+
 // buildSchemaTree maps a set of yang.Entry pointers into a ctree structure.
 // Only leaf or leaflist values are mapped, since these are the only entities
 // that can be referenced by XPATH expressions within a YANG schema.
 // It returns an error if there is duplication within the set of entries. The
 // paths that are used within the schema are represented as a slice of strings.
-func buildSchemaTree(entries []*yang.Entry) (*ctree.Tree, error) {
-	t := &ctree.Tree{}
+func buildSchemaTree(entries []*yang.Entry) (*schemaTree, error) {
+	t := &schemaTree{}
 	for _, e := range entries {
 		pp := strings.Split(e.Path(), "/")
 		// We only want to find entities that are at the root of the
@@ -56,9 +62,40 @@ func buildSchemaTree(entries []*yang.Entry) (*ctree.Tree, error) {
 	return t, nil
 }
 
+// resolveLeafrefTarget takes an input path and context entry and
+// determines the type of the leaf that is referred to by the path, such that
+// it can be mapped to a native language type. It returns the yang.YangType that
+// is associated with the target, and the target yang.Entry, such that the
+// caller can map this to the relevant language type.
+func (t *schemaTree) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
+	if t == nil {
+		// This should not be possible if the calling code generation is
+		// well structured and builds the schematree during parsing of YANG
+		// files.
+		return nil, fmt.Errorf("could not map leafref path: %v, from contextEntry: %v", path, contextEntry)
+	}
+
+	fixedPath, err := fixSchemaTreePath(path, contextEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	e := t.GetLeafValue(fixedPath)
+	if e == nil {
+		return nil, fmt.Errorf("could not resolve leafref path: %v from %v, tree: %v", fixedPath, contextEntry, t)
+	}
+
+	target, ok := e.(*yang.Entry)
+	if !ok {
+		return nil, fmt.Errorf("invalid element returned from schema tree, must be a yang.Entry for path %v from %v", path, contextEntry)
+	}
+
+	return target, nil
+}
+
 // schemaTreeChildrenAdd adds the children of the supplied yang.Entry to the
 // supplied ctree.Tree recursively.
-func schemaTreeChildrenAdd(t *ctree.Tree, e *yang.Entry) error {
+func schemaTreeChildrenAdd(t *schemaTree, e *yang.Entry) error {
 	for _, ch := range util.Children(e) {
 		chPath := strings.Split(ch.Path(), "/")
 		// chPath is of the form []string{"", "module", "entity", "child"}


### PR DESCRIPTION
Currently, genState contains all the internal state variables and
generation functions for both Go and proto, making the code more
confusing than necessary and changes to the code seemingly more
precarious due to the lack of clear separation between Go and proto
generation. This is a problem for both the reader of the code as well as
maintainers.

To help with this, genState is split into protoGenState, goGenState,
enumGenState, and genHelper. genHelper contains helpers used for
generation, and enumGenState contains functionality and internal state
used for generating enum names. These two are language independent.
protoGenState and goGenState then contains the language-specific
generation functionalities.

The generation methods are partitioned either into one of these new
smaller generators, or became independent of generation state and lost
their receivers, making each of the generators easier to understand.