### PR TITLE
Replace reflect.DeepEqual with cmp.Equal/Diff where possible

### DIFF
--- a/experimental/ygotutils/getnode_test.go
+++ b/experimental/ygotutils/getnode_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
 
@@ -299,8 +299,9 @@ func TestGetNodeSimpleKeyedList(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
 		if isOK(status) {
-			if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+			got, want := val, tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: struct (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}
@@ -459,8 +460,9 @@ func TestGetNodeStructKeyedList(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
 		if isOK(status) {
-			if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+			got, want := val, tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: struct (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}
@@ -737,8 +739,9 @@ func TestNewNodeStructKeyedList(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
 		if isOK(status) {
-			if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: got: %s, want: %s", tt.desc, got, want)
+			got, want := val, tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -174,7 +174,7 @@ func JSONIETFComparer(a, b *gnmipb.TypedValue_JsonIetfVal) bool {
 		return false
 	}
 
-	return reflect.DeepEqual(aj, bj)
+	return cmp.Equal(aj, bj)
 }
 
 // notificationMatch tracks whether a gNMI notification pair has matched.

--- a/util/path_test.go
+++ b/util/path_test.go
@@ -68,8 +68,9 @@ func TestRelativeSchemaPath(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := sp, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("got:%v want: %v", pretty.Sprint(got), pretty.Sprint(want))
+				got, want := sp, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("(-want, +got):\n%s", diff)
 				}
 			}
 		})
@@ -125,8 +126,9 @@ func TestSchemaPaths(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := sp, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("struct got:%v want: %v", pretty.Sprint(got), pretty.Sprint(want))
+				got, want := sp, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("struct (-want, +got):\n%s", diff)
 				}
 			}
 		})

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 
@@ -448,7 +449,7 @@ func DeepEqualDerefPtrs(a, b interface{}) bool {
 	if !IsValueNil(b) && reflect.TypeOf(b).Kind() == reflect.Ptr {
 		bb = reflect.ValueOf(b).Elem().Interface()
 	}
-	return reflect.DeepEqual(aa, bb)
+	return cmp.Equal(aa, bb)
 }
 
 // ChildSchema returns the schema for the struct field f, if f contains a valid

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/testutil"
@@ -61,10 +62,10 @@ func areEqual(a, b interface{}) bool {
 	}
 	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
 	if va.Kind() == reflect.Ptr && vb.Kind() == reflect.Ptr {
-		return reflect.DeepEqual(va.Elem().Interface(), vb.Elem().Interface())
+		return cmp.Equal(va.Elem().Interface(), vb.Elem().Interface(), cmp.AllowUnexported(testImpl{}))
 	}
 
-	return reflect.DeepEqual(a, b)
+	return cmp.Equal(a, b)
 }
 
 // areEqualWithWildcards compares s against pattern word by word, where any
