### PR TITLE
Fix in place `ForDevice` function name; allow customizable FakeRoot name

### DIFF
--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -44,7 +44,7 @@ const (
 	// used for the generated Go package.
 	defaultPathPackageName = "ocpathstructs"
 	// defaultFakeRootName is the default name for the root structure.
-	defaultFakeRootName = "device"
+	defaultFakeRootName = "root"
 	// WildcardSuffix is the suffix given to the wildcard versions of each
 	// node as well as a list's wildcard child constructor methods that
 	// distinguishes each from its non-wildcard counterpart.
@@ -141,6 +141,7 @@ func (cg *GenConfig) GeneratePathCode(yangFiles, includePaths []string) (*Genera
 		TransformationOptions: ygen.TransformationOpts{
 			CompressBehaviour: genutil.PreferOperationalState,
 			GenerateFakeRoot:  true,
+			FakeRootName:      cg.FakeRootName,
 		},
 	}
 	directories, leafTypeMap, errs := dcg.GetDirectoriesAndLeafTypes(yangFiles, includePaths)
@@ -319,7 +320,7 @@ func GetOrderedNodeDataNames(nodeDataMap NodeDataMap) []string {
 
 var (
 	// goPathCommonHeaderTemplate is populated and output at the top of the generated code package
-	goPathCommonHeaderTemplate = `
+	goPathCommonHeaderTemplate = mustTemplate("commonHeader", `
 {{- /**/ -}}
 /*
 Package {{ .PackageName }} is a generated package which contains definitions
@@ -345,11 +346,11 @@ import (
 	{{ .SchemaStructPkgAlias }} "{{ .SchemaStructPkgPath }}"
 	"{{ .YgotImportPath }}"
 )
-`
+`)
 
 	// goPathOneOffHeaderTemplate defines the template for package code that should
 	// be output in only one file.
-	goPathOneOffHeaderTemplate = `
+	goPathOneOffHeaderTemplate = mustTemplate("oneoffHeader", `
 // Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
 func Resolve(n ygot.{{ .PathStructInterfaceName }}) (*gpb.Path, []error) {
 	n, p, errs := ygot.ResolvePath(n)
@@ -363,24 +364,24 @@ func Resolve(n ygot.{{ .PathStructInterfaceName }}) (*gpb.Path, []error) {
 	}
 	return &gpb.Path{Target: root.id, Elem: p}, nil
 }
-`
+`)
 
-	// goFakerootTemplate defines a template for the type definition and
+	// goPathFakeRootTemplate defines a template for the type definition and
 	// basic methods of the fakeroot object. The fakeroot object adheres to
 	// the methods of PathStructInterfaceName in order to allow its path
 	// struct descendents to use the Resolve() helper function for
 	// obtaining their absolute paths.
-	goFakeRootTemplate = `
+	goPathFakeRootTemplate = mustTemplate("fakeroot", `
 // {{ .TypeName }} represents the {{ .YANGPath }} YANG schema element.
 type {{ .TypeName }} struct {
 	ygot.{{ .PathBaseTypeName }}
 	id string
 }
 
-func For{{ .TypeName }}(id string) *{{ .TypeName }} {
+func ForDevice(id string) *{{ .TypeName }} {
 	return &{{ .TypeName }}{id: id}
 }
-`
+`)
 
 	// goPathStructTemplate defines the template for the type definition of
 	// a path node as well as its core method(s). A path struct/node is
@@ -391,7 +392,7 @@ func For{{ .TypeName }}(id string) *{{ .TypeName }} {
 	// path. There are two versions of these, non-wildcard and wildcard.
 	// The wildcard version is simply a type to indicate that the path it
 	// holds contains a wildcard, but is otherwise the exact same.
-	goPathStructTemplate = `
+	goPathStructTemplate = mustTemplate("struct", `
 // {{ .TypeName }} represents the {{ .YANGPath }} YANG schema element.
 type {{ .TypeName }} struct {
 	ygot.{{ .PathBaseTypeName }}
@@ -401,12 +402,12 @@ type {{ .TypeName }} struct {
 type {{ .TypeName }}{{ .WildcardSuffix }} struct {
 	ygot.{{ .PathBaseTypeName }}
 }
-`
+`)
 
-	// goChildConstructorTemplate generates the child constructor method
+	// goPathChildConstructorTemplate generates the child constructor method
 	// for a generated struct by returning an instantiation of the child's
 	// path struct object.
-	goChildConstructorTemplate = `
+	goPathChildConstructorTemplate = mustTemplate("childConstructor", `
 // {{ .MethodName }} returns from {{ .Struct.TypeName }} the path struct for its child "{{ .SchemaName }}".
 func (n *{{ .Struct.TypeName }}) {{ .MethodName -}} ({{ .KeyParamListStr }}) *{{ .TypeName }} {
 	return &{{ .TypeName }}{
@@ -417,20 +418,11 @@ func (n *{{ .Struct.TypeName }}) {{ .MethodName -}} ({{ .KeyParamListStr }}) *{{
 		),
 	}
 }
-`
-
-	// The set of built templates that are to be referenced during code generation.
-	goPathTemplates = map[string]*template.Template{
-		"commonHeader":     makePathTemplate("commonHeader", goPathCommonHeaderTemplate),
-		"oneoffHeader":     makePathTemplate("oneoffHeader", goPathOneOffHeaderTemplate),
-		"fakeroot":         makePathTemplate("fakeroot", goFakeRootTemplate),
-		"struct":           makePathTemplate("struct", goPathStructTemplate),
-		"childConstructor": makePathTemplate("childConstructor", goChildConstructorTemplate),
-	}
+`)
 )
 
-// makePathTemplate generates a template.Template for a particular named source template
-func makePathTemplate(name, src string) *template.Template {
+// mustTemplate generates a template.Template for a particular named source template
+func mustTemplate(name, src string) *template.Template {
 	return template.Must(template.New(name).Parse(src))
 }
 
@@ -529,12 +521,12 @@ func writeHeader(yangFiles, includePaths []string, cg *GenConfig, genCode *Gener
 	}
 
 	var common bytes.Buffer
-	if err := goPathTemplates["commonHeader"].Execute(&common, s); err != nil {
+	if err := goPathCommonHeaderTemplate.Execute(&common, s); err != nil {
 		return err
 	}
 
 	var oneoff bytes.Buffer
-	if err := goPathTemplates["oneoffHeader"].Execute(&oneoff, s); err != nil {
+	if err := goPathOneOffHeaderTemplate.Execute(&oneoff, s); err != nil {
 		return err
 	}
 
@@ -602,10 +594,10 @@ func generateDirectorySnippet(directory *ygen.Directory, directories map[string]
 	structData := getStructData(directory)
 	if ygen.IsFakeRoot(directory.Entry) {
 		// Fakeroot has its unique output.
-		if err := goPathTemplates["fakeroot"].Execute(&structBuf, structData); err != nil {
+		if err := goPathFakeRootTemplate.Execute(&structBuf, structData); err != nil {
 			return GoPathStructCodeSnippet{}, util.AppendErr(errs, err)
 		}
-	} else if err := goPathTemplates["struct"].Execute(&structBuf, structData); err != nil {
+	} else if err := goPathStructTemplate.Execute(&structBuf, structData); err != nil {
 		return GoPathStructCodeSnippet{}, util.AppendErr(errs, err)
 	}
 
@@ -640,7 +632,7 @@ func generateDirectorySnippet(directory *ygen.Directory, directories map[string]
 					PathStructInterfaceName: ygot.PathStructInterfaceName,
 					WildcardSuffix:          WildcardSuffix,
 				}
-				if err := goPathTemplates["struct"].Execute(&structBuf, structData); err != nil {
+				if err := goPathStructTemplate.Execute(&structBuf, structData); err != nil {
 					errs = util.AppendErr(errs, err)
 				}
 			}
@@ -716,7 +708,7 @@ func generateChildConstructors(methodBuf *bytes.Buffer, directory *ygen.Director
 func generateChildConstructorsForLeafOrContainer(methodBuf *bytes.Buffer, fieldData goPathFieldData, isUnderFakeRoot bool) []error {
 	// Generate child constructor for the non-wildcard version of the parent struct.
 	var errors []error
-	if err := goPathTemplates["childConstructor"].Execute(methodBuf, fieldData); err != nil {
+	if err := goPathChildConstructorTemplate.Execute(methodBuf, fieldData); err != nil {
 		errors = append(errors, err)
 	}
 
@@ -728,7 +720,7 @@ func generateChildConstructorsForLeafOrContainer(methodBuf *bytes.Buffer, fieldD
 	// Generate child constructor for the wildcard version of the parent struct.
 	fieldData.TypeName += WildcardSuffix
 	fieldData.Struct.TypeName += WildcardSuffix
-	if err := goPathTemplates["childConstructor"].Execute(methodBuf, fieldData); err != nil {
+	if err := goPathChildConstructorTemplate.Execute(methodBuf, fieldData); err != nil {
 		errors = append(errors, err)
 	}
 	return errors
@@ -806,7 +798,7 @@ func generateChildConstructorsForList(methodBuf *bytes.Buffer, listAttr *ygen.Ya
 
 		// Generate child constructor method for non-wildcard version of parent struct.
 		fieldData.Struct.TypeName = parentTypeName
-		if err := goPathTemplates["childConstructor"].Execute(methodBuf, fieldData); err != nil {
+		if err := goPathChildConstructorTemplate.Execute(methodBuf, fieldData); err != nil {
 			errors = append(errors, err)
 		}
 
@@ -819,7 +811,7 @@ func generateChildConstructorsForList(methodBuf *bytes.Buffer, listAttr *ygen.Ya
 		fieldData.Struct.TypeName = wildcardParentTypeName
 		// Override the corner case for generating the non-wildcard child.
 		fieldData.TypeName = wildcardFieldTypeName
-		if err := goPathTemplates["childConstructor"].Execute(methodBuf, fieldData); err != nil {
+		if err := goPathChildConstructorTemplate.Execute(methodBuf, fieldData); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -345,6 +345,7 @@ func TestGeneratePathCode(t *testing.T) {
 				// Set the name of the caller explicitly to avoid issues when
 				// the unit tests are called by external test entities.
 				cg.GeneratingBinary = "pathgen-tests"
+				cg.FakeRootName = "device"
 
 				gotCode, gotNodeDataMap, err := cg.GeneratePathCode(tt.inFiles, tt.inIncludePaths)
 				if err != nil && !tt.wantErr {
@@ -436,6 +437,7 @@ func TestGeneratePathCodeSplitFiles(t *testing.T) {
 				// Set the name of the caller explicitly to avoid issues when
 				// the unit tests are called by external test entities.
 				cg.GeneratingBinary = "pathgen-tests"
+				cg.FakeRootName = "device"
 
 				gotCode, _, err := cg.GeneratePathCode(tt.inFiles, tt.inIncludePaths)
 				if err != nil {
@@ -630,14 +632,14 @@ func getSchemaAndDirs() (*yang.Entry, map[string]*ygen.Directory, map[string]map
 	addParents(schema)
 
 	// Build fake root.
-	fakeRoot := ygen.MakeFakeRoot("device")
+	fakeRoot := ygen.MakeFakeRoot("root")
 	for k, v := range schema.Dir {
 		fakeRoot.Dir[k] = v
 	}
 
 	directories := map[string]*ygen.Directory{
-		"/device": {
-			Name: "Device",
+		"/root": {
+			Name: "Root",
 			Fields: map[string]*yang.Entry{
 				"leaf":                  schema.Dir["leaf"],
 				"container":             schema.Dir["container"],
@@ -645,7 +647,7 @@ func getSchemaAndDirs() (*yang.Entry, map[string]*ygen.Directory, map[string]map
 				"list":                  schema.Dir["list-container"].Dir["list"],
 				"list-with-state":       schema.Dir["list-container-with-state"].Dir["list-with-state"],
 			},
-			Path:  []string{"", "device"},
+			Path:  []string{"", "root"},
 			Entry: fakeRoot,
 		},
 		"/root-module/container": {
@@ -701,7 +703,7 @@ func getSchemaAndDirs() (*yang.Entry, map[string]*ygen.Directory, map[string]map
 	}
 
 	leafTypeMap := map[string]map[string]*ygen.MappedType{
-		"/device": {
+		"/root": {
 			"leaf":                  {NativeType: "Binary"},
 			"container":             nil,
 			"container-with-config": nil,
@@ -731,8 +733,8 @@ func getSchemaAndDirs() (*yang.Entry, map[string]*ygen.Directory, map[string]map
 
 // wantListMethods is the expected child constructor methods for the list node.
 const wantListMethods = `
-// ListAny returns from Device the path struct for its child "list".
-func (n *Device) ListAny() *ListAny {
+// ListAny returns from Root the path struct for its child "list".
+func (n *Root) ListAny() *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -742,8 +744,8 @@ func (n *Device) ListAny() *ListAny {
 	}
 }
 
-// ListAnyKey2AnyUnionKey returns from Device the path struct for its child "list".
-func (n *Device) ListAnyKey2AnyUnionKey(Key1 string) *ListAny {
+// ListAnyKey2AnyUnionKey returns from Root the path struct for its child "list".
+func (n *Root) ListAnyKey2AnyUnionKey(Key1 string) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -753,8 +755,8 @@ func (n *Device) ListAnyKey2AnyUnionKey(Key1 string) *ListAny {
 	}
 }
 
-// ListAnyKey1AnyUnionKey returns from Device the path struct for its child "list".
-func (n *Device) ListAnyKey1AnyUnionKey(Key2 oc.Binary) *ListAny {
+// ListAnyKey1AnyUnionKey returns from Root the path struct for its child "list".
+func (n *Root) ListAnyKey1AnyUnionKey(Key2 oc.Binary) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -764,8 +766,8 @@ func (n *Device) ListAnyKey1AnyUnionKey(Key2 oc.Binary) *ListAny {
 	}
 }
 
-// ListAnyUnionKey returns from Device the path struct for its child "list".
-func (n *Device) ListAnyUnionKey(Key1 string, Key2 oc.Binary) *ListAny {
+// ListAnyUnionKey returns from Root the path struct for its child "list".
+func (n *Root) ListAnyUnionKey(Key1 string, Key2 oc.Binary) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -775,8 +777,8 @@ func (n *Device) ListAnyUnionKey(Key1 string, Key2 oc.Binary) *ListAny {
 	}
 }
 
-// ListAnyKey1AnyKey2 returns from Device the path struct for its child "list".
-func (n *Device) ListAnyKey1AnyKey2(UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+// ListAnyKey1AnyKey2 returns from Root the path struct for its child "list".
+func (n *Root) ListAnyKey1AnyKey2(UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -786,8 +788,8 @@ func (n *Device) ListAnyKey1AnyKey2(UnionKey oc.RootModule_List_UnionKey_Union) 
 	}
 }
 
-// ListAnyKey2 returns from Device the path struct for its child "list".
-func (n *Device) ListAnyKey2(Key1 string, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+// ListAnyKey2 returns from Root the path struct for its child "list".
+func (n *Root) ListAnyKey2(Key1 string, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -797,8 +799,8 @@ func (n *Device) ListAnyKey2(Key1 string, UnionKey oc.RootModule_List_UnionKey_U
 	}
 }
 
-// ListAnyKey1 returns from Device the path struct for its child "list".
-func (n *Device) ListAnyKey1(Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
+// ListAnyKey1 returns from Root the path struct for its child "list".
+func (n *Root) ListAnyKey1(Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *ListAny {
 	return &ListAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -808,8 +810,8 @@ func (n *Device) ListAnyKey1(Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKe
 	}
 }
 
-// List returns from Device the path struct for its child "list".
-func (n *Device) List(Key1 string, Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *List {
+// List returns from Root the path struct for its child "list".
+func (n *Root) List(Key1 string, Key2 oc.Binary, UnionKey oc.RootModule_List_UnionKey_Union) *List {
 	return &List{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container", "list"},
@@ -843,16 +845,16 @@ func TestGetNodeDataMap(t *testing.T) {
 	addParents(schema2)
 	binaryContainerEntry := schema2.Dir["container"]
 
-	fakeRoot := ygen.MakeFakeRoot("device")
+	fakeRoot := ygen.MakeFakeRoot("root")
 	fakeRoot.Dir["container"] = binaryContainerEntry
 
 	directoryWithBinaryLeaf := map[string]*ygen.Directory{
-		"/device": {
-			Name: "Device",
+		"/root": {
+			Name: "Root",
 			Fields: map[string]*yang.Entry{
 				"container": binaryContainerEntry,
 			},
-			Path:  []string{"", "device"},
+			Path:  []string{"", "root"},
 			Entry: fakeRoot,
 		},
 		"/root-module/container": {
@@ -866,7 +868,7 @@ func TestGetNodeDataMap(t *testing.T) {
 	}
 
 	leafTypeMap2 := map[string]map[string]*ygen.MappedType{
-		"/device": {
+		"/root": {
 			"container": nil,
 		},
 		"/root-module/container": {
@@ -911,7 +913,7 @@ func TestGetNodeDataMap(t *testing.T) {
 			"Container": {
 				GoTypeName:       "*struct.Container",
 				GoFieldName:      "Container",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           false,
 				IsScalarField:    false,
 			},
@@ -928,7 +930,7 @@ func TestGetNodeDataMap(t *testing.T) {
 		name:          "non-existent path",
 		inDirectories: map[string]*ygen.Directory{"/root-module/container": directories["/root-module/container"]},
 		inLeafTypeMap: map[string]map[string]*ygen.MappedType{
-			"/device": {
+			"/root": {
 				"container": nil,
 			},
 			"/you can't find me": {
@@ -941,7 +943,7 @@ func TestGetNodeDataMap(t *testing.T) {
 		name:          "non-existent field",
 		inDirectories: map[string]*ygen.Directory{"/root-module/container": directories["/root-module/container"]},
 		inLeafTypeMap: map[string]map[string]*ygen.MappedType{
-			"/device": {
+			"/root": {
 				"container": nil,
 			},
 			"/root-module/container": {
@@ -959,14 +961,14 @@ func TestGetNodeDataMap(t *testing.T) {
 			"Container": {
 				GoTypeName:       "*oc.Container",
 				GoFieldName:      "Container",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           false,
 				IsScalarField:    false,
 			},
 			"ContainerWithConfig": {
 				GoTypeName:       "*oc.ContainerWithConfig",
 				GoFieldName:      "ContainerWithConfig",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           false,
 				IsScalarField:    false,
 			},
@@ -1002,7 +1004,7 @@ func TestGetNodeDataMap(t *testing.T) {
 			"Leaf": {
 				GoTypeName:       "oc.Binary",
 				GoFieldName:      "Leaf",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           true,
 				IsScalarField:    false,
 				YANGTypeName:     "ieeefloat32",
@@ -1010,14 +1012,14 @@ func TestGetNodeDataMap(t *testing.T) {
 			"List": {
 				GoTypeName:       "*oc.List",
 				GoFieldName:      "List",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           false,
 				IsScalarField:    false,
 			},
 			"ListWithState": {
 				GoTypeName:       "*oc.ListWithState",
 				GoFieldName:      "ListWithState",
-				ParentGoTypeName: "Device",
+				ParentGoTypeName: "Root",
 				IsLeaf:           false,
 				IsScalarField:    false,
 			},
@@ -1210,18 +1212,18 @@ func (n *ContainerWithConfigAny) Leaflist2() *ContainerWithConfig_Leaflist2Any {
 		},
 	}, {
 		name:        "fakeroot",
-		inDirectory: directories["/device"],
+		inDirectory: directories["/root"],
 		want: GoPathStructCodeSnippet{
-			PathStructName: "Device",
+			PathStructName: "Root",
 			StructBase: `
-// Device represents the /device YANG schema element.
-type Device struct {
+// Root represents the /root YANG schema element.
+type Root struct {
 	ygot.NodePath
 	id string
 }
 
-func ForDevice(id string) *Device {
-	return &Device{id: id}
+func ForDevice(id string) *Root {
+	return &Root{id: id}
 }
 
 // Leaf represents the /root-module/leaf YANG schema element.
@@ -1235,8 +1237,8 @@ type LeafAny struct {
 }
 `,
 			ChildConstructors: `
-// Container returns from Device the path struct for its child "container".
-func (n *Device) Container() *Container {
+// Container returns from Root the path struct for its child "container".
+func (n *Root) Container() *Container {
 	return &Container{
 		NodePath: ygot.NewNodePath(
 			[]string{"container"},
@@ -1246,8 +1248,8 @@ func (n *Device) Container() *Container {
 	}
 }
 
-// ContainerWithConfig returns from Device the path struct for its child "container-with-config".
-func (n *Device) ContainerWithConfig() *ContainerWithConfig {
+// ContainerWithConfig returns from Root the path struct for its child "container-with-config".
+func (n *Root) ContainerWithConfig() *ContainerWithConfig {
 	return &ContainerWithConfig{
 		NodePath: ygot.NewNodePath(
 			[]string{"container-with-config"},
@@ -1257,8 +1259,8 @@ func (n *Device) ContainerWithConfig() *ContainerWithConfig {
 	}
 }
 
-// Leaf returns from Device the path struct for its child "leaf".
-func (n *Device) Leaf() *Leaf {
+// Leaf returns from Root the path struct for its child "leaf".
+func (n *Root) Leaf() *Leaf {
 	return &Leaf{
 		NodePath: ygot.NewNodePath(
 			[]string{"leaf"},
@@ -1268,8 +1270,8 @@ func (n *Device) Leaf() *Leaf {
 	}
 }
 ` + wantListMethods + `
-// ListWithStateAny returns from Device the path struct for its child "list-with-state".
-func (n *Device) ListWithStateAny() *ListWithStateAny {
+// ListWithStateAny returns from Root the path struct for its child "list-with-state".
+func (n *Root) ListWithStateAny() *ListWithStateAny {
 	return &ListWithStateAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container-with-state", "list-with-state"},
@@ -1279,8 +1281,8 @@ func (n *Device) ListWithStateAny() *ListWithStateAny {
 	}
 }
 
-// ListWithState returns from Device the path struct for its child "list-with-state".
-func (n *Device) ListWithState(Key float64) *ListWithState {
+// ListWithState returns from Root the path struct for its child "list-with-state".
+func (n *Root) ListWithState(Key float64) *ListWithState {
 	return &ListWithState{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container-with-state", "list-with-state"},
@@ -1474,18 +1476,18 @@ func TestGenerateChildConstructor(t *testing.T) {
 	addParents(deepSchema)
 
 	// Build fake root.
-	fakeRoot := ygen.MakeFakeRoot("device")
+	fakeRoot := ygen.MakeFakeRoot("root")
 	for k, v := range deepSchema.Dir {
 		fakeRoot.Dir[k] = v
 	}
 
 	deepSchemaDirectories := map[string]*ygen.Directory{
-		"/device": {
-			Name: "Device",
+		"/root": {
+			Name: "Root",
 			Fields: map[string]*yang.Entry{
 				"container": deepSchema.Dir["container"],
 			},
-			Path:  []string{"", "device"},
+			Path:  []string{"", "root"},
 			Entry: fakeRoot,
 		},
 		"/root-module/container": {
@@ -1530,13 +1532,13 @@ func TestGenerateChildConstructor(t *testing.T) {
 		want              string
 	}{{
 		name:              "container method",
-		inDirectory:       directories["/device"],
+		inDirectory:       directories["/root"],
 		inDirectories:     directories,
 		inFieldName:       "container",
 		inUniqueFieldName: "Container",
 		want: `
-// Container returns from Device the path struct for its child "container".
-func (n *Device) Container() *Container {
+// Container returns from Root the path struct for its child "container".
+func (n *Root) Container() *Container {
 	return &Container{
 		NodePath: ygot.NewNodePath(
 			[]string{"container"},
@@ -1577,13 +1579,13 @@ func (n *ContainerAny) Leaf() *Container_LeafAny {
 `,
 	}, {
 		name:              "top-level leaf method",
-		inDirectory:       directories["/device"],
+		inDirectory:       directories["/root"],
 		inDirectories:     directories,
 		inFieldName:       "leaf",
 		inUniqueFieldName: "Leaf",
 		want: `
-// Leaf returns from Device the path struct for its child "leaf".
-func (n *Device) Leaf() *Leaf {
+// Leaf returns from Root the path struct for its child "leaf".
+func (n *Root) Leaf() *Leaf {
 	return &Leaf{
 		NodePath: ygot.NewNodePath(
 			[]string{"leaf"},
@@ -1704,20 +1706,20 @@ func (n *ContainerAny) InnerContainer() *Container_InnerContainerAny {
 `,
 	}, {
 		name:              "list method",
-		inDirectory:       directories["/device"],
+		inDirectory:       directories["/root"],
 		inDirectories:     directories,
 		inFieldName:       "list",
 		inUniqueFieldName: "List",
 		want:              wantListMethods,
 	}, {
 		name:              "list with state method",
-		inDirectory:       directories["/device"],
+		inDirectory:       directories["/root"],
 		inDirectories:     directories,
 		inFieldName:       "list-with-state",
 		inUniqueFieldName: "ListWithState",
 		want: `
-// ListWithStateAny returns from Device the path struct for its child "list-with-state".
-func (n *Device) ListWithStateAny() *ListWithStateAny {
+// ListWithStateAny returns from Root the path struct for its child "list-with-state".
+func (n *Root) ListWithStateAny() *ListWithStateAny {
 	return &ListWithStateAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container-with-state", "list-with-state"},
@@ -1727,8 +1729,8 @@ func (n *Device) ListWithStateAny() *ListWithStateAny {
 	}
 }
 
-// ListWithState returns from Device the path struct for its child "list-with-state".
-func (n *Device) ListWithState(Key float64) *ListWithState {
+// ListWithState returns from Root the path struct for its child "list-with-state".
+func (n *Root) ListWithState(Key float64) *ListWithState {
 	return &ListWithState{
 		NodePath: ygot.NewNodePath(
 			[]string{"list-container-with-state", "list-with-state"},


### PR DESCRIPTION
Since `ForDevice` takes in a device ID, just fix in place the function's
name. On the other hand, allow the root struct's name to be different,
and change its default to "root" as the name fits better with ypathgen's
purpose of path-building instead of ygen's purpose of representing device state.