### PR TITLE
Add a new mechanism for rendering rfc7951 JSON.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -963,13 +963,7 @@ func structJSON(s GoStruct, parentMod string, args jsonOutputConfig) (map[string
 			continue
 		}
 
-		var value interface{}
-
-		/*if util.IsYgotAnnotation(fType) {
-			value, err = jsonAnnotationSlice(field)
-		} else {*/
-		value, err = jsonValue(field, pmod, args)
-
+		value, err := jsonValue(field, pmod, args)
 		if err != nil {
 			errs.Add(err)
 			continue

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -890,7 +890,10 @@ func ConstructInternalJSON(s GoStruct) (map[string]interface{}, error) {
 // to be rendered. The supplied args are used to control RFC7951-specific behaviours
 // of the rendering. The rendered JSON is returned as a string.
 func EmitRFC7951(d interface{}, args *RFC7951JSONConfig) (string, error) {
-	j, err := marshalRFC7951(d, args)
+	j, err := jsonValue(reflect.ValueOf(d), "", jsonOutputConfig{
+		jType:         RFC7951,
+		rfc7951Config: args,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -900,53 +903,6 @@ func EmitRFC7951(d interface{}, args *RFC7951JSONConfig) (string, error) {
 	}
 
 	return string(js), nil
-}
-
-// marshalRFC7951 marshals the supplied interface{} d into an interface{} which
-// can be handed directly to json.Marshal. It has specific handling for struct,
-// map, and slice fields within the supplied interface{} to ensure RFC7951-compatible
-// marshalling.
-func marshalRFC7951(d interface{}, args *RFC7951JSONConfig) (interface{}, error) {
-	v := reflect.ValueOf(d)
-	gsT := reflect.TypeOf((*GoStruct)(nil)).Elem()
-
-	jargs := jsonOutputConfig{
-		jType:         RFC7951,
-		rfc7951Config: args,
-	}
-
-	if v.Type().Implements(gsT) {
-		return structJSON(v.Interface().(GoStruct), "", jargs)
-	}
-
-	if util.IsValueMap(v) {
-		j := []interface{}{}
-		for _, k := range v.MapKeys() {
-			f := v.MapIndex(k)
-			if !f.Type().Implements(gsT) {
-				return nil, fmt.Errorf("invalid input type to MarshalRFC7951, maps must be valid YANG lists, got: %T", f.Interface())
-			}
-			js, err := structJSON(f.Interface().(GoStruct), "", jargs)
-			if err != nil {
-				return nil, fmt.Errorf("cannot marshal entry %v to JSON, got err: %v", f.Interface(), err)
-			}
-			j = append(j, js)
-		}
-	}
-
-	isAnnotationSlice := func(v reflect.Value) bool {
-		annoT := reflect.TypeOf((*Annotation)(nil)).Elem()
-		return v.Index(0).Type().Implements(annoT)
-	}
-
-	if util.IsValueSlice(v) && v.Len() != 0 && isAnnotationSlice(v) {
-		//&& v.Index(0).Type().Implements(reflect.TypeOf((*Annotation)(nil)).Elem()) {
-		// This is a slice of annotations, so we render them using the specific handling
-		// for annotations.
-		return jsonAnnotationSlice(v)
-	}
-
-	return jsonValue(v, "", jargs)
 }
 
 // jsonOutputConfig is used to determine how constructJSON should generate
@@ -1009,11 +965,10 @@ func structJSON(s GoStruct, parentMod string, args jsonOutputConfig) (map[string
 
 		var value interface{}
 
-		if util.IsYgotAnnotation(fType) {
+		/*if util.IsYgotAnnotation(fType) {
 			value, err = jsonAnnotationSlice(field)
-		} else {
-			value, err = jsonValue(field, pmod, args)
-		}
+		} else {*/
+		value, err = jsonValue(field, pmod, args)
 
 		if err != nil {
 			errs.Add(err)
@@ -1306,8 +1261,19 @@ func jsonValue(field reflect.Value, parentMod string, args jsonOutputConfig) (in
 			}
 		}
 	case reflect.Slice:
+
+		isAnnotationSlice := func(v reflect.Value) bool {
+			annoT := reflect.TypeOf((*Annotation)(nil)).Elem()
+			return v.Index(0).Type().Implements(annoT)
+		}
+
 		var err error
-		value, err = jsonSlice(field, parentMod, args)
+		switch {
+		case isAnnotationSlice(field):
+			value, err = jsonAnnotationSlice(field)
+		default:
+			value, err = jsonSlice(field, parentMod, args)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -1258,7 +1258,7 @@ func jsonValue(field reflect.Value, parentMod string, args jsonOutputConfig) (in
 
 		isAnnotationSlice := func(v reflect.Value) bool {
 			annoT := reflect.TypeOf((*Annotation)(nil)).Elem()
-			return v.Index(0).Type().Implements(annoT)
+			return v.Type().Elem().Implements(annoT)
 		}
 
 		var err error

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -911,13 +911,13 @@ func (JSONIndent) IsMarshal7951Arg() {}
 // The rendered JSON is returned as a byte slice - in common with json.Marshal.
 func Marshal7951(d interface{}, args ...Marshal7951Arg) ([]byte, error) {
 	var (
-		rfccfg *RFC7951JSONConfig
+		rfcCfg *RFC7951JSONConfig
 		indent string
 	)
 	for _, a := range args {
 		switch v := a.(type) {
 		case *RFC7951JSONConfig:
-			rfccfg = v
+			rfcCfg = v
 		case JSONIndent:
 			indent = string(v)
 		}
@@ -925,7 +925,7 @@ func Marshal7951(d interface{}, args ...Marshal7951Arg) ([]byte, error) {
 	}
 	j, err := jsonValue(reflect.ValueOf(d), "", jsonOutputConfig{
 		jType:         RFC7951,
-		rfc7951Config: rfccfg,
+		rfc7951Config: rfcCfg,
 	})
 
 	if err != nil {

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2977,7 +2977,7 @@ func TestMarshal7951(t *testing.T) {
 	}, {
 		desc: "empty type",
 		in:   &renderExample{Empty: true},
-		want: `{"empty":null}`,
+		want: `{"empty":[null]}`,
 	}, {
 		desc: "indentation requested",
 		in: &renderExample{

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2937,7 +2937,7 @@ func TestEmitRFC7951(t *testing.T) {
 		in: map[string]string{
 			"one": "two",
 		},
-		wantErrSubstring: "maps must be valid YANG lists",
+		wantErrSubstring: "invalid GoStruct",
 	}, {
 		desc: "map of invalid GoStruct",
 		in: map[string]*invalidGoStructField{

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -2962,6 +2962,21 @@ func TestEmitRFC7951(t *testing.T) {
 			},
 		},
 		want: `[{"field":"test"}]`,
+	}, {
+		desc: "empty annotation slice",
+		in:   []*testAnnotation{},
+		want: `null`,
+	}, {
+		desc: "empty map",
+		in:   map[string]*renderExample{},
+		want: `null`,
+	}, {
+		desc: "nil string pointer",
+		in: func() *string {
+			var s *string
+			return s
+		}(),
+		want: `null`,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
 * (M) ygot/{render,render_test}.go
  - Some users wish to be able to render a specific field to
    RFC7951 JSON directly, such that a particular subtree can be
    rendered.
    Today, this is not possible since we require arguments to the
    rendering functions to be specified as GoStructs. This PR adds
    a new rendering method that specifically takes an interface{}
    and returns a string such that these users can call this method
    generically for any valid input type of a ygen generated Go file.
    We lose some type-safety in this mechanism, but this is similar to
    the interface provided by json.Marshal.
    This method is implemented only for RFC7951 JSON, as we aim to
    move away from the 'internal' format (which today is only
    supported for marshalling and not unmarshalling).
```