### PR TITLE
Fix defects in merging structs for enums and unions.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -625,11 +625,11 @@ func copyInterfaceField(dstField, srcField reflect.Value) error {
 	s := srcField.Elem().Elem() // Dereference src to a struct.
 	if !util.IsNilOrInvalidValue(dstField) {
 		dV := dstField.Elem().Elem() // Dereference dst to a struct.
-		if !reflect.DeepEqual(s.Interface(), dV.Interface()){
+		if !reflect.DeepEqual(s.Interface(), dV.Interface()) {
 			return fmt.Errorf("interface field was set in both src and dst and was not equal, src: %v, dst: %v", s.Interface(), dV.Interface())
 		}
 	}
-	
+
 	var d reflect.Value
 	d = reflect.New(s.Type())
 	if err := copyStruct(d.Elem(), s); err != nil {

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -502,6 +502,9 @@ func MergeStructInto(dst, src ValidatedGoStruct) error {
 // DeepCopy returns a deep copy of the supplied GoStruct. A new copy
 // of the GoStruct is created, along with any underlying values.
 func DeepCopy(s GoStruct) (GoStruct, error) {
+	if util.IsNilOrInvalidValue(reflect.ValueOf(s)) {
+		return nil, fmt.Errorf("invalid input to DeepCopy, got nil value: %v", s)
+	}
 	n := reflect.New(reflect.TypeOf(s).Elem())
 	if err := copyStruct(n.Elem(), reflect.ValueOf(s).Elem()); err != nil {
 		return nil, fmt.Errorf("cannot DeepCopy struct: %v", err)
@@ -539,6 +542,17 @@ func copyStruct(dstVal, srcVal reflect.Value) error {
 		case reflect.Slice:
 			if err := copySliceField(dstField, srcField); err != nil {
 				return err
+			}
+		case reflect.Int64:
+			// In the case of an int64 field, which represents a YANG enumeration
+			// we should only set the value in the destination if it is not set
+			// to the default value in the source.
+			vSrc, vDst := srcField.Int(), dstField.Int()
+			switch {
+			case vSrc != 0 && vDst != 0 && vSrc != vDst:
+				return fmt.Errorf("destination and source values were set when merging enum field, dst: %d, src: %d", vSrc, vDst)
+			case vSrc != 0 && vDst == 0:
+				dstField.Set(srcField)
 			}
 		default:
 			dstField.Set(srcField)
@@ -600,7 +614,7 @@ func copyPtrField(dstField, srcField reflect.Value) error {
 // copyInterfaceField copies srcField into dstField. Both srcField and dstField
 // are reflect.Value structs which contain an interface value.
 func copyInterfaceField(dstField, srcField reflect.Value) error {
-	if srcField.IsNil() || !srcField.IsValid() {
+	if util.IsNilOrInvalidValue(srcField) {
 		return nil
 	}
 
@@ -608,7 +622,14 @@ func copyInterfaceField(dstField, srcField reflect.Value) error {
 		return fmt.Errorf("invalid interface type received: %T", srcField.Interface())
 	}
 
-	s := srcField.Elem().Elem() // Dereference to a struct.
+	s := srcField.Elem().Elem() // Dereference src to a struct.
+	if !util.IsNilOrInvalidValue(dstField) {
+		dV := dstField.Elem().Elem() // Dereference dst to a struct.
+		if !reflect.DeepEqual(s.Interface(), dV.Interface()){
+			return fmt.Errorf("interface field was set in both src and dst and was not equal, src: %v, dst: %v", s.Interface(), dV.Interface())
+		}
+	}
+	
 	var d reflect.Value
 	d = reflect.New(s.Type())
 	if err := copyStruct(d.Elem(), s); err != nil {

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -1169,6 +1169,7 @@ func (*copyUnionS) IsUnion() {}
 type copyUnionI struct {
 	I int64
 }
+
 func (*copyUnionI) IsUnion() {}
 
 type copyMapKey struct {
@@ -1552,7 +1553,7 @@ type validatedMergeTest struct {
 	StringTwo   *string
 	Uint32Field *uint32
 	EnumValue   enumType
-	UnionField copyUnion
+	UnionField  copyUnion
 }
 
 func (*validatedMergeTest) Validate(...ValidationOption) error      { return nil }
@@ -1732,7 +1733,7 @@ var mergeStructTests = []struct {
 		UnionField: &copyUnionS{"mikkeler-pale-peter-and-mary"},
 	},
 	wantErr: "interface field was set in both src and dst and was not equal",
-},{
+}, {
 	name: "merge union: values equal",
 	inA: &validatedMergeTest{
 		UnionField: &copyUnionS{"ipswich-ale-celia-saison"},
@@ -1749,16 +1750,16 @@ var mergeStructTests = []struct {
 		UnionField: &copyUnionS{"estrella-damn-daura"},
 	},
 	inB: &validatedMergeTest{},
-	want:  &validatedMergeTest{
+	want: &validatedMergeTest{
 		UnionField: &copyUnionS{"estrella-damn-daura"},
 	},
 }, {
 	name: "merge union: set in dst and not src",
-	inA: &validatedMergeTest{},
-	inB:  &validatedMergeTest{
+	inA:  &validatedMergeTest{},
+	inB: &validatedMergeTest{
 		UnionField: &copyUnionS{"two-brothers-prairie-path-golden-ale"},
 	},
-	want:  &validatedMergeTest{
+	want: &validatedMergeTest{
 		UnionField: &copyUnionS{"two-brothers-prairie-path-golden-ale"},
 	},
 }, {


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map(_test)?.go
  - Resolve bug with merging enums where an unset value would overwrite
    a set value.
  - Resolve bug with merging enums where an error would not be thrown
    when the values were explicitly set to different values.
  - Resolve bug with merging unions where two unequal values would not
    result in an error being thrown.
  - Resolve bug with merging unions where an unset value would overwrite
    a set value.
```