### PR TITLE
Add a merge function that mutates inputs

### DIFF
--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -1596,111 +1596,93 @@ func (e *ExampleAnnotation) UnmarshalJSON([]byte) error {
 	return fmt.Errorf("unimplemented")
 }
 
+// mergeStructTests are shared test cases for both MergeStructs and
+// MergeStructInto. Used to capture the common cases between the two functions.
+var mergeStructTests = []struct {
+	name    string
+	inA     ValidatedGoStruct
+	inB     ValidatedGoStruct
+	want    ValidatedGoStruct
+	wantErr string
+}{{
+	name: "simple struct merge, a empty",
+	inA:  &validatedMergeTest{},
+	inB:  &validatedMergeTest{String: String("odell-90-shilling")},
+	want: &validatedMergeTest{String: String("odell-90-shilling")},
+}, {
+	name: "simple struct merge, a populated",
+	inA:  &validatedMergeTest{String: String("left-hand-milk-stout-nitro"), Uint32Field: Uint32(42)},
+	inB:  &validatedMergeTest{StringTwo: String("new-belgium-lips-of-faith-la-folie")},
+	want: &validatedMergeTest{
+		String:      String("left-hand-milk-stout-nitro"),
+		StringTwo:   String("new-belgium-lips-of-faith-la-folie"),
+		Uint32Field: Uint32(42),
+	},
+}, {
+	name:    "error, differing types",
+	inA:     &validatedMergeTest{String: String("great-divide-yeti")},
+	inB:     &validatedMergeTestTwo{String: String("north-coast-old-rasputin")},
+	wantErr: "cannot merge structs that are not of matching types, *ygot.validatedMergeTest != *ygot.validatedMergeTestTwo",
+}, {
+	name:    "error, bad data in B",
+	inA:     &validatedMergeTestTwo{String: String("weird-beard-sorachi-faceplant")},
+	inB:     &validatedMergeTestTwo{I: "fourpure-southern-latitude"},
+	wantErr: "invalid interface type received: string",
+}, {
+	name:    "error, field set in both structs",
+	inA:     &validatedMergeTest{String: String("karbach-hopadillo")},
+	inB:     &validatedMergeTest{String: String("blackwater-draw-brewing-co-border-town")},
+	wantErr: "destination value was set, but was not equal to source value when merging ptr field",
+}, {
+	name: "allow leaf overwrite if equal",
+	inA:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
+	inB:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
+	want: &validatedMergeTest{String: String("new-belgium-sour-saison")},
+}, {
+	name:    "error - merge leaf overwrite but not equal",
+	inA:     &validatedMergeTest{String: String("schneider-weisse-hopfenweisse")},
+	inB:     &validatedMergeTest{String: String("deschutes-jubelale")},
+	wantErr: "destination value was set, but was not equal to source value when merging ptr field",
+}, {
+	name: "merge fields with slice of structs",
+	inA: &validatedMergeTestWithSlice{
+		SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
+	},
+	inB: &validatedMergeTestWithSlice{
+		SliceField: []*validatedMergeTestSliceField{{String("citrus-dream")}},
+	},
+	want: &validatedMergeTestWithSlice{
+		SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}, {String("citrus-dream")}},
+	},
+}, {
+	name: "merge fields with duplicate slices of annotations",
+	inA: &validatedMergeTestWithAnnotationSlice{
+		SliceField: []Annotation{&ExampleAnnotation{ConfigSource: "devicedemo"}},
+	},
+	inB: &validatedMergeTestWithAnnotationSlice{
+		SliceField: []Annotation{&ExampleAnnotation{ConfigSource: "devicedemo"}},
+	},
+	want: &validatedMergeTestWithAnnotationSlice{
+		SliceField: []Annotation{
+			&ExampleAnnotation{ConfigSource: "devicedemo"},
+			&ExampleAnnotation{ConfigSource: "devicedemo"},
+		},
+	},
+}, {
+	name: "error - merge fields with slice with duplicate strings",
+	inA: &validatedMergeTestWithSlice{
+		SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
+	},
+	inB: &validatedMergeTestWithSlice{
+		SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
+	},
+	wantErr: "source and destination lists must be unique",
+}}
+
 func TestMergeStructs(t *testing.T) {
-	tests := []struct {
-		name    string
-		inA     ValidatedGoStruct
-		inB     ValidatedGoStruct
-		want    ValidatedGoStruct
-		wantErr string
-	}{{
-		name: "simple struct merge, a empty",
-		inA:  &validatedMergeTest{},
-		inB:  &validatedMergeTest{String: String("odell-90-shilling")},
-		want: &validatedMergeTest{String: String("odell-90-shilling")},
-	}, {
-		name: "simple struct merge, a populated",
-		inA:  &validatedMergeTest{String: String("left-hand-milk-stout-nitro"), Uint32Field: Uint32(42)},
-		inB:  &validatedMergeTest{StringTwo: String("new-belgium-lips-of-faith-la-folie")},
-		want: &validatedMergeTest{
-			String:      String("left-hand-milk-stout-nitro"),
-			StringTwo:   String("new-belgium-lips-of-faith-la-folie"),
-			Uint32Field: Uint32(42),
-		},
-	}, {
-		name:    "error, differing types",
-		inA:     &validatedMergeTest{String: String("great-divide-yeti")},
-		inB:     &validatedMergeTestTwo{String: String("north-coast-old-rasputin")},
-		wantErr: "cannot merge structs that are not of matching types, *ygot.validatedMergeTest != *ygot.validatedMergeTestTwo",
-	}, {
-		name:    "error, bad data in B",
-		inA:     &validatedMergeTestTwo{String: String("weird-beard-sorachi-faceplant")},
-		inB:     &validatedMergeTestTwo{I: "fourpure-southern-latitude"},
-		wantErr: "invalid interface type received: string",
-	}, {
-		name:    "error, field set in both structs",
-		inA:     &validatedMergeTest{String: String("karbach-hopadillo")},
-		inB:     &validatedMergeTest{String: String("blackwater-draw-brewing-co-border-town")},
-		wantErr: "destination value was set, but was not equal to source value when merging ptr field",
-	}, {
-		name: "allow leaf overwrite if equal",
-		inA:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
-		inB:  &validatedMergeTest{String: String("new-belgium-sour-saison")},
-		want: &validatedMergeTest{String: String("new-belgium-sour-saison")},
-	}, {
-		name:    "error - merge leaf overwrite but not equal",
-		inA:     &validatedMergeTest{String: String("schneider-weisse-hopfenweisse")},
-		inB:     &validatedMergeTest{String: String("deschutes-jubelale")},
-		wantErr: "destination value was set, but was not equal to source value when merging ptr field",
-	}, {
-		name: "merge fields with slice of structs",
-		inA: &validatedMergeTestWithSlice{
-			SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
-		},
-		inB: &validatedMergeTestWithSlice{
-			SliceField: []*validatedMergeTestSliceField{{String("citrus-dream")}},
-		},
-		want: &validatedMergeTestWithSlice{
-			SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}, {String("citrus-dream")}},
-		},
-	}, {
-		name: "merge fields with duplicate slices of annotations",
-		inA: &validatedMergeTestWithAnnotationSlice{
-			SliceField: []Annotation{&ExampleAnnotation{ConfigSource: "devicedemo"}},
-		},
-		inB: &validatedMergeTestWithAnnotationSlice{
-			SliceField: []Annotation{&ExampleAnnotation{ConfigSource: "devicedemo"}},
-		},
-		want: &validatedMergeTestWithAnnotationSlice{
-			SliceField: []Annotation{
-				&ExampleAnnotation{ConfigSource: "devicedemo"},
-				&ExampleAnnotation{ConfigSource: "devicedemo"},
-			},
-		},
-	}, {
-		name: "error - merge fields with slice with duplicate strings",
-		inA: &validatedMergeTestWithSlice{
-			SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
-		},
-		inB: &validatedMergeTestWithSlice{
-			SliceField: []*validatedMergeTestSliceField{{String("chinook-single-hop")}},
-		},
-		wantErr: "source and destination lists must be unique",
-	}}
-
-	for _, tt := range tests {
-		// Make a copy of inA here since it will get mutated.
-		got, err := DeepCopy(tt.inA)
-		if err != nil {
-			t.Errorf("%s: DeepCopy(%v): unexpected error with testdata, %v", tt.name, tt.inA, err)
-			continue
-		}
-		err = MergeStructInto(got.(ValidatedGoStruct), tt.inB)
-		if diff := errdiff.Substring(err, tt.wantErr); diff != "" {
-			t.Errorf("%s: MergeStructInto(%v, %v): did not get expected error status, %s", tt.name, tt.inA, tt.inB, diff)
-		}
-		if err != nil {
-			continue
-		}
-
-		if diff := pretty.Compare(got, tt.want); diff != "" {
-			t.Errorf("%s: MergeStructInto(%v, %v): did not mutate inA struct correctly, diff(-got,+want):\n%s", tt.name, tt.inA, tt.inB, diff)
-		}
-	}
-
-	// Appended tests that only apply to the extra copy steps performed in
-	// MergeStructs as it does not mutate any inputs.
-	tests = append(tests, struct {
+	// Tests that only apply to the extra copy steps performed in MergeStructs as
+	// it does not mutate any inputs.
+	tests := append(mergeStructTests, struct {
 		name    string
 		inA     ValidatedGoStruct
 		inB     ValidatedGoStruct
@@ -1721,6 +1703,28 @@ func TestMergeStructs(t *testing.T) {
 
 		if diff := pretty.Compare(got, tt.want); diff != "" {
 			t.Errorf("%s: MergeStructs(%v, %v): did not get expected returned struct, diff(-got,+want):\n%s", tt.name, tt.inA, tt.inB, diff)
+		}
+	}
+}
+
+func TestMergeStructInto(t *testing.T) {
+	for _, tt := range mergeStructTests {
+		// Make a copy of inA here since it will get mutated.
+		got, err := DeepCopy(tt.inA)
+		if err != nil {
+			t.Errorf("%s: DeepCopy(%v): unexpected error with testdata, %v", tt.name, tt.inA, err)
+			continue
+		}
+		err = MergeStructInto(got.(ValidatedGoStruct), tt.inB)
+		if diff := errdiff.Substring(err, tt.wantErr); diff != "" {
+			t.Errorf("%s: MergeStructInto(%v, %v): did not get expected error status, %s", tt.name, tt.inA, tt.inB, diff)
+		}
+		if err != nil {
+			continue
+		}
+
+		if diff := pretty.Compare(got, tt.want); diff != "" {
+			t.Errorf("%s: MergeStructInto(%v, %v): did not mutate inA struct correctly, diff(-got,+want):\n%s", tt.name, tt.inA, tt.inB, diff)
 		}
 	}
 }


### PR DESCRIPTION
The DeepCopy performed in MergeStructs can be expensive. This provides a
more efficient merging function which allows smaller inputs to be more
efficiently copied into a larger destination struct.

Tests are mostly shared between the two merge functions as they share
the same copying code.