@@ -363,7 +364,7 @@ func TestIsTypeInterface(t *testing.T) {
 
 func isInListOfInterface(lv []interface{}, v interface{}) bool {
 	for _, vv := range lv {
-		if reflect.DeepEqual(vv, v) {
+		if cmp.Equal(vv, v) {
 			return true
 		}
 	}
@@ -868,7 +869,8 @@ func TestInsertIntoSlice(t *testing.T) {
 		t.Fatalf("got error: %s, want error: nil", err)
 	}
 	wantSlice := []int{42, 43, value}
-	if got, want := parentSlice, wantSlice; !reflect.DeepEqual(got, want) {
+	got, want := parentSlice, wantSlice
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
 	}
 
@@ -887,7 +889,8 @@ func TestInsertIntoMap(t *testing.T) {
 		t.Fatalf("got error: %s, want error: nil", err)
 	}
 	wantMap := map[int]string{42: "forty two", 43: "forty three", 44: "forty four"}
-	if got, want := parentMap, wantMap; !reflect.DeepEqual(got, want) {
+	got, want := parentMap, wantMap
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
 	}
 
@@ -1781,8 +1784,9 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := val, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := val, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: struct (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -2051,8 +2055,9 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, err)
 		if err == nil {
-			if got, want := sliceToMap(val), sliceToMap(tt.want); (len(want) != 0 || len(got) != 0) && !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: struct got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+			got, want := sliceToMap(val), sliceToMap(tt.want)
+			if diff := cmp.Diff(want, got); (len(want) != 0 || len(got) != 0) && diff != "" {
+				t.Errorf("%s: struct (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}

--- a/util/yang_test.go
+++ b/util/yang_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 )
@@ -1474,8 +1475,9 @@ func TestListKeyFieldsMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := ListKeyFieldsMap(tt.entry), tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("ListKeyFieldsMap(%v): did not get expected map, got: %v\nwant: %v\n", tt.entry, pretty.Sprint(got), pretty.Sprint(want))
+			got, want := ListKeyFieldsMap(tt.entry), tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("ListKeyFieldsMap(%v): did not get expected map, (-want, +got):\n%s", tt.entry, diff)
 			}
 		})
 	}

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"testing"
 
@@ -766,7 +765,7 @@ func TestSimpleStructs(t *testing.T) {
 					t.Fatalf("%s: json.Unmarshal(..., [contents of %s]), could not unmarshal golden JSON file: %v", tt.name, tt.wantSchemaFile, err)
 				}
 
-				if !reflect.DeepEqual(gotJSON, wantJSON) {
+				if !cmp.Equal(gotJSON, wantJSON) {
 					diff, _ := testutil.GenerateUnifiedDiff(string(gotGeneratedCode.RawJSONSchema), string(wantSchema))
 					t.Fatalf("%s: GenerateGoCode(%v, %v), Config: %v, did not return correct JSON (file: %v), diff: \n%s", tt.name, tt.inFiles, tt.inIncludePaths, tt.inConfig, tt.wantSchemaFile, diff)
 				}

--- a/ygen/goelements_test.go
+++ b/ygen/goelements_test.go
@@ -231,8 +231,8 @@ func TestUnionSubTypes(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(mtypes, tt.wantMtypes, cmp.AllowUnexported(MappedType{}), cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("mtypes not as expected\n%s", diff)
+			if diff := cmp.Diff(tt.wantMtypes, mtypes, cmp.AllowUnexported(MappedType{}), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("mtypes not as expected (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/ygen/gogen_test.go
+++ b/ygen/gogen_test.go
@@ -16,9 +16,9 @@ package ygen
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/testutil"
@@ -2129,9 +2129,8 @@ func TestFindMapPaths(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.wantPaths) {
-			t.Errorf("%s: YANGCodeGenerator.findMapPaths(%v, %v): compress: %v, got wrong paths, got: %v, want: %v",
-				tt.name, tt.inStruct, tt.inField, tt.inCompressPaths, got, tt.wantPaths)
+		if diff := cmp.Diff(tt.wantPaths, got); diff != "" {
+			t.Errorf("%s: YANGCodeGenerator.findMapPaths(%v, %v): compress: %v, (-want, +got):\n%s", tt.name, tt.inStruct, tt.inField, tt.inCompressPaths, diff)
 		}
 	}
 }
@@ -2253,18 +2252,11 @@ func TestGoLeafDefault(t *testing.T) {
 		want: ygot.String("EnumType_FORTY_TWO"),
 	}}
 
-	// Define a helper to print string pointers in a more useful way during test output.
-	pp := func(s *string) string {
-		if s == nil {
-			return "nil"
-		}
-		return *s
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := goLeafDefault(tt.inLeaf, tt.inType); !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("did not get expected default, got: %s, want: %s", pp(got), pp(tt.want))
+			got := goLeafDefault(tt.inLeaf, tt.inType)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("did not get expected default, (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/ygen/protogen_test.go
+++ b/ygen/protogen_test.go
@@ -15,10 +15,10 @@
 package ygen
 
 import (
-	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/testutil"
@@ -33,7 +33,7 @@ func protoMsgEq(a, b *protoMsg) bool {
 		return false
 	}
 
-	if a.Imports != nil && b.Imports != nil && !reflect.DeepEqual(a.Imports, b.Imports) {
+	if a.Imports != nil && b.Imports != nil && !cmp.Equal(a.Imports, b.Imports) {
 		return false
 	}
 
@@ -46,7 +46,7 @@ func protoMsgEq(a, b *protoMsg) bool {
 		return e
 	}
 
-	if !reflect.DeepEqual(fieldMap(a.Fields), fieldMap(b.Fields)) {
+	if !cmp.Equal(fieldMap(a.Fields), fieldMap(b.Fields)) {
 		return false
 	}
 
@@ -1428,8 +1428,8 @@ message MessageName {
 				t.Errorf("%s: writeProto3Msg(%v, %v, %v, %v): did not get expected package name, got: %v, want: %v", tt.name, tt.inMsg, tt.inMsgs, s, compress, got.PackageName, want.PackageName)
 			}
 
-			if !reflect.DeepEqual(got.RequiredImports, want.RequiredImports) {
-				t.Errorf("%s: writeProto3Msg(%v, %v, %v, %v): did not get expected set of imports, got: %v, want: %v", tt.name, tt.inMsg, tt.inMsgs, s, compress, got.RequiredImports, want.RequiredImports)
+			if diff := cmp.Diff(got.RequiredImports, want.RequiredImports); diff != "" {
+				t.Errorf("%s: writeProto3Msg(%v, %v, %v, %v): did not get expected set of imports, (-got, +want):\n%s", tt.name, tt.inMsg, tt.inMsgs, s, compress, diff)
 			}
 
 			if diff := pretty.Compare(got.MessageCode, want.MessageCode); diff != "" {

--- a/ygen/schema_tests/schema_test.go
+++ b/ygen/schema_tests/schema_test.go
@@ -17,9 +17,9 @@
 package schematest
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/ygot/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
@@ -42,7 +42,7 @@ func TestSimpleListRename(t *testing.T) {
 		t.Fatalf("did not populate eth1 in list")
 	}
 
-	if !reflect.DeepEqual(in.Interface["eth1"].Name, ygot.String("eth1")) {
+	if !cmp.Equal(in.Interface["eth1"].Name, ygot.String("eth1")) {
 		t.Errorf("did not get correct name value, got: %v, want: eth1", *in.Interface["eth1"].Name)
 	}
 
@@ -84,7 +84,7 @@ func TestMultiKeyListRename(t *testing.T) {
 		t.Errorf("did not have correct identifier in newBGP, got: %v, want: OpenconfigPolicyTypes_INSTALL_PROTOCOL_TYPE_BGP", ni.Protocol[newBGP].Identifier)
 	}
 
-	if !reflect.DeepEqual(ni.Protocol[newBGP].Name, ygot.String("36040")) {
+	if !cmp.Equal(ni.Protocol[newBGP].Name, ygot.String("36040")) {
 		t.Errorf("did not have correct name in newBGP, got: %v, want: 36040", *ni.Protocol[newBGP].Name)
 	}
 }
@@ -129,8 +129,9 @@ func TestGetOrCreateSimpleElement(t *testing.T) {
 	v := d.GetOrCreateSystem().GetOrCreateDns()
 	v.Search = []string{"rob.sh", "google.com"}
 
-	if got, want := d.System.Dns.Search, []string{"rob.sh", "google.com"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("GetOrCreateSystem().GetOrCreateDns(): got incorrect return value, got: %v, want: %v", got, want)
+	got, want := d.System.Dns.Search, []string{"rob.sh", "google.com"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GetOrCreateSystem().GetOrCreateDns(): got incorrect return value, (-want, +got):\n%s", diff)
 	}
 }
 

--- a/ygen/schemaparse_test.go
+++ b/ygen/schemaparse_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/testutil"
@@ -298,8 +299,8 @@ func TestWriteGzippedByteSlice(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%s: WriteGzippedByteSlice(%v): did not get expected output, got: %v, want: %v", tt.name, tt.inBytes, got, tt.want)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("%s: WriteGzippedByteSlice(%v): did not get expected output, (-want, +got):\n%s", tt.name, tt.inBytes, diff)
 		}
 	}
 }
@@ -322,8 +323,8 @@ func TestBytesToGoByteSlice(t *testing.T) {
 
 	for _, tt := range tests {
 		got := BytesToGoByteSlice(tt.in)
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%s: BytesToGoByteSlice(%v): did not get expected output, got: %v, want: %v", tt.name, tt.in, got, tt.want)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("%s: BytesToGoByteSlice(%v): did not get expected output, (-want, +got):\n%s", tt.name, tt.in, diff)
 		}
 	}
 }

--- a/ygen/schematree_test.go
+++ b/ygen/schematree_test.go
@@ -15,9 +15,9 @@
 package ygen
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 )
@@ -219,8 +219,8 @@ func TestFixSchemaTreePath(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.wantParts) {
-			t.Errorf("%s: fixedSchemaTreePath(%v, %v): did not get expected parts, got: %v, want: %v", tt.name, tt.inPath, tt.inContext, got, tt.wantParts)
+		if diff := cmp.Diff(tt.wantParts, got); diff != "" {
+			t.Errorf("%s: fixedSchemaTreePath(%v, %v): did not get expected parts, (-want, +got):\n%s", tt.name, tt.inPath, tt.inContext, diff)
 		}
 	}
 }

--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/ygot/util"
 
@@ -215,7 +216,7 @@ func findSetLeaves(s GoStruct, opts ...DiffOpt) (map[*pathSpec]interface{}, erro
 	processedPaths := map[string]bool{}
 
 	findSetIterFunc := func(ni *util.NodeInfo, in, out interface{}) (errs util.Errors) {
-		if reflect.DeepEqual(ni.StructField, reflect.StructField{}) {
+		if cmp.Equal(ni.StructField, reflect.StructField{}) {
 			return
 		}
 
@@ -411,7 +412,7 @@ func Diff(original, modified GoStruct, opts ...DiffOpt) (*gnmipb.Notification, e
 				// is equal.
 				matched[modPath] = true
 				origMatched = true
-				if !reflect.DeepEqual(origVal, modVal) {
+				if !cmp.Equal(origVal, modVal) {
 					// The contents of the value should indicate that value a has changed
 					// to value b.
 					if err := appendUpdate(n, origPath, modVal); err != nil {

--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -1335,8 +1335,9 @@ func TestLeastSpecificPath(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		if got := leastSpecificPath(tt.in); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%s: leastSpecificPath(%v): did not get expected value, got: %v, want: %v", tt.name, tt.in, got, tt.want)
+		got := leastSpecificPath(tt.in)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("%s: leastSpecificPath(%v): did not get expected value, (-want, +got):\n%s", tt.name, tt.in, diff)
 		}
 	}
 }

--- a/ygot/helpers_test.go
+++ b/ygot/helpers_test.go
@@ -15,8 +15,9 @@
 package ygot
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestToPtr(t *testing.T) {
@@ -38,8 +39,9 @@ func TestToPtr(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		if got := ToPtr(tt.in); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%s: ToPtr(%v): did not get expected ptr, got: %v, want: %v", tt.name, tt.in, got, tt.want)
+		got := ToPtr(tt.in)
+		if diff := cmp.Diff(tt.want, got); diff != "" {
+			t.Errorf("%s: ToPtr(%v): did not get expected ptr, (-want, +got):\n%s", tt.name, tt.in, diff)
 		}
 	}
 }

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -15,11 +15,11 @@
 package ygot
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
 )
@@ -127,7 +127,7 @@ func TestPathToStrings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !cmp.Equal(got, want) {
 		t.Fatalf("PathToStrings(%v): got %q, want %q", in, got, want)
 	}
 }

--- a/ygot/pathtranslate/pathtranslate_test.go
+++ b/ygot/pathtranslate/pathtranslate_test.go
@@ -15,7 +15,6 @@
 package pathtranslate
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -100,8 +99,8 @@ func TestInstantiationOfTranslator(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(r.rules, tt.wantRules) {
-				t.Errorf("got %v, want %v", r.rules, tt.wantRules)
+			if diff := cmp.Diff(tt.wantRules, r.rules); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -146,8 +146,8 @@ func TestAppendName(t *testing.T) {
 			continue
 		}
 
-		if diff := cmp.Diff(tt.inPath, tt.want, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
-			t.Errorf("%s: (gnmiPath)(%#v).AppendName(%s): did not get expected path, diff(-got,+want):\n%s", tt.name, tt.inPath, tt.inName, diff)
+		if diff := cmp.Diff(tt.want, tt.inPath, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("%s: (gnmiPath)(%#v).AppendName(%s): did not get expected path, diff(-want,+got):\n%s", tt.name, tt.inPath, tt.inName, diff)
 		}
 	}
 }
@@ -168,7 +168,7 @@ func TestGNMIPathCopy(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		if got := tt.inPath.Copy(); !reflect.DeepEqual(got, tt.inPath) {
+		if got := tt.inPath.Copy(); !cmp.Equal(got, tt.inPath, cmp.AllowUnexported(gnmiPath{})) {
 			t.Errorf("%s: (gnmiPath).Copy(): did not get expected result, got: %v, want: %v", tt.name, got, tt.inPath)
 		}
 	}
@@ -628,8 +628,8 @@ func TestAppendGNMIPathElemKey(t *testing.T) {
 			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected error status, got: %v, want error: %v", tt.name, tt.inValue, tt.inPath, err, tt.wantErr)
 		}
 
-		if diff := cmp.Diff(got, tt.wantPath, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
-			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected return path, diff(-got,+want):\n%s", tt.name, tt.inValue, tt.inPath, diff)
+		if diff := cmp.Diff(tt.wantPath, got, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("%s: appendgNMIPathElemKey(%v, %v): did not get expected return path, diff(-want,+got):\n%s", tt.name, tt.inValue, tt.inPath, diff)
 		}
 	}
 }
@@ -2355,7 +2355,7 @@ func TestUnionPtrValue(t *testing.T) {
 			t.Errorf("%s: unionPtrValue(%v, %v): did not get expected error, got: %v, want error: %v", tt.name, tt.inValue, tt.inAppendModName, err, tt.wantErr)
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
+		if !cmp.Equal(got, tt.want) {
 			t.Errorf("%s: unionPtrValue(%v, %v): did not get expected value, got: %v, want: %v", tt.name, tt.inValue, tt.inAppendModName, got, tt.want)
 		}
 	}
@@ -2449,7 +2449,7 @@ func TestLeaflistToSlice(t *testing.T) {
 			t.Errorf("%s: leaflistToSlice(%v): got unexpected error: %v", tt.name, tt.inVal.Interface(), err)
 		}
 
-		if !reflect.DeepEqual(got, tt.wantSlice) {
+		if !cmp.Equal(got, tt.wantSlice) {
 			t.Errorf("%s: leaflistToSlice(%v): did not get expected slice, got: %v, want: %v", tt.name, tt.inVal.Interface(), got, tt.wantSlice)
 		}
 	}
@@ -2522,7 +2522,7 @@ func TestKeyValueAsString(t *testing.T) {
 				continue
 			}
 		}
-		if !reflect.DeepEqual(s, tt.want) {
+		if !cmp.Equal(s, tt.want) {
 			t.Errorf("got %v, want %v", s, tt.want)
 		}
 	}

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -1636,7 +1636,7 @@ func TestMergeStructs(t *testing.T) {
 		name:    "error, field set in both structs",
 		inA:     &validatedMergeTest{String: String("karbach-hopadillo")},
 		inB:     &validatedMergeTest{String: String("blackwater-draw-brewing-co-border-town")},
-		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field, src: blackwater-draw-brewing-co-border-town, dst: karbach-hopadillo",
+		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field",
 	}, {
 		name: "allow leaf overwrite if equal",
 		inA:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
@@ -1646,7 +1646,7 @@ func TestMergeStructs(t *testing.T) {
 		name:    "error - merge leaf overwrite but not equal",
 		inA:     &validatedMergeTest{String: String("schneider-weisse-hopfenweisse")},
 		inB:     &validatedMergeTest{String: String("deschutes-jubelale")},
-		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field, src: deschutes-jubelale, dst: schneider-weisse-hopfenweisse",
+		wantErr: "error merging b to new struct: destination value was set, but was not equal to source value when merging ptr field",
 	}, {
 		name: "merge fields with slice of structs",
 		inA: &validatedMergeTestWithSlice{

--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
@@ -81,10 +82,10 @@ func areEqual(a, b interface{}) bool {
 	}
 	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
 	if va.Kind() == reflect.Ptr && vb.Kind() == reflect.Ptr {
-		return reflect.DeepEqual(va.Elem().Interface(), vb.Elem().Interface())
+		return cmp.Equal(va.Elem().Interface(), vb.Elem().Interface())
 	}
 
-	return reflect.DeepEqual(a, b)
+	return cmp.Equal(a, b)
 }
 
 func TestValidateListAttr(t *testing.T) {

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
@@ -328,8 +328,9 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-			t.Errorf("%s: unmarshalGeneric got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+		got, want := parent, tt.want
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("%s: unmarshalGeneric (-want, +got):\n%s", tt.desc, diff)
 		}
 	}
 }
@@ -408,8 +409,9 @@ func TestUnmarshalLeafListJSONEncoding(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -1386,8 +1386,9 @@ func TestUnmarshalLeafJSONEncoding(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s (#%d): Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, idx, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s (#%d): Unmarshal (-want, +got):\n%s", tt.desc, idx, diff)
 				}
 			}
 		})
@@ -1487,8 +1488,9 @@ func TestUnmarshalLeafRef(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: Unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -1867,8 +1869,8 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		if !reflect.DeepEqual(inParent, tt.wantVal) {
-			t.Errorf("%s: unmarshalLeaf(%v, %v, %v, GNMIEncoding): got %v, want %v", tt.desc, tt.inSchema, inParent, tt.inVal, inParent, tt.wantVal)
+		if diff := cmp.Diff(tt.wantVal, inParent); diff != "" {
+			t.Errorf("%s: unmarshalLeaf(%v, %v, %v, GNMIEncoding): (-want, +got):\n%s", tt.desc, tt.inSchema, inParent, tt.inVal, diff)
 		}
 	}
 }

--- a/ytypes/leafref.go
+++ b/ytypes/leafref.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
@@ -318,7 +319,7 @@ func matchesNodes(ni *util.NodeInfo, matchNodes []interface{}) (bool, error) {
 				// This is an interface value, which is represented as a struct pointer.
 				ovv := ov.Elem().FieldByIndex([]int{0})
 				svv := ni.FieldValue.Elem().Elem().FieldByIndex([]int{0})
-				if reflect.DeepEqual(ovv.Interface(), svv.Interface()) {
+				if cmp.Equal(ovv.Interface(), svv.Interface()) {
 					match = true
 					break
 				}

--- a/ytypes/leafref_test.go
+++ b/ytypes/leafref_test.go
@@ -15,10 +15,10 @@
 package ytypes
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -649,8 +649,9 @@ func TestSplitUnescaped(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := splitUnescaped(tt.in, '/'), tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: got: %v, want: %v", tt.desc, got, want)
+			got, want := splitUnescaped(tt.in, '/'), tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: (-want, +got):\n%s", tt.desc, diff)
 			}
 		})
 	}
@@ -691,8 +692,9 @@ func TestSplitUnquoted(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := splitUnquoted(tt.in, tt.splitStr), tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: got: %v, want: %v", tt.desc, got, want)
+			got, want := splitUnquoted(tt.in, tt.splitStr), tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: (-want, +got):\n%s", tt.desc, diff)
 			}
 		})
 	}
@@ -762,11 +764,13 @@ func TestExtractKeyValue(t *testing.T) {
 			if got, want := prefix, tt.wantPrefix; got != want {
 				t.Errorf("%s prefix: got: %s, want: %s", tt.desc, got, want)
 			}
-			if got, want := k, tt.wantKey; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s key: got: %v, want: %v", tt.desc, got, want)
+			got, want := k, tt.wantKey
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s key: (-want, +got):\n%s", tt.desc, diff)
 			}
-			if got, want := v, tt.wantValue; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s value: got: %v, want: %v", tt.desc, got, want)
+			got, want = v, tt.wantValue
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s value: (-want, +got):\n%s", tt.desc, diff)
 			}
 		})
 	}

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
@@ -517,8 +516,9 @@ func TestUnmarshalUnkeyedList(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: Unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -613,8 +613,9 @@ func TestUnmarshalKeyedList(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: Unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -710,8 +711,9 @@ func TestUnmarshalStructKeyedList(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: Unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -778,8 +780,9 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 			}
 			testErrLog(t, tt.desc, err)
 			if err == nil {
-				if got, want := parent, tt.want; !reflect.DeepEqual(got, want) {
-					t.Errorf("%s: Unmarshal got:\n%v\nwant:\n%v\n", tt.desc, pretty.Sprint(got), pretty.Sprint(want))
+				got, want := parent, tt.want
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("%s: Unmarshal (-want, +got):\n%s", tt.desc, diff)
 				}
 			}
 		})
@@ -897,8 +900,8 @@ func TestStructMapKeyValueCreation(t *testing.T) {
 			if e != nil {
 				return
 			}
-			if diff := cmp.Diff(k.Interface(), tt.want); diff != "" {
-				t.Errorf("got %v, want %v: diff %v", k, tt.want, diff)
+			if diff := cmp.Diff(tt.want, k.Interface()); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -1266,8 +1269,8 @@ func TestInsertAndGetKey(t *testing.T) {
 				return
 			}
 			val := reflect.ValueOf(tt.inParent).MapIndex(reflect.ValueOf(got)).Interface()
-			if !reflect.DeepEqual(val, tt.want) {
-				t.Errorf("got %v, want %v", val, tt.want)
+			if diff := cmp.Diff(tt.want, val); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -445,8 +444,8 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s:\ngot: %v\nwant: %v", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("%s:\n(-want, +got):\n%s", tt.inDesc, diff)
 			}
 		})
 	}
@@ -623,8 +622,8 @@ func TestGetOrCreateNodeStructKeyedList(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s:\ngot: %v\nwant: %v", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("%s:\n(-want, +got):\n%s", tt.inDesc, diff)
 			}
 		})
 	}
