### PR TITLE
check skipValidation before calling Validate

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -359,8 +359,10 @@ func EmitJSON(s ValidatedGoStruct, opts *EmitJSONConfig) (string, error) {
 		skipValidation = opts.SkipValidation
 	}
 
-	if err := s.Validate(vopts...); !skipValidation && err != nil {
-		return "", fmt.Errorf("validation err: %v", err)
+	if !skipValidation {
+		if err := s.Validate(vopts...); err != nil {
+			return "", fmt.Errorf("validation err: %v", err)
+		}
 	}
 
 	v, err := makeJSON(s, opts)


### PR DESCRIPTION
When the `ValidatedGoStruct` is of considerable size, `EmitJSON()` method takes significant memory resource even though skipValidation is `true`. 

This change can reduce the memory utilization while using EmitJSON with `skipValidation=true`