### PR TITLE
Add TolerateJSONInconsistencies option for SetNode

### DIFF
--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -497,9 +497,7 @@ func unmarshalUnion(schema *yang.Entry, parent interface{}, fieldName string, va
 	var valueStr string
 	var ok bool
 	switch enc {
-	case GNMIEncoding:
-		fallthrough
-	case gNMIEncodingWithJSONTolerance:
+	case GNMIEncoding, gNMIEncodingWithJSONTolerance:
 		var sv *gpb.TypedValue_StringVal
 		if sv, ok = value.(*gpb.TypedValue).GetValue().(*gpb.TypedValue_StringVal); ok {
 			valueStr = sv.StringVal

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -498,6 +498,8 @@ func unmarshalUnion(schema *yang.Entry, parent interface{}, fieldName string, va
 	var ok bool
 	switch enc {
 	case GNMIEncoding:
+		fallthrough
+	case gNMIEncodingWithJSONTolerance:
 		var sv *gpb.TypedValue_StringVal
 		if sv, ok = value.(*gpb.TypedValue).GetValue().(*gpb.TypedValue_StringVal); ok {
 			valueStr = sv.StringVal
@@ -665,11 +667,13 @@ func unmarshalScalar(parent interface{}, schema *yang.Entry, fieldName string, v
 	case JSONEncoding:
 		return sanitizeJSON(parent, schema, fieldName, value)
 	case GNMIEncoding:
+		fallthrough
+	case gNMIEncodingWithJSONTolerance:
 		tv, ok := value.(*gpb.TypedValue)
 		if !ok {
 			return nil, fmt.Errorf("got %T type, want gNMI TypedValue as value type", value)
 		}
-		return sanitizeGNMI(parent, schema, fieldName, tv)
+		return sanitizeGNMI(parent, schema, fieldName, tv, enc == gNMIEncodingWithJSONTolerance)
 	}
 
 	return nil, fmt.Errorf("unknown encoding mode; %v", enc)
@@ -762,15 +766,18 @@ func sanitizeJSON(parent interface{}, schema *yang.Entry, fieldName string, valu
 	return nil, fmt.Errorf("unmarshalScalar: unsupported type %v in schema node %s", ykind, schema.Name)
 }
 
-// sanitizeGNMI decodes the GNMI TypedValue encoded value into the type of
-// corresponding field in GoStruct. Parent is the parent struct containing the
+// sanitizeGNMI decodes the GNMI TypedValue encoded value into a field of the
+// corresponding type in GoStruct. Parent is the parent struct containing the
 // field being unmarshaled. schema is *yang.Entry corresponding to the field.
-// fieldName is the name of the field being written in GoStruct. value is the
-// JSON encoded value.
-func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *gpb.TypedValue) (interface{}, error) {
+// fieldName is the name of the field being written in GoStruct. tv is the
+// JSON encoded value. jsonTolerance means to allow some otherwise nonmatching
+// types to match due to inconsistencies after json translation; for now, this
+// just involves accepting positive ints as uints.
+func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *gpb.TypedValue, jsonTolerance bool) (interface{}, error) {
 	ykind := schema.Type.Kind
 
-	if !gNMIToYANGTypeMatches(ykind, tv) {
+	var ok bool
+	if ok, tv = gNMIToYANGTypeMatches(ykind, tv, jsonTolerance); !ok {
 		return nil, fmt.Errorf("failed to unmarshal %v into %v", tv.GetValue(), yang.TypeKindToName[ykind])
 	}
 
@@ -817,10 +824,14 @@ func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *
 }
 
 // gNMIToYANGTypeMatches checks whether the provided yang.TypeKind can be set
-// by using the provided gNMI TypedValue. gNMI TypedValue oneof fields can
+// by using the provided gNMI TypedValue, and returns the TypedValue that
+// should be used to get the underlying value. gNMI TypedValue oneof fields can
 // carry more than one sizes of the same type per gNMI specification:
 // https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#223-node-values
-func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue) bool {
+// jsonTolerance means to allow some otherwise nonmatching types to match due
+// to inconsistencies after json translation; for now, this just involves
+// accepting positive ints as uints.
+func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue, jsonTolerance bool) (bool, *gpb.TypedValue) {
 	var ok bool
 	switch ykind {
 	case yang.Ybool:
@@ -831,6 +842,12 @@ func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue) bool {
 		_, ok = tv.GetValue().(*gpb.TypedValue_IntVal)
 	case yang.Yuint8, yang.Yuint16, yang.Yuint32, yang.Yuint64:
 		_, ok = tv.GetValue().(*gpb.TypedValue_UintVal)
+		if !ok && jsonTolerance {
+			// Allow positive ints to be treated as uints.
+			if v, intOk := tv.GetValue().(*gpb.TypedValue_IntVal); intOk && v.IntVal >= 0 {
+				return true, &gpb.TypedValue{Value: &gpb.TypedValue_UintVal{uint64(v.IntVal)}}
+			}
+		}
 	case yang.Ybinary:
 		_, ok = tv.GetValue().(*gpb.TypedValue_BytesVal)
 	case yang.Ydecimal64:
@@ -839,7 +856,7 @@ func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue) bool {
 			_, ok = tv.GetValue().(*gpb.TypedValue_FloatVal)
 		}
 	}
-	return ok
+	return ok, tv
 }
 
 // isValueInterfacePtrToEnum reports whether v is an interface ptr to enum type.

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -845,7 +845,7 @@ func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue, jsonToleranc
 		if !ok && jsonTolerance {
 			// Allow positive ints to be treated as uints.
 			if v, intOk := tv.GetValue().(*gpb.TypedValue_IntVal); intOk && v.IntVal >= 0 {
-				return true, &gpb.TypedValue{Value: &gpb.TypedValue_UintVal{uint64(v.IntVal)}}
+				return true, &gpb.TypedValue{Value: &gpb.TypedValue_UintVal{UintVal: uint64(v.IntVal)}}
 			}
 		}
 	case yang.Ybinary:

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -664,9 +664,7 @@ func unmarshalScalar(parent interface{}, schema *yang.Entry, fieldName string, v
 	switch enc {
 	case JSONEncoding:
 		return sanitizeJSON(parent, schema, fieldName, value)
-	case GNMIEncoding:
-		fallthrough
-	case gNMIEncodingWithJSONTolerance:
+	case GNMIEncoding, gNMIEncodingWithJSONTolerance:
 		tv, ok := value.(*gpb.TypedValue)
 		if !ok {
 			return nil, fmt.Errorf("got %T type, want gNMI TypedValue as value type", value)
@@ -843,8 +841,7 @@ func gNMIToYANGTypeMatches(ykind yang.TypeKind, tv *gpb.TypedValue, jsonToleranc
 		if !ok && jsonTolerance {
 			// Allow positive ints to be treated as uints.
 			if v, intOk := tv.GetValue().(*gpb.TypedValue_IntVal); intOk && v.IntVal >= 0 {
-				tv.Value = &gpb.TypedValue_UintVal{UintVal: uint64(v.IntVal)}
-				return true
+				ok, tv.Value = true, &gpb.TypedValue_UintVal{UintVal: uint64(v.IntVal)}
 			}
 		}
 	case yang.Ybinary:

--- a/ytypes/leaf_list.go
+++ b/ytypes/leaf_list.go
@@ -105,6 +105,8 @@ func unmarshalLeafList(schema *yang.Entry, parent interface{}, value interface{}
 
 	switch enc {
 	case GNMIEncoding:
+		fallthrough
+	case gNMIEncodingWithJSONTolerance:
 		if _, ok := value.(*gpb.TypedValue); !ok {
 			return fmt.Errorf("unmarshalLeafList for schema %s: value %v: got type %T, expect *gpb.TypedValue", schema.Name, util.ValueStr(value), value)
 		}

--- a/ytypes/leaf_list.go
+++ b/ytypes/leaf_list.go
@@ -104,9 +104,7 @@ func unmarshalLeafList(schema *yang.Entry, parent interface{}, value interface{}
 	leafSchema.ListAttr = nil
 
 	switch enc {
-	case GNMIEncoding:
-		fallthrough
-	case gNMIEncodingWithJSONTolerance:
+	case GNMIEncoding, gNMIEncodingWithJSONTolerance:
 		if _, ok := value.(*gpb.TypedValue); !ok {
 			return fmt.Errorf("unmarshalLeafList for schema %s: value %v: got type %T, expect *gpb.TypedValue", schema.Name, util.ValueStr(value), value)
 		}

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -164,8 +164,7 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 					// With GNMIEncoding, unmarshalGeneric can only unmarshal leaf or leaf list
 					// nodes. Schema provided must be the schema of the leaf or leaf list node.
 					// root must be the reference of container leaf/leaf list belongs to.
-					var encoding Encoding
-					encoding = GNMIEncoding
+					encoding := GNMIEncoding
 					if args.tolerateJSONInconsistenciesForVal {
 						encoding = gNMIEncodingWithJSONTolerance
 					}

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -48,6 +48,11 @@ type retrieveNodeArgs struct {
 	// If val is set to a non-nil value, leaf/leaflist node corresponding
 	// to the given path is updated with this value.
 	val interface{}
+	// tolerateJSONInconsistenciesForVal means to tolerate inconsistencies
+	// for val as if it were converted from JSON. As of right now, this is
+	// specifically to deal with uint values being streamed as positive int
+	// values.
+	tolerateJSONInconsistenciesForVal bool
 }
 
 // retrieveNode is an internal function that retrieves the node specified by
@@ -159,7 +164,12 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 					// With GNMIEncoding, unmarshalGeneric can only unmarshal leaf or leaf list
 					// nodes. Schema provided must be the schema of the leaf or leaf list node.
 					// root must be the reference of container leaf/leaf list belongs to.
-					if err := unmarshalGeneric(cschema, root, args.val, GNMIEncoding); err != nil {
+					var encoding Encoding
+					encoding = GNMIEncoding
+					if args.tolerateJSONInconsistenciesForVal {
+						encoding = gNMIEncodingWithJSONTolerance
+					}
+					if err := unmarshalGeneric(cschema, root, args.val, encoding); err != nil {
 						return nil, status.Errorf(codes.Unknown, "failed to update struct field %s in %T with value %v; %v", ft.Name, root, args.val, err)
 					}
 				}
@@ -416,8 +426,9 @@ func appendElem(p *gpb.Path, e *gpb.PathElem) *gpb.Path {
 // behaviours, such as whether or not to ensure that the node's ancestors are initialized.
 func SetNode(schema *yang.Entry, root interface{}, path *gpb.Path, val interface{}, opts ...SetNodeOpt) error {
 	nodes, err := retrieveNode(schema, root, path, nil, retrieveNodeArgs{
-		modifyRoot: hasInitMissingElements(opts),
-		val:        val,
+		modifyRoot:                        hasInitMissingElements(opts),
+		val:                               val,
+		tolerateJSONInconsistenciesForVal: hasTolerateJSONInconsistencies(opts),
 	})
 
 	if err != nil {
@@ -449,6 +460,25 @@ func (*InitMissingElements) IsSetNodeOpt() {}
 func hasInitMissingElements(opts []SetNodeOpt) bool {
 	for _, o := range opts {
 		if _, ok := o.(*InitMissingElements); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TolerateJSONInconsistencies signals SetNode to tolerate inconsistencies for
+// val as if it were converted from JSON. As of right now, this is specifically
+// to deal with uint values being streamed as positive int values.
+type TolerateJSONInconsistencies struct{}
+
+// IsSetNodeOpt implements the SetNodeOpt interface.
+func (*TolerateJSONInconsistencies) IsSetNodeOpt() {}
+
+// hasTolerateJSONInconsistencies determines whether there is an instance of
+// TolerateJSONInconsistencies within the supplied SetNodeOpt slice.
+func hasTolerateJSONInconsistencies(opts []SetNodeOpt) bool {
+	for _, o := range opts {
+		if _, ok := o.(*TolerateJSONInconsistencies); ok {
 			return true
 		}
 	}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -1394,6 +1394,15 @@ func TestSetNode(t *testing.T) {
 			inOpts:   []SetNodeOpt{&TolerateJSONInconsistencies{}},
 		},
 		{
+			inDesc:   "success setting uint field in uint node with 0 int value with JSON tolerance is set",
+			inSchema: listElemStruct4Schema,
+			inParent: &ListElemStruct4{},
+			inPath:   mustPath("/key1"),
+			inVal:    &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 0}},
+			want:     ygot.Uint32(0),
+			inOpts:   []SetNodeOpt{&TolerateJSONInconsistencies{}},
+		},
+		{
 			inDesc:           "failure setting uint field in uint node with negative int value with JSON tolerance is set",
 			inSchema:         listElemStruct4Schema,
 			inParent:         &ListElemStruct4{},

--- a/ytypes/unmarshal.go
+++ b/ytypes/unmarshal.go
@@ -52,7 +52,7 @@ type Encoding int
 
 const (
 	// JSONEncoding indicates that provided value is JSON encoded.
-	JSONEncoding = iota
+	JSONEncoding Encoding = iota
 
 	// GNMIEncoding indicates that provided value is gNMI TypedValue.
 	GNMIEncoding
@@ -61,6 +61,8 @@ const (
 	// TypedValue, but it tolerates the case that the values were produced
 	// from JSON and that a tolerance may be needed (e.g. positive int is
 	// accepted as an uint).
+	// This is made unexported because the feature is unstable and could
+	// change at any point.
 	gNMIEncodingWithJSONTolerance
 )
 

--- a/ytypes/unmarshal.go
+++ b/ytypes/unmarshal.go
@@ -56,6 +56,12 @@ const (
 
 	// GNMIEncoding indicates that provided value is gNMI TypedValue.
 	GNMIEncoding
+
+	// gNMIEncodingWithJSONTolerance indicates that provided value is gNMI
+	// TypedValue, but it tolerates the case that the values were produced
+	// from JSON and that a tolerance may be needed (e.g. positive int is
+	// accepted as an uint).
+	gNMIEncodingWithJSONTolerance
 )
 
 // unmarshalGeneric unmarshals the provided value encoded with the given


### PR DESCRIPTION
TolerateJSONInconsistencies signals SetNode to tolerate inconsistencies
for val as if it were converted from JSON. As of right now, this is
specifically to deal with uint values being streamed as positive int
values.

The unexported encoding gNMIEncodingWithJSONTolerance is added to allow this exception handling
to occur within ytype's unmarshal codebase.