@@ -763,8 +762,8 @@ func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
 			if err != nil {
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s:\ngot: %v\nwant: %v", tt.inDesc, pretty.Sprint(got), pretty.Sprint(tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("%s:\n(-want, +got):\n%s", tt.inDesc, diff)
 			}
 		})
 	}
@@ -786,7 +785,8 @@ func treeNodesEqual(got, want []*TreeNode) error {
 	for _, w := range want {
 		match := false
 		for _, g := range got {
-			if reflect.DeepEqual(g.Data, w.Data) && reflect.DeepEqual(g.Schema, w.Schema) && proto.Equal(g.Path, w.Path) {
+			// Use reflect.DeepEqual on schema comparison to avoid stack overflow (maybe due to circular references).
+			if cmp.Equal(g.Data, w.Data) && reflect.DeepEqual(g.Schema, w.Schema) && proto.Equal(g.Path, w.Path) {
 				match = true
 				break
 			}
@@ -1545,8 +1545,8 @@ func TestSetNode(t *testing.T) {
 				t.Fatalf("did not get exactly one tree node: %v", treeNode)
 			}
 			got := treeNode[0].Data
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got: %v\nwant: %v", pretty.Sprint(got), pretty.Sprint(tt.want))
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -1796,7 +1796,7 @@ func TestDeleteNode(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tt.inRoot, tt.want); diff != "" {
+			if diff := cmp.Diff(tt.want, tt.inRoot); diff != "" {
 				t.Errorf("TestDeleteNode (-want, +got):\n%s", diff)
 			}
 		})

--- a/ytypes/schema_tests/validate_test.go
+++ b/ytypes/schema_tests/validate_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/ygot/experimental/ygotutils"
 	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/util"
@@ -680,8 +681,9 @@ func TestNewNode(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
 		if isOK(status) {
-			if got, want := n, tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: got: %v, want: %v ", tt.desc, util.ValueStr(got), util.ValueStr(want))
+			got, want := n, tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}
@@ -814,8 +816,9 @@ func TestGetNode(t *testing.T) {
 		}
 		testErrLog(t, tt.desc, fmt.Errorf(status.GetMessage()))
 		if isOK(status) {
-			if got, want := n, tt.want; !reflect.DeepEqual(got, want) {
-				t.Errorf("%s: got: %v, want: %v ", tt.desc, util.ValueStr(got), util.ValueStr(want))
+			got, want := n, tt.want
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("%s: (-want, +got):\n%s", tt.desc, diff)
 			}
 		}
 	}

--- a/ytypes/util_json.go
+++ b/ytypes/util_json.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 )
@@ -36,7 +37,7 @@ func getJSONTreeValForField(parentSchema, schema *yang.Entry, f reflect.StructFi
 	var outPath []string
 	for _, p := range ps {
 		if jr, ok := getJSONTreeValForPath(tree, p); ok {
-			if out != nil && !reflect.DeepEqual(out, jr) {
+			if out != nil && !cmp.Equal(out, jr) {
 				return nil, fmt.Errorf("values at paths %v and %v are different: %v != %v", outPath, p, out, jr)
 			}
 			out = jr


### PR DESCRIPTION
https://godoc.org/github.com/google/go-cmp/cmp:
> This package is intended to be a more powerful and safer alternative to reflect.DeepEqual for comparing whether two values are semantically equal.

yang.Entry still needs reflect.Equal because cmp.Equal doesn't seem to support the circular references it has despite cmp claiming to support graph comparison (stack overflow).

Note that some changes just trivially change (-got, +want) to (-want, +got) in the error message. I wanted to make everything consistent, but I stopped because I noticed a lack of consistency with `testutil.GenerateUnifiedDiff` always doing (-got, +want), and this style issue is not a big deal anyways.