### PR TITLE
Remove Resolve function from generated code

### DIFF
--- a/exampleocpath/ocpath_augment.go
+++ b/exampleocpath/ocpath_augment.go
@@ -1,6 +1,6 @@
 package exampleocpath
 
 func (r *Root) WithName(name string) *Root {
-	r.CustomData["name"] = name
+	r.SetCustomDataKey("name", name)
 	return r
 }

--- a/exampleocpath/ocpath_augment.go
+++ b/exampleocpath/ocpath_augment.go
@@ -1,6 +1,6 @@
 package exampleocpath
 
 func (r *Root) WithName(name string) *Root {
-	r.SetCustomDataKey("name", name)
+	r.PutCustomData("name", name)
 	return r
 }

--- a/exampleocpath/ocpath_augment.go
+++ b/exampleocpath/ocpath_augment.go
@@ -1,6 +1,6 @@
 package exampleocpath
 
 func (r *Root) WithName(name string) *Root {
-	r.customData["name"] = name
+	r.CustomData["name"] = name
 	return r
 }

--- a/ygot/path_types.go
+++ b/ygot/path_types.go
@@ -86,8 +86,8 @@ func (d *DeviceRootBase) CustomData() map[string]interface{} {
 	return d.customData
 }
 
-// SetCustomDataKey modifies an entry in the customData field of the DeviceRootBase struct.
-func (d *DeviceRootBase) SetCustomDataKey(key string, val interface{}) {
+// PutCustomData modifies an entry in the customData field of the DeviceRootBase struct.
+func (d *DeviceRootBase) PutCustomData(key string, val interface{}) {
 	d.customData[key] = val
 }
 

--- a/ygot/path_types.go
+++ b/ygot/path_types.go
@@ -54,37 +54,45 @@ type NodePath struct {
 	p             PathStruct
 }
 
-// FakeRootPathStruct is an interface that is implemented by the fake root path
+// fakeRootPathStruct is an interface that is implemented by the fake root path
 // struct type.
-type FakeRootPathStruct interface {
+type fakeRootPathStruct interface {
 	PathStruct
-	GetId() string
-	GetCustomData() map[string]interface{}
+	Id() string
+	CustomData() map[string]interface{}
 }
 
 func NewDeviceRootBase(id string) *DeviceRootBase {
-	return &DeviceRootBase{NodePath: &NodePath{}, id: id, CustomData: map[string]interface{}{}}
+	return &DeviceRootBase{NodePath: &NodePath{}, id: id, customData: map[string]interface{}{}}
 }
 
 // DeviceRootBase represents the fakeroot for all YANG schema elements.
 type DeviceRootBase struct {
 	*NodePath
-	id         string
-	CustomData map[string]interface{}
+	id string
+	// customData is meant to store root-specific information that may be
+	// useful to know when processing the resolved path. It is meant to be
+	// accessible through a user-defined accessor.
+	customData map[string]interface{}
 }
 
-// GetId returns the device ID of the DeviceRootBase struct.
-func (d *DeviceRootBase) GetId() string {
+// Id returns the device ID of the DeviceRootBase struct.
+func (d *DeviceRootBase) Id() string {
 	return d.id
 }
 
-// GetId returns the CustomData field of the DeviceRootBase struct.
-func (d *DeviceRootBase) GetCustomData() map[string]interface{} {
-	return d.CustomData
+// CustomData returns the customData field of the DeviceRootBase struct.
+func (d *DeviceRootBase) CustomData() map[string]interface{} {
+	return d.customData
+}
+
+// SetCustomDataKey modifies an entry in the customData field of the DeviceRootBase struct.
+func (d *DeviceRootBase) SetCustomDataKey(key string, val interface{}) {
+	d.customData[key] = val
 }
 
 // ResolvePath is a helper which returns the resolved *gpb.Path of a PathStruct
-// node as well as the root node's CustomData.
+// node as well as the root node's customData.
 func ResolvePath(n PathStruct) (*gpb.Path, map[string]interface{}, []error) {
 	var p []*gpb.PathElem
 	var errs []error
@@ -100,11 +108,11 @@ func ResolvePath(n PathStruct) (*gpb.Path, map[string]interface{}, []error) {
 		return nil, nil, errs
 	}
 
-	root, ok := n.(FakeRootPathStruct)
+	root, ok := n.(fakeRootPathStruct)
 	if !ok {
 		return nil, nil, append(errs, fmt.Errorf("ygot.ResolvePath(ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
 	}
-	return &gpb.Path{Target: root.GetId(), Elem: p}, root.GetCustomData(), nil
+	return &gpb.Path{Target: root.Id(), Elem: p}, root.CustomData(), nil
 }
 
 // ResolveRelPath returns the partial []*gpb.PathElem representing the

--- a/ygot/path_types_test.go
+++ b/ygot/path_types_test.go
@@ -22,13 +22,13 @@ import (
 )
 
 type deviceRoot struct {
-	DeviceRootBase
+	*DeviceRootBase
 }
 
 func TestResolvePath(t *testing.T) {
 	wantId := "FOO"
 	wantCustomData := map[string]interface{}{"foo": "bar"}
-	root := NewDeviceRootBase(wantId)
+	root := deviceRoot{DeviceRootBase: NewDeviceRootBase(wantId)}
 	root.CustomData = wantCustomData
 
 	tests := []struct {

--- a/ygot/path_types_test.go
+++ b/ygot/path_types_test.go
@@ -29,7 +29,7 @@ func TestResolvePath(t *testing.T) {
 	wantId := "FOO"
 	wantCustomData := map[string]interface{}{"foo": "bar"}
 	root := deviceRoot{NewDeviceRootBase(wantId)}
-	root.SetCustomDataKey("foo", "bar")
+	root.PutCustomData("foo", "bar")
 
 	tests := []struct {
 		name        string

--- a/ygot/path_types_test.go
+++ b/ygot/path_types_test.go
@@ -28,8 +28,8 @@ type deviceRoot struct {
 func TestResolvePath(t *testing.T) {
 	wantId := "FOO"
 	wantCustomData := map[string]interface{}{"foo": "bar"}
-	root := deviceRoot{DeviceRootBase: NewDeviceRootBase(wantId)}
-	root.CustomData = wantCustomData
+	root := deviceRoot{NewDeviceRootBase(wantId)}
+	root.SetCustomDataKey("foo", "bar")
 
 	tests := []struct {
 		name        string

--- a/ygot/path_types_test.go
+++ b/ygot/path_types_test.go
@@ -21,14 +21,20 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type deviceRoot struct {
+	DeviceRootBase
+}
+
 func TestResolvePath(t *testing.T) {
-	root := &NodePath{}
+	wantId := "FOO"
+	wantCustomData := map[string]interface{}{"foo": "bar"}
+	root := NewDeviceRootBase(wantId)
+	root.CustomData = wantCustomData
 
 	tests := []struct {
 		name        string
 		in          PathStruct
 		wantPathStr string
-		wantRoot    PathStruct
 		wantErr     bool
 	}{{
 		name: "simple",
@@ -42,12 +48,10 @@ func TestResolvePath(t *testing.T) {
 			},
 		},
 		wantPathStr: "/parent/child",
-		wantRoot:    root,
 	}, {
 		name:        "root",
 		in:          root,
 		wantPathStr: "/",
-		wantRoot:    root,
 	}, {
 		name: "list",
 		in: &NodePath{
@@ -60,7 +64,6 @@ func TestResolvePath(t *testing.T) {
 			},
 		},
 		wantPathStr: "/parent/values/value[ID=5]",
-		wantRoot:    root,
 	}, {
 		name: "list with unconvertible key value",
 		in: &NodePath{
@@ -73,31 +76,33 @@ func TestResolvePath(t *testing.T) {
 			},
 		},
 		wantPathStr: "",
-		wantRoot:    nil,
 		wantErr:     true,
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wantP, err := StringToStructuredPath(tt.wantPathStr)
+			wantPath, err := StringToStructuredPath(tt.wantPathStr)
 			if err != nil {
 				t.Fatal(err)
 			}
-			wantPath := wantP.Elem
+			wantPath.Target = wantId
 
-			gotRoot, gotPath, gotErrs := ResolvePath(tt.in)
+			gotPath, gotCustomData, gotErrs := ResolvePath(tt.in)
 			if gotErrs != nil && !tt.wantErr {
 				t.Fatal(gotErrs)
 			} else if gotErrs == nil && tt.wantErr {
 				t.Fatal("expected error but did not receive any")
 			}
-
-			if gotRoot != tt.wantRoot {
-				t.Errorf("root not expected - got: %v, want: %v", gotRoot, tt.wantRoot)
+			if gotErrs != nil {
+				return
 			}
 
 			if diff := cmp.Diff(wantPath, gotPath, cmp.Comparer(proto.Equal)); diff != "" {
-				t.Errorf("ResolvePath returned diff (-want +got):\n%s", diff)
+				t.Errorf("ResolvePath returned diff (-want, +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(wantCustomData, gotCustomData); diff != "" {
+				t.Errorf("ResolvePath: customData is not same as expected (-want, +got)\n%s", diff)
 			}
 		})
 	}

--- a/ypathgen/generator/generator_test.go
+++ b/ypathgen/generator/generator_test.go
@@ -31,7 +31,6 @@ func TestWritePathCode(t *testing.T) {
 		name: "simple",
 		in: &ypathgen.GeneratedPathCode{
 			CommonHeader: "path common header\n",
-			OneOffHeader: "\npath one-off header\n",
 			Structs: []ypathgen.GoPathStructCodeSnippet{{
 				PathStructName:    "PathStructName",
 				StructBase:        "\nStructDef\n",
@@ -39,8 +38,6 @@ func TestWritePathCode(t *testing.T) {
 			}},
 		},
 		want: `path common header
-
-path one-off header
 
 StructDef
 

--- a/ypathgen/path_tests/path_test.go
+++ b/ypathgen/path_tests/path_test.go
@@ -32,7 +32,7 @@ const deviceId = "dev"
 // verifyPath checks the given path against expected.
 func verifyPath(t *testing.T, p ygot.PathStruct, wantPathStr string) {
 	t.Helper()
-	gotPath, _, errs := ocp.Resolve(p)
+	gotPath, _, errs := ygot.ResolvePath(p)
 	if errs != nil {
 		t.Fatal(errs)
 	}
@@ -53,11 +53,11 @@ func verifyPath(t *testing.T, p ygot.PathStruct, wantPathStr string) {
 // be the non-wildcard version of the path struct.
 func verifyTypesEqual(t *testing.T, target ygot.PathStruct, wild ygot.PathStruct, equal bool) {
 	t.Helper()
-	targetPathProto, _, errs := ocp.Resolve(target)
+	targetPathProto, _, errs := ygot.ResolvePath(target)
 	if errs != nil {
 		t.Fatal(errs)
 	}
-	wildPathProto, _, errs := ocp.Resolve(wild)
+	wildPathProto, _, errs := ygot.ResolvePath(wild)
 	if errs != nil {
 		t.Fatal(errs)
 	}
@@ -90,7 +90,7 @@ func TestCustomData(t *testing.T) {
 	p := root.WithName("foo").Interface("eth1").Ethernet().PortSpeed()
 	verifyPath(t, p, "/interfaces/interface[name=eth1]/ethernet/state/port-speed")
 
-	_, customData, _ := ocp.Resolve(p)
+	_, customData, _ := ygot.ResolvePath(p)
 	if diff := cmp.Diff(map[string]interface{}{"name": "foo"}, customData); diff != "" {
 		t.Errorf("resolved customData for root does not match (-want, +got):\n%s", diff)
 	}

--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -386,10 +386,6 @@ import (
 	// the methods of PathStructInterfaceName and FakeRootBaseTypeName in
 	// order to allow its path struct descendents to use the ygot.Resolve()
 	// helper function for obtaining their absolute paths.
-	//
-	// CustomData is meant to store root-specific information that may be
-	// useful to know when processing the resolved path. It is meant to be
-	// accessible through a user-defined accessor.
 	goPathFakeRootTemplate = mustTemplate("fakeroot", `
 // {{ .TypeName }} represents the {{ .YANGPath }} YANG schema element.
 type {{ .TypeName }} struct {
@@ -398,7 +394,7 @@ type {{ .TypeName }} struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *{{ .TypeName }} {
-	return &{{ .TypeName }}{ {{- .FakeRootBaseTypeName }}: ygot.New{{- .FakeRootBaseTypeName }}(id)}
+	return &{{ .TypeName }}{ygot.New{{- .FakeRootBaseTypeName }}(id)}
 }
 `)
 

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -1410,13 +1410,12 @@ func (n *ContainerWithConfigAny) Leaflist2() *ContainerWithConfig_Leaflist2Any {
 			StructBase: `
 // Root represents the /root YANG schema element.
 type Root struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Root {
-	return &Root{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Root{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Leaf represents the /root-module/leaf YANG schema element.

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -1415,7 +1415,7 @@ type Root struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Root {
-	return &Root{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Root{ygot.NewDeviceRootBase(id)}
 }
 
 // Leaf represents the /root-module/leaf YANG schema element.

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -11,26 +11,9 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
-
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
 
 // ChoiceCaseAnonymousCase represents the /choice-case-example/choice-case-anonymous-case YANG schema element.
 type ChoiceCaseAnonymousCase struct {
@@ -182,13 +165,12 @@ func (n *ChoiceCaseWithLeafrefAny) Referenced() *ChoiceCaseWithLeafref_Reference
 
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // ChoiceCaseAnonymousCase returns from Device the path struct for its child "choice-case-anonymous-case".

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -170,7 +170,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // ChoiceCaseAnonymousCase returns from Device the path struct for its child "choice-case-anonymous-case".

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -11,26 +11,9 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
-
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
 
 // AList represents the /enum-module/a-lists/a-list YANG schema element.
 type AList struct {
@@ -160,13 +143,12 @@ func (n *CAny) Cl() *C_ClAny {
 
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // AListAny returns from Device the path struct for its child "a-list".

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -148,7 +148,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // AListAny returns from Device the path struct for its child "a-list".

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -12,36 +12,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Native returns from Device the path struct for its child "native".

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -23,7 +23,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Native returns from Device the path struct for its child "native".

--- a/ypathgen/testdata/structs/openconfig-camelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase.path-txt
@@ -11,26 +11,9 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
-
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
 
 // BGP represents the /openconfig-camelcase/bgp YANG schema element.
 type BGP struct {
@@ -130,13 +113,12 @@ func (n *BGP_NeighborAny) PeerIP() *BGP_Neighbor_PeerIPAny {
 
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // BGP returns from Device the path struct for its child "bgp".

--- a/ypathgen/testdata/structs/openconfig-camelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase.path-txt
@@ -118,7 +118,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // BGP returns from Device the path struct for its child "bgp".

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Foo returns from Device the path struct for its child "foo".

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Foo returns from Device the path struct for its child "foo".

--- a/ypathgen/testdata/structs/openconfig-simple-0.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-0.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-0.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-0.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-1.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-1.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-30.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-30.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-30.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-30.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-31.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-31.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-32.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-32.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-40.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-40.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-40.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-40.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-41.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-41.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-42.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-42.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-43.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-43.path-txt
@@ -11,9 +11,6 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )

--- a/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Parent returns from Device the path struct for its child "parent".

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // DupEnum returns from Device the path struct for its child "dup-enum".

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // DupEnum returns from Device the path struct for its child "dup-enum".

--- a/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Model returns from Device the path struct for its child "model".

--- a/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Model returns from Device the path struct for its child "model".

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -11,36 +11,18 @@ Imported modules were sourced from:
 package ocpathstructs
 
 import (
-	"fmt"
-
-	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"
 	"github.com/openconfig/ygot/ygot"
 )
 
-// Resolve is a helper which returns the resolved *gpb.Path of a PathStruct node.
-func Resolve(n ygot.PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	n, p, errs := ygot.ResolvePath(n)
-	root, ok := n.(*Device)
-	if !ok {
-		errs = append(errs, fmt.Errorf("Resolve(n ygot.PathStruct): got unexpected root of (type, value) (%T, %v)", n, n))
-	}
-
-	if errs != nil {
-		return nil, nil, errs
-	}
-	return &gpb.Path{Target: root.id, Elem: p}, root.customData, nil
-}
-
 // Device represents the /device YANG schema element.
 type Device struct {
-	*ygot.NodePath
-	id string
-	customData map[string]interface{}
+	*ygot.DeviceRootBase
 }
 
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{NodePath: &ygot.NodePath{}, id: id, customData: map[string]interface{}{}}
+	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
 }
 
 // Model returns from Device the path struct for its child "model".

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -22,7 +22,7 @@ type Device struct {
 
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *Device {
-	return &Device{DeviceRootBase: ygot.NewDeviceRootBase(id)}
+	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
 // Model returns from Device the path struct for its child "model".


### PR DESCRIPTION
Merge its functionality into `ResolvePath` in `ygot/ygot`. This reduces complexity in the generated code.

The reason why this function was needed in the generated code instead of being able to reside in `ygot/ygot` was it needed to access special fields from the generated root `PathStruct`. Using the pattern analogous to `ygot.NodePath`, a base struct `DeviceRootBase` is defined along with an interface that the generated root object embeds. This allows `ygot` to access those root struct fields.