### PR TITLE
Create Annotation JSON Tree using deepcopy instead of Marshal+Unmarshal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
 	github.com/google/go-cmp v0.4.0
 	github.com/kylelemons/godebug v1.1.0
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600
 	github.com/openconfig/goyang v0.0.0-20200328051049-f3d50fd25b33
 	github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/protobuf v3.11.4+incompatible/go.mod h1:lUQ9D1ePzbH2PrIS7ob/bjm9HXyH5WHB0Akwh7URreM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/openconfig/gnmi v0.0.0-20200307010808-e7106f7f5493 h1:e/znXbq+Yiws97a4lJYlUeRw9OGxT2q27L4aMUb0GuM=
 github.com/openconfig/gnmi v0.0.0-20200307010808-e7106f7f5493/go.mod h1:jMSUQIR4z9WTtM58/QBHbElXAwbUnomFdty1aund1uY=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600 h1:EO0ADDEFlykRo0dVFbFglXO16iDoD60IxPJyttU49Ko=

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -1355,6 +1355,9 @@ func jsonAnnotationSlice(v reflect.Value) (interface{}, error) {
 
 	vals := []interface{}{}
 	for i := 0; i < v.Len(); i++ {
+		// deepcopy the Annotation to avoid accidentally modifying its contents.
+		// Since Annotations must have an implemented MarshalJSON
+		// function, this should not impact the final JSON.
 		vals = append(vals, deepcopy.Copy(v.Index(i).Interface().(Annotation)))
 	}
 	return vals, nil

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/mohae/deepcopy"
 	"github.com/openconfig/gnmi/errlist"
 	"github.com/openconfig/gnmi/value"
 	"github.com/openconfig/ygot/util"
@@ -1354,20 +1355,7 @@ func jsonAnnotationSlice(v reflect.Value) (interface{}, error) {
 
 	vals := []interface{}{}
 	for i := 0; i < v.Len(); i++ {
-		fv := v.Index(i).Interface().(Annotation)
-		jv, err := fv.MarshalJSON()
-		if err != nil {
-			return nil, fmt.Errorf("cannot marshal annotation %v type %T to JSON: %v", fv, fv, err)
-		}
-
-		// MarshalJSON returns []byte, but we really want to have this as the unmarshalled
-		// value, since constructJSON returns a series of map[string]interface{} Which
-		// are later marshalled, we therefore unmarshal the []byte into an interface{}
-		var nv interface{}
-		if err := json.Unmarshal(jv, &nv); err != nil {
-			return nil, fmt.Errorf("annotation %v, type %T could not be unmarshalled from JSON: %v", fv, fv, err)
-		}
-		vals = append(vals, nv)
+		vals = append(vals, deepcopy.Copy(v.Index(i).Interface().(Annotation)))
 	}
 	return vals, nil
 }

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1580,8 +1580,14 @@ type testAnnotation struct {
 }
 
 // MarshalJSON repeats the string in the JSON representation. This deviation
-// from json.Marshal helps test that the json generation uses the
-// Annotation's custom MarshalJSON/UnmarshalJSON functions.
+// from json.Marshal helps ensure that the test actually uses Annotation's
+// custom MarshalJSON/UnmarshalJSON functions instead of using the default
+// mechanism.
+// e.g. It prevents the implementation from successfully using
+// json.Marshal(obj) followed by json.Unmarshal(obj, interface{}) to copy the
+// value -- the unmarshal call would fail to use the json.Unmarshaler
+// interface to invoke UnmarshalJSON(), and cause the data to be repeated after
+// the unmarshal call.
 func (t *testAnnotation) MarshalJSON() ([]byte, error) {
 	t2 := *t
 	t2.AnnotationFieldOne += t2.AnnotationFieldOne
@@ -1589,8 +1595,9 @@ func (t *testAnnotation) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON halves the string from the JSON representation. This deviation
-// from json.Unmarshal helps test that the json generation uses the
-// Annotation's custom MarshalJSON/UnmarshalJSON functions.
+// from json.Unmarshal helps ensure that the test actually uses Annotation's
+// custom MarshalJSON/UnmarshalJSON functions instead of using the default
+// mechanism.
 func (t *testAnnotation) UnmarshalJSON(d []byte) error {
 	if err := json.Unmarshal(d, t); err != nil {
 		return err


### PR DESCRIPTION
Currently, the jsonTree (`map[string]interface{}`) construction is done incorrectly due to a `json.Unmarshal` call on the marshalled data from the custom `Marshaler`, which doesn't make sense if the two calls are not compatible.

I believe the reason Marshal+Unmarshal is done is to copy the data, so instead I've used an MIT licensed library to do a deepcopy so that the final jsonTree contains the `Annotation` struct directly, meaning that a subsequent `json.Marshal` will call the customized `MarshalJSON` function.

Although I don't see how using the `Annotation` struct directly instead of a `map[string]interface{}` would create any new problems, it still doesn't solve the problem of how to unmarshal from bytes to the jsonTree correctly, but I saw this so I'm assuming this is irrelevant for now: `// TODO(robjs): Implement unmarshalling annotations.`

I don't see how to do `bytes -> jsonTree` easily, maybe somehow we'll have to bypass the `Marshaler` interface if we ever do intend to unmarshal `Annotation`s.