### PR TITLE
Simplify Key-Processing Functions in ypathgen

### DIFF
--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -859,7 +859,7 @@ func getFieldTypeName(directory *ygen.Directory, directoryFieldName string, goFi
 	return directory.Name + "_" + goFieldName, nil
 }
 
-type KeyParam struct {
+type keyParam struct {
 	name     string
 	varName  string
 	typeName string
@@ -877,13 +877,13 @@ type KeyParam struct {
 // 	KeyElems: []*yang.Entry{{Name: "fluorine"}, {Name: "iodine-liquid"}},
 // }
 // out: [{"fluroine", "Fluorine", "string"}, {"iodine-liquid", "IodineLiquid", "oc.Binary"}]
-func makeKeyParams(listAttr *ygen.YangListAttr, schemaStructPkgAlias string) ([]KeyParam, error) {
+func makeKeyParams(listAttr *ygen.YangListAttr, schemaStructPkgAlias string) ([]keyParam, error) {
 	if len(listAttr.KeyElems) == 0 {
 		return nil, fmt.Errorf("makeKeyParams: invalid list - has no key; cannot process param list string")
 	}
 
 	// Create parameter list *in order* of keys, which should be in schema order.
-	var keyParams []KeyParam
+	var keyParams []keyParam
 	// NOTE: Although the generated key names might not match their
 	// corresponding ygen field names in case of a camelcase name
 	// collision, we expect that the user is aware of the schema to know
@@ -907,7 +907,7 @@ func makeKeyParams(listAttr *ygen.YangListAttr, schemaStructPkgAlias string) ([]
 		default:
 			typeName = mappedType.NativeType
 		}
-		keyParams = append(keyParams, KeyParam{name: keyElem.Name, varName: goKeyNameMap[keyElem.Name], typeName: typeName})
+		keyParams = append(keyParams, keyParam{name: keyElem.Name, varName: goKeyNameMap[keyElem.Name], typeName: typeName})
 	}
 	return keyParams, nil
 }

--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -752,8 +752,6 @@ func generateChildConstructorsForList(methodBuf *strings.Builder, listAttr *ygen
 	if err != nil {
 		return append(errors, err)
 	}
-	// List of key parameters as would appear in the key attribute of a
-	// ygot.NodePath definition.
 	keyN := len(keyParams)
 	combos := combinations(keyN)
 

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -1849,7 +1849,7 @@ func TestMakeKeyParams(t *testing.T) {
 	tests := []struct {
 		name             string
 		in               *ygen.YangListAttr
-		want             []KeyParam
+		want             []keyParam
 		wantErrSubstring string
 	}{{
 		name:             "empty listattr",
@@ -1861,14 +1861,14 @@ func TestMakeKeyParams(t *testing.T) {
 			Keys:     map[string]*ygen.MappedType{"fluorine": {NativeType: "string"}},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}},
 		},
-		want: []KeyParam{{name: "fluorine", varName: "Fluorine", typeName: "string"}},
+		want: []keyParam{{name: "fluorine", varName: "Fluorine", typeName: "string"}},
 	}, {
 		name: "simple int param, also testing camel-case",
 		in: &ygen.YangListAttr{
 			Keys:     map[string]*ygen.MappedType{"cl-cl": {NativeType: "int"}},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}},
 		},
-		want: []KeyParam{{name: "cl-cl", varName: "ClCl", typeName: "int"}},
+		want: []keyParam{{name: "cl-cl", varName: "ClCl", typeName: "int"}},
 	}, {
 		name: "name uniquification",
 		in: &ygen.YangListAttr{
@@ -1878,7 +1878,7 @@ func TestMakeKeyParams(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}, {Name: "clCl"}},
 		},
-		want: []KeyParam{
+		want: []keyParam{
 			{name: "cl-cl", varName: "ClCl", typeName: "int"},
 			{name: "clCl", varName: "ClCl_", typeName: "int"},
 		},
@@ -1888,7 +1888,7 @@ func TestMakeKeyParams(t *testing.T) {
 			Keys:     map[string]*ygen.MappedType{"fluorine": {NativeType: "interface{}"}},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}},
 		},
-		want: []KeyParam{{name: "fluorine", varName: "Fluorine", typeName: "string"}},
+		want: []keyParam{{name: "fluorine", varName: "Fluorine", typeName: "string"}},
 	}, {
 		name: "keyElems doesn't match keys",
 		in: &ygen.YangListAttr{
@@ -1914,7 +1914,7 @@ func TestMakeKeyParams(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "fluorine"}, {Name: "cl-cl"}, {Name: "bromine"}, {Name: "iodine"}},
 		},
-		want: []KeyParam{
+		want: []keyParam{
 			{name: "fluorine", varName: "Fluorine", typeName: "string"},
 			{name: "cl-cl", varName: "ClCl", typeName: "int"},
 			{name: "bromine", varName: "Bromine", typeName: "complex128"},
@@ -1929,7 +1929,7 @@ func TestMakeKeyParams(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "astatine"}, {Name: "tennessine"}},
 		},
-		want: []KeyParam{
+		want: []keyParam{
 			{name: "astatine", varName: "Astatine", typeName: "oc.Halogen"},
 			{name: "tennessine", varName: "Tennessine", typeName: "oc.Ununseptium"},
 		},
@@ -1942,7 +1942,7 @@ func TestMakeKeyParams(t *testing.T) {
 			},
 			KeyElems: []*yang.Entry{{Name: "cl-cl"}, {Name: "bromine"}},
 		},
-		want: []KeyParam{
+		want: []keyParam{
 			{name: "cl-cl", varName: "ClCl", typeName: "oc.YANGEmpty"},
 			{name: "bromine", varName: "Bromine", typeName: "oc.Binary"},
 		},
@@ -1951,7 +1951,7 @@ func TestMakeKeyParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := makeKeyParams(tt.in, "oc")
-			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(KeyParam{})); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(keyParam{})); diff != "" {
 				t.Errorf("(-want, +got):\n%s", diff)
 			}
 


### PR DESCRIPTION
Merged two overlapping functions into one.

Before:
`makeKeyMapStrs` returns (name, varName) for each list parameter key.
`makeParamListStrs` returns (varName, typeName) for each list parameter key.

After:
`makeKeyParams` returns (name, varName, typeName) for each list parameter key.