### PR TITLE
Error out on nil input values when doing gNMI Encoding unmarshalling

### DIFF
--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -827,6 +827,13 @@ func TestDiff(t *testing.T) {
 			}},
 		},
 	}, {
+		desc:   "extra empty child struct in modified -- no difference",
+		inOrig: &renderExample{},
+		inMod: &renderExample{
+			Ch: &renderExampleChild{},
+		},
+		want: &gnmipb.Notification{},
+	}, {
 		desc: "single path deletion in modified",
 		inOrig: &renderExample{
 			Str: String("chardonnay"),

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -809,10 +809,17 @@ func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *
 		}
 		return rv.Interface(), nil
 	case yang.Ybinary:
-		return tv.GetBytesVal(), nil
+		bytes := tv.GetBytesVal()
+		if bytes == nil {
+			return nil, fmt.Errorf("received BytesVal is nil -- this is invalid")
+		}
+		return bytes, nil
 	case yang.Ydecimal64:
 		switch v := tv.GetValue().(type) {
 		case *gpb.TypedValue_DecimalVal:
+			if v.DecimalVal == nil {
+				return nil, fmt.Errorf("received DecimalVal is nil -- this is invalid")
+			}
 			prec := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(v.DecimalVal.Precision)), nil)
 			// Second return value indicates whether returned float64 value exactly
 			// represents the division. We don't want to fail unmarshalling as float64

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -344,7 +344,10 @@ type Binary []byte
 //   schema points to the schema for the leaf type.
 func unmarshalLeaf(inSchema *yang.Entry, parent interface{}, value interface{}, enc Encoding) error {
 	if util.IsValueNil(value) {
-		return nil
+		if enc == JSONEncoding {
+			return nil
+		}
+		return fmt.Errorf("unmarshalLeaf: invalid nil value to unmarshal")
 	}
 
 	var err error
@@ -660,7 +663,10 @@ func schemaToEnumTypes(schema *yang.Entry, t reflect.Type) ([]reflect.Type, erro
 //     Required if the unmarshaled type is an enum.
 func unmarshalScalar(parent interface{}, schema *yang.Entry, fieldName string, value interface{}, enc Encoding) (interface{}, error) {
 	if util.IsValueNil(value) {
-		return nil, nil
+		if enc == JSONEncoding {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unmarshalScalar: invalid nil value to unmarshal")
 	}
 
 	if err := validateLeafSchema(schema); err != nil {

--- a/ytypes/leaf_list.go
+++ b/ytypes/leaf_list.go
@@ -113,6 +113,9 @@ func unmarshalLeafList(schema *yang.Entry, parent interface{}, value interface{}
 		if !ok {
 			return fmt.Errorf("unmarshalLeafList for schema %s: value %v: got type %T, expect *gpb.TypedValue_LeaflistVal set in *gpb.TypedValue", schema.Name, util.ValueStr(value), tv.GetValue())
 		}
+		if len(sa.LeaflistVal.GetElement()) == 0 {
+			return fmt.Errorf("unmarshalLeafList for schema %s: value %v: got empty leaf list, expect non-empty leaf list", schema.Name, util.ValueStr(value))
+		}
 		for _, v := range sa.LeaflistVal.GetElement() {
 			if err := unmarshalGeneric(&leafSchema, parent, v, enc); err != nil {
 				return err

--- a/ytypes/leaf_list.go
+++ b/ytypes/leaf_list.go
@@ -90,7 +90,10 @@ func validateLeafListSchema(schema *yang.Entry) error {
 //   value is a gNMI TypedValue if enc is GNMIEncoding, represented as TypedValue_LeafListVal
 func unmarshalLeafList(schema *yang.Entry, parent interface{}, value interface{}, enc Encoding) error {
 	if util.IsValueNil(value) {
-		return nil
+		if enc == JSONEncoding {
+			return nil
+		}
+		return fmt.Errorf("unmarshalLeafList: invalid nil value to unmarshal")
 	}
 	// Check that the schema itself is valid.
 	if err := validateLeafListSchema(schema); err != nil {

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -233,8 +233,9 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		wantErr string
 	}{
 		{
-			desc: "nil success",
-			want: LeafListContainer{},
+			desc:    "nil fail",
+			want:    LeafListContainer{},
+			wantErr: "nil",
 		},
 		{
 			desc: "int32 success",
@@ -251,10 +252,10 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 			want: LeafListContainer{Int32LeafList: []*int32{ygot.Int32(-42), ygot.Int32(0), ygot.Int32(42)}},
 		},
 		{
-			desc: "int32 pass with nil TypedValue",
-			sch:  int32LeafListSchema,
-			val:  nil,
-			want: LeafListContainer{},
+			desc:    "int32 fail with nil TypedValue",
+			sch:     int32LeafListSchema,
+			val:     (*gpb.TypedValue)(nil),
+			wantErr: "nil value to unmarshal",
 		},
 		{
 			desc:    "int32 fail with nil Value within TypedValue",

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -251,6 +251,46 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 			want: LeafListContainer{Int32LeafList: []*int32{ygot.Int32(-42), ygot.Int32(0), ygot.Int32(42)}},
 		},
 		{
+			desc: "int32 pass with nil TypedValue",
+			sch:  int32LeafListSchema,
+			val:  nil,
+			want: LeafListContainer{},
+		},
+		{
+			desc:    "int32 fail with nil Value within TypedValue",
+			sch:     int32LeafListSchema,
+			val:     &gpb.TypedValue{Value: nil},
+			wantErr: "got type <nil>",
+		},
+		{
+			desc: "int32 fail with nil LeaflistVal",
+			sch:  int32LeafListSchema,
+			val: &gpb.TypedValue{Value: &gpb.TypedValue_LeaflistVal{
+				LeaflistVal: nil,
+			}},
+			wantErr: "empty leaf list",
+		},
+		{
+			desc: "int32 fail with nil elements",
+			sch:  int32LeafListSchema,
+			val: &gpb.TypedValue{Value: &gpb.TypedValue_LeaflistVal{
+				LeaflistVal: &gpb.ScalarArray{
+					Element: nil,
+				},
+			}},
+			wantErr: "empty leaf list",
+		},
+		{
+			desc: "int32 fail with empty elements",
+			sch:  int32LeafListSchema,
+			val: &gpb.TypedValue{Value: &gpb.TypedValue_LeaflistVal{
+				LeaflistVal: &gpb.ScalarArray{
+					Element: []*gpb.TypedValue{},
+				},
+			}},
+			wantErr: "empty leaf list",
+		},
+		{
 			desc: "enum success",
 			sch:  enumLeafListSchema,
 			val: &gpb.TypedValue{Value: &gpb.TypedValue_LeaflistVal{

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1688,6 +1688,12 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantErr: `StringToType("4242", int8) failed; unable to convert "4242" to int8`,
 		},
 		{
+			desc:     "success gNMI nil value (no-op)",
+			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
+			inVal:    nil,
+			wantVal:  &LeafContainerStruct{},
+		},
+		{
 			desc:     "success gNMI IntVal to Yuint8",
 			inSchema: typeToLeafSchema("uint8-leaf", yang.Yuint8),
 			inVal: &gpb.TypedValue{
@@ -1718,6 +1724,12 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantErr: `StringToType("4242", uint8) failed; unable to convert "4242" to uint8`,
 		},
 		{
+			desc:     "fail gNMI TypedValue with nil Value field",
+			inSchema: typeToLeafSchema("uint8-leaf", yang.Yuint8),
+			inVal:    &gpb.TypedValue{},
+			wantErr:  `failed to unmarshal`,
+		},
+		{
 			desc:     "success gNMI FloatVal to Ydecimal64",
 			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
 			inVal: &gpb.TypedValue{
@@ -1740,6 +1752,16 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantVal: &LeafContainerStruct{DecimalLeaf: ygot.Float64(0.42)},
 		},
 		{
+			desc:     "fail gNMI nil Decimal64 value",
+			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
+			inVal: &gpb.TypedValue{
+				Value: &gpb.TypedValue_DecimalVal{
+					DecimalVal: nil,
+				},
+			},
+			wantErr: "DecimalVal is nil",
+		},
+		{
 			desc:     "success gNMI BytesVal to Ybinary",
 			inSchema: typeToLeafSchema("binary-leaf", yang.Ybinary),
 			inVal: &gpb.TypedValue{
@@ -1748,6 +1770,16 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 				},
 			},
 			wantVal: &LeafContainerStruct{BinaryLeaf: Binary([]byte("value"))},
+		},
+		{
+			desc:     "fail gNMI BytesVal is nil",
+			inSchema: typeToLeafSchema("binary-leaf", yang.Ybinary),
+			inVal: &gpb.TypedValue{
+				Value: &gpb.TypedValue_BytesVal{
+					BytesVal: nil,
+				},
+			},
+			wantErr: "BytesVal is nil",
 		},
 		{
 			desc:     "success unmarshalling union leaf string field",

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1688,10 +1688,16 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantErr: `StringToType("4242", int8) failed; unable to convert "4242" to int8`,
 		},
 		{
-			desc:     "success gNMI nil value (no-op)",
+			desc:     "failure gNMI nil value",
 			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
 			inVal:    nil,
-			wantVal:  &LeafContainerStruct{},
+			wantErr:  "nil value to unmarshal",
+		},
+		{
+			desc:     "failure gNMI nil TypedValue",
+			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
+			inVal:    (*gpb.TypedValue)(nil),
+			wantErr:  "nil value to unmarshal",
 		},
 		{
 			desc:     "success gNMI IntVal to Yuint8",
@@ -1790,6 +1796,12 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 				},
 			},
 			wantVal: &LeafContainerStruct{UnionLeaf: &UnionLeafType_String{String: "forty two"}},
+		},
+		{
+			desc:     "fail unmarshalling nil for union leaf string field",
+			inSchema: unionSchema,
+			inVal:    nil,
+			wantErr:  "nil value to unmarshal",
 		},
 		{
 			desc:     "success unmarshalling union leaf enum field",

--- a/ytypes/unmarshal.go
+++ b/ytypes/unmarshal.go
@@ -74,10 +74,6 @@ func unmarshalGeneric(schema *yang.Entry, parent interface{}, value interface{},
 	util.Indent()
 	defer util.Dedent()
 
-	// Nil value means the field is unset.
-	if util.IsValueNil(value) {
-		return nil
-	}
 	if schema == nil {
 		return fmt.Errorf("nil schema for parent type %T, value %v (%T)", parent, value, value)
 	}


### PR DESCRIPTION
Also add a corner case test for ygot.Diff.

NOTE: A nil TypeValue currently doesn't fail, and it looks to be implemented that way. I can change it if this doesn't make sense.

e.g.
```
func unmarshalLeafList(schema *yang.Entry, parent interface{}, value interface{}, enc Encoding) error {
	if util.IsValueNil(value) {
		return nil
	}
```