### PR TITLE
Add support for new Go unions for ytypes' Validate functions

### DIFF
--- a/testutil/types.go
+++ b/testutil/types.go
@@ -73,11 +73,11 @@ type TestUnion interface {
 	IsTestUnion()
 }
 
-func (String) IsTestUnion()  {}
-func (Int16) IsTestUnion()   {}
-func (Int64) IsTestUnion()   {}
-func (*Binary) IsTestUnion() {}
+func (String) IsTestUnion() {}
+func (Int16) IsTestUnion()  {}
+func (Int64) IsTestUnion()  {}
+func (Binary) IsTestUnion() {}
 
-func (String) IsUnion()  {}
-func (Int64) IsUnion()   {}
-func (*Binary) IsUnion() {}
+func (String) IsUnion() {}
+func (Int64) IsUnion()  {}
+func (Binary) IsUnion() {}

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -64,6 +64,11 @@ type Unsupported struct {
 	Value interface{}
 }
 
+// Union1 is an interface defined within *this* (testutil) package that is
+// satisfied by a subset of the above union types to aid testing within other
+// packages.
+// Enumerations defined within other test packages can still satisfy this
+// interface by defining an IsUnion1() method.
 type Union1 interface {
 	IsUnion1()
 }

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+// Binary is a type that is used for fields that have a YANG type of
+// binary. It is used such that binary fields can be distinguished from
+// leaf-lists of uint8s (which are mapped to []uint8, equivalent to
+// []byte in reflection).
+type Binary []byte
+
+// YANGEmpty is a type that is used for fields that have a YANG type of
+// empty. It is used such that empty fields can be distinguished from boolean fields
+// in the generated code.
+type YANGEmpty bool
+
+// Int8 is an int8 type assignable to unions of which it is a subtype.
+type Int8 int8
+
+// Int16 is an int16 type assignable to unions of which it is a subtype.
+type Int16 int16
+
+// Int32 is an int32 type assignable to unions of which it is a subtype.
+type Int32 int32
+
+// Int64 is an int64 type assignable to unions of which it is a subtype.
+type Int64 int64
+
+// Uint8 is a uint8 type assignable to unions of which it is a subtype.
+type Uint8 uint8
+
+// Uint16 is a uint16 type assignable to unions of which it is a subtype.
+type Uint16 uint16
+
+// Uint32 is a uint32 type assignable to unions of which it is a subtype.
+type Uint32 uint32
+
+// Uint64 is a uint64 type assignable to unions of which it is a subtype.
+type Uint64 uint64
+
+// Float64 is a float64 type assignable to unions of which it is a subtype.
+type Float64 float64
+
+// String is a string type assignable to unions of which it is a subtype.
+type String string
+
+// Bool is a bool type assignable to unions of which it is a subtype.
+type Bool bool
+
+// Unsupported is an interface{} wrapper type for unsupported types. It is
+// assignable to unions of which it is a subtype.
+type Unsupported struct {
+	Value interface{}
+}
+
+type Union1 interface {
+	IsUnion1()
+}
+
+func (String) IsUnion1()  {}
+func (Int16) IsUnion1()   {}
+func (Int64) IsUnion1()   {}
+func (*Binary) IsUnion1() {}
+
+func (String) IsUnion()  {}
+func (Int64) IsUnion()   {}
+func (*Binary) IsUnion() {}

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -64,19 +64,19 @@ type Unsupported struct {
 	Value interface{}
 }
 
-// Union1 is an interface defined within *this* (testutil) package that is
+// TestUnion is an interface defined within *this* (testutil) package that is
 // satisfied by a subset of the above union types to aid testing within other
 // packages.
 // Enumerations defined within other test packages can still satisfy this
-// interface by defining an IsUnion1() method.
-type Union1 interface {
-	IsUnion1()
+// interface by defining an IsTestUnion() method.
+type TestUnion interface {
+	IsTestUnion()
 }
 
-func (String) IsUnion1()  {}
-func (Int16) IsUnion1()   {}
-func (Int64) IsUnion1()   {}
-func (*Binary) IsUnion1() {}
+func (String) IsTestUnion()  {}
+func (Int16) IsTestUnion()   {}
+func (Int64) IsTestUnion()   {}
+func (*Binary) IsTestUnion() {}
 
 func (String) IsUnion()  {}
 func (Int64) IsUnion()   {}

--- a/testutil/types.go
+++ b/testutil/types.go
@@ -25,42 +25,42 @@ type Binary []byte
 // in the generated code.
 type YANGEmpty bool
 
-// Int8 is an int8 type assignable to unions of which it is a subtype.
-type Int8 int8
+// UnionInt8 is an int8 type assignable to unions of which it is a subtype.
+type UnionInt8 int8
 
-// Int16 is an int16 type assignable to unions of which it is a subtype.
-type Int16 int16
+// UnionInt16 is an int16 type assignable to unions of which it is a subtype.
+type UnionInt16 int16
 
-// Int32 is an int32 type assignable to unions of which it is a subtype.
-type Int32 int32
+// UnionInt32 is an int32 type assignable to unions of which it is a subtype.
+type UnionInt32 int32
 
-// Int64 is an int64 type assignable to unions of which it is a subtype.
-type Int64 int64
+// UnionInt64 is an int64 type assignable to unions of which it is a subtype.
+type UnionInt64 int64
 
-// Uint8 is a uint8 type assignable to unions of which it is a subtype.
-type Uint8 uint8
+// UnionUint8 is a uint8 type assignable to unions of which it is a subtype.
+type UnionUint8 uint8
 
-// Uint16 is a uint16 type assignable to unions of which it is a subtype.
-type Uint16 uint16
+// UnionUint16 is a uint16 type assignable to unions of which it is a subtype.
+type UnionUint16 uint16
 
-// Uint32 is a uint32 type assignable to unions of which it is a subtype.
-type Uint32 uint32
+// UnionUint32 is a uint32 type assignable to unions of which it is a subtype.
+type UnionUint32 uint32
 
-// Uint64 is a uint64 type assignable to unions of which it is a subtype.
-type Uint64 uint64
+// UnionUint64 is a uint64 type assignable to unions of which it is a subtype.
+type UnionUint64 uint64
 
-// Float64 is a float64 type assignable to unions of which it is a subtype.
-type Float64 float64
+// UnionFloat64 is a float64 type assignable to unions of which it is a subtype.
+type UnionFloat64 float64
 
-// String is a string type assignable to unions of which it is a subtype.
-type String string
+// UnionString is a string type assignable to unions of which it is a subtype.
+type UnionString string
 
-// Bool is a bool type assignable to unions of which it is a subtype.
-type Bool bool
+// UnionBool is a bool type assignable to unions of which it is a subtype.
+type UnionBool bool
 
-// Unsupported is an interface{} wrapper type for unsupported types. It is
+// UnionUnsupported is an interface{} wrapper type for unsupported types. It is
 // assignable to unions of which it is a subtype.
-type Unsupported struct {
+type UnionUnsupported struct {
 	Value interface{}
 }
 
@@ -73,11 +73,11 @@ type TestUnion interface {
 	IsTestUnion()
 }
 
-func (String) IsTestUnion() {}
-func (Int16) IsTestUnion()  {}
-func (Int64) IsTestUnion()  {}
-func (Binary) IsTestUnion() {}
+func (UnionString) IsTestUnion() {}
+func (UnionInt16) IsTestUnion()  {}
+func (UnionInt64) IsTestUnion()  {}
+func (Binary) IsTestUnion()      {}
 
-func (String) IsUnion() {}
-func (Int64) IsUnion()  {}
-func (Binary) IsUnion() {}
+func (UnionString) IsUnion() {}
+func (UnionInt64) IsUnion()  {}
+func (Binary) IsUnion()      {}

--- a/ytypes/int_type.go
+++ b/ytypes/int_type.go
@@ -38,6 +38,22 @@ var (
 		yang.Yuint32: yang.Uint32Range,
 		yang.Yuint64: yang.Uint64Range,
 	}
+
+	// typeKindFromKind maps the primitive type kinds of Go to the
+	// enumerated TypeKind used in goyang.
+	typeKindFromKind = map[reflect.Kind]yang.TypeKind{
+		reflect.Int8:    yang.Yint8,
+		reflect.Int16:   yang.Yint16,
+		reflect.Int32:   yang.Yint32,
+		reflect.Int64:   yang.Yint64,
+		reflect.Uint8:   yang.Yuint8,
+		reflect.Uint16:  yang.Yuint16,
+		reflect.Uint32:  yang.Yuint32,
+		reflect.Uint64:  yang.Yuint64,
+		reflect.Bool:    yang.Ybool,
+		reflect.Float64: yang.Ydecimal64,
+		reflect.String:  yang.Ystring,
+	}
 )
 
 // validateInt validates value, which must be a Go integer type, against the
@@ -54,7 +70,7 @@ func validateInt(schema *yang.Entry, value interface{}) error {
 	ranges := schema.Type.Range
 
 	// Check that type of value is the type expected from the schema.
-	if yang.TypeKindFromName[reflect.TypeOf(value).Name()] != kind {
+	if typeKindFromKind[reflect.TypeOf(value).Kind()] != kind {
 		return fmt.Errorf("non %v type %T with value %v for schema %s", kind, value, value, schema.Name)
 	}
 

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -62,6 +62,7 @@ func validateLeaf(inSchema *yang.Entry, value interface{}) util.Errors {
 		if ykind != yang.Ybinary {
 			return util.NewErrs(fmt.Errorf("bad leaf type: expect []byte for binary value %v for schema %s, have type %v", value, schema.Name, ykind))
 		}
+		rv = value
 	case reflect.Int64:
 		if ykind != yang.Yenum && ykind != yang.Yidentityref && ykind != yang.Yunion {
 			return util.NewErrs(fmt.Errorf("bad leaf type: expect Int64 for enum type for schema %s, have type %v", schema.Name, ykind))
@@ -71,13 +72,17 @@ func validateLeaf(inSchema *yang.Entry, value interface{}) util.Errors {
 			return util.NewErrs(fmt.Errorf("bad leaf type: expect Bool for empty type for schema %s, have type %v", schema.Name, ykind))
 		}
 		rv = value
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float64, reflect.String:
+		if ykind != yang.Yunion {
+			return util.NewErrs(fmt.Errorf("bad leaf type: expect %v for union type for schema %s, have type %v", rkind, schema.Name, ykind))
+		}
 	default:
 		return util.NewErrs(fmt.Errorf("bad leaf value type %v, expect Ptr or Int64 for schema %s", rkind, schema.Name))
 	}
 
 	switch ykind {
 	case yang.Ybinary:
-		return util.NewErrs(validateBinary(schema, value))
+		return util.NewErrs(validateBinary(schema, rv))
 	case yang.Ybits:
 		return nil
 		// TODO(mostrowski): restore when representation is decided.
@@ -217,22 +222,13 @@ func validateUnion(schema *yang.Entry, value interface{}) util.Errors {
 
 	util.DbgPrint("validateUnion %s", schema.Name)
 	v := reflect.ValueOf(value)
-	switch v.Kind() {
-	case reflect.Ptr:
-		// The union is usually a ptr - either a struct ptr or Go value ptr like *string.
-		// Enum types are also represented as a struct for union where the field
-		// has the enum type.
+	if v.Kind() == reflect.Ptr {
+		// The union could be a ptr - either a struct ptr or Go value ptr like *string.
 		v = v.Elem()
-	case reflect.Int64:
-		// A union containing a single enumerated type would simply resolve to the
-		// enum type, which represented directly by a derived Int64 type.
-	default:
-		return util.NewErrs(fmt.Errorf("wrong value type for union %s: got: %T, expect ptr or Int64 (enumerated type)", schema.Name, value))
 	}
 
-	// Unions of enum types are passed as ptr to interface to struct ptr.
-	// Normalize to a union struct.
-	// TODO(wenbli): Remove this if statement in a future PR.
+	// All wrapper unions and unsupported types for simplified unions are passed as ptr to interface to struct ptr.
+	// Normalize these to a union struct.
 	// v here is already a struct, as multi-type unions are represented as
 	// interfaces within their parents' structs, *not* ptrs to interfaces.
 	if util.IsValueInterface(v) {

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -59,7 +59,7 @@ func validateLeaf(inSchema *yang.Entry, value interface{}) util.Errors {
 	case reflect.Ptr:
 		rv = reflect.ValueOf(value).Elem().Interface()
 	case reflect.Slice:
-		if ykind != yang.Ybinary {
+		if ykind != yang.Ybinary && ykind != yang.Yunion {
 			return util.NewErrs(fmt.Errorf("bad leaf type: expect []byte for binary value %v for schema %s, have type %v", value, schema.Name, ykind))
 		}
 	case reflect.Int64:

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -483,17 +483,17 @@ func TestValidateLeafUnion(t *testing.T) {
 		{
 			desc:   "success string",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: testutil.String("aaa")},
+			val:    &UnionContainer{UnionField: testutil.UnionString("aaa")},
 		},
 		{
 			desc:   "success int16",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: testutil.Int16(42)},
+			val:    &UnionContainer{UnionField: testutil.UnionInt16(42)},
 		},
 		{
 			desc:   "success int64",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: testutil.Int64(42)},
+			val:    &UnionContainer{UnionField: testutil.UnionInt64(42)},
 		},
 		{
 			desc:   "success enum",
@@ -503,7 +503,7 @@ func TestValidateLeafUnion(t *testing.T) {
 		{
 			desc:    "bad regex",
 			schema:  unionContainerSchema,
-			val:     &UnionContainer{UnionField: testutil.String("bbb")},
+			val:     &UnionContainer{UnionField: testutil.UnionString("bbb")},
 			wantErr: true,
 		},
 		{

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -309,37 +309,37 @@ func TestValidateLeaf(t *testing.T) {
 // UnionContainer and types below are defined outside function scope because
 // type methods cannot be defined in function scope.
 type UnionContainer struct {
-	UnionField testutil.Union1 `path:"union1"`
+	UnionField testutil.TestUnion `path:"union1"`
 }
 
 func (*UnionContainer) IsYANGGoStruct() {}
 
-// IsUnion1 ensures EnumType satisfies the testutil.Union1 interface.
-func (EnumType) IsUnion1() {}
+// IsTestUnion ensures EnumType satisfies the testutil.TestUnion interface.
+func (EnumType) IsTestUnion() {}
 
 type Union1String struct {
 	String string
 }
 
-func (*Union1String) IsUnion1() {}
+func (*Union1String) IsTestUnion() {}
 
 type Union1Int16 struct {
 	Int16 int16
 }
 
-func (*Union1Int16) IsUnion1() {}
+func (*Union1Int16) IsTestUnion() {}
 
 type Union1EnumType struct {
 	EnumType EnumType
 }
 
-func (*Union1EnumType) IsUnion1() {}
+func (*Union1EnumType) IsTestUnion() {}
 
 type Union1BadLeaf struct {
 	BadLeaf *float32
 }
 
-func (*Union1BadLeaf) IsUnion1() {}
+func (*Union1BadLeaf) IsTestUnion() {}
 
 type UnionContainerCompressed struct {
 	UnionField *string `path:"union1"`

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/ygot"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -308,14 +309,13 @@ func TestValidateLeaf(t *testing.T) {
 // UnionContainer and types below are defined outside function scope because
 // type methods cannot be defined in function scope.
 type UnionContainer struct {
-	UnionField Union1 `path:"union1"`
+	UnionField testutil.Union1 `path:"union1"`
 }
 
 func (*UnionContainer) IsYANGGoStruct() {}
 
-type Union1 interface {
-	IsUnion1()
-}
+// IsUnion1 ensures EnumType satisfies the testutil.Union1 interface.
+func (EnumType) IsUnion1() {}
 
 type Union1String struct {
 	String string
@@ -378,6 +378,10 @@ func TestValidateLeafUnion(t *testing.T) {
 							Name: "enum",
 							Kind: yang.Yenum,
 						},
+						{
+							Name: "bin",
+							Kind: yang.Ybinary,
+						},
 					},
 				},
 			},
@@ -423,7 +427,7 @@ func TestValidateLeafUnion(t *testing.T) {
 							Pattern: []string{"a+"},
 						},
 						{
-							Name:    "int16",
+							Name:    "string2",
 							Kind:    yang.Ystring,
 							Pattern: []string{"b+"},
 						},
@@ -449,7 +453,7 @@ func TestValidateLeafUnion(t *testing.T) {
 							Pattern: []string{"a+"},
 						},
 						{
-							Name:    "int16",
+							Name:    "string2",
 							Kind:    yang.Ystring,
 							Pattern: []string{"b+"},
 						},
@@ -470,6 +474,8 @@ func TestValidateLeafUnion(t *testing.T) {
 		},
 	}
 
+	bin := testutil.Binary("abc")
+
 	tests := []struct {
 		desc    string
 		schema  *yang.Entry
@@ -479,52 +485,83 @@ func TestValidateLeafUnion(t *testing.T) {
 		{
 			desc:   "success string",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &Union1String{"aaa"}},
+			val:    &UnionContainer{UnionField: testutil.String("aaa")},
 		},
 		{
 			desc:   "success int16",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &Union1Int16{1}},
+			val:    &UnionContainer{UnionField: testutil.Int16(42)},
+		},
+		{
+			desc:   "success int64",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: testutil.Int64(42)},
 		},
 		{
 			desc:   "success enum",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &Union1EnumType{EnumType: 42}},
+			val:    &UnionContainer{UnionField: EnumType(42)},
 		},
 		{
 			desc:    "bad regex",
+			schema:  unionContainerSchema,
+			val:     &UnionContainer{UnionField: testutil.String("bbb")},
+			wantErr: true,
+		},
+		{
+			desc:   "success binary",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: &bin},
+		},
+		{
+			desc:   "success string (wrapper union type)",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: &Union1String{"aaa"}},
+		},
+		{
+			desc:   "success int16 (wrapper union type)",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: &Union1Int16{1}},
+		},
+		{
+			desc:   "success enum (wrapper union type)",
+			schema: unionContainerSchema,
+			val:    &UnionContainer{UnionField: &Union1EnumType{EnumType: 42}},
+		},
+		{
+			desc:    "bad regex (wrapper union type)",
 			schema:  unionContainerSchema,
 			val:     &UnionContainer{UnionField: &Union1String{"bbb"}},
 			wantErr: true,
 		},
 		{
-			desc:    "bad type",
+			desc:    "bad type (wrapper union type)",
 			schema:  unionContainerSchema,
 			val:     &UnionContainer{UnionField: &Union1BadLeaf{BadLeaf: ygot.Float32(0)}},
 			wantErr: true,
 		},
 		{
-			desc:   "success no wrapping struct enum",
+			desc:   "success single-valued union: enum",
 			schema: unionContainerSingleEnumSchema,
 			val:    &UnionContainerSingleEnum{UnionField: EnumType(42)},
 		},
 		{
-			desc:   "success no wrapping struct string",
+			desc:   "success single-valued union: string",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("aaa")},
 		},
 		{
-			desc:   "success no wrapping struct int16",
+			desc:   "success single-valued union: int16",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("bbb")},
 		},
 		{
-			desc:   "success no wrapping struct string",
+			desc:   "success single-valued union: string",
 			schema: unionContainerSchemaNoWrappingStruct,
 			val:    &UnionContainerCompressed{UnionField: ygot.String("aaa")},
 		},
 		{
-			desc:    "no wrapping struct no schemas match",
+			desc:    "single-valued union: no schemas match",
 			schema:  unionContainerSchemaNoWrappingStruct,
 			val:     &UnionContainerCompressed{UnionField: ygot.String("ccc")},
 			wantErr: true,
@@ -553,10 +590,10 @@ func TestValidateLeafUnion(t *testing.T) {
 	}
 
 	// Additional tests through private API.
-	if err := validateUnion(unionContainerSchema, nil); err != nil {
+	if err := validateUnion(unionContainerSchema.Dir["union1"], nil); err != nil {
 		t.Errorf("nil value: got error: %v, want error: nil", err)
 	}
-	if err := validateUnion(unionContainerSchema, 42); err == nil {
+	if err := validateUnion(unionContainerSchema.Dir["union1"], 42); err == nil {
 		t.Errorf("bad value type: got error: nil, want type error")
 	}
 }

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -474,8 +474,6 @@ func TestValidateLeafUnion(t *testing.T) {
 		},
 	}
 
-	bin := testutil.Binary("abc")
-
 	tests := []struct {
 		desc    string
 		schema  *yang.Entry
@@ -511,7 +509,7 @@ func TestValidateLeafUnion(t *testing.T) {
 		{
 			desc:   "success binary",
 			schema: unionContainerSchema,
-			val:    &UnionContainer{UnionField: &bin},
+			val:    &UnionContainer{UnionField: testutil.Binary("abc")},
 		},
 		{
 			desc:   "success string (wrapper union type)",

--- a/ytypes/leafref_test.go
+++ b/ytypes/leafref_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -215,16 +216,16 @@ func TestValidateLeafRefData(t *testing.T) {
 		LeafRefToList *int32 `path:"int32-ref-to-list"`
 	}
 	type Container2 struct {
-		LeafRefToInt32         *int32      `path:"int32-ref-to-leaf"`
-		LeafRefToEnum          EnumType    `path:"enum-ref-to-leaf"`
-		LeafRefToLeafList      *int32      `path:"int32-ref-to-leaf-list"`
-		LeafListRefToLeafList  []*int32    `path:"leaf-list-ref-to-leaf-list"`
-		LeafRefToList          *int32      `path:"int32-ref-to-list"`
-		LeafRefToListEnumKeyed *int32      `path:"int32-ref-to-list-enum-keyed"`
-		Key                    *int32      `path:"key"`
-		Container3             *Container3 `path:"container3"`
-		LeafListLeafRefToInt32 []*int32    `path:"leaf-list-with-leafref"`
-		LeafRefToUnion         Union1      `path:"leaf-ref-to-union"`
+		LeafRefToInt32         *int32          `path:"int32-ref-to-leaf"`
+		LeafRefToEnum          EnumType        `path:"enum-ref-to-leaf"`
+		LeafRefToLeafList      *int32          `path:"int32-ref-to-leaf-list"`
+		LeafListRefToLeafList  []*int32        `path:"leaf-list-ref-to-leaf-list"`
+		LeafRefToList          *int32          `path:"int32-ref-to-list"`
+		LeafRefToListEnumKeyed *int32          `path:"int32-ref-to-list-enum-keyed"`
+		Key                    *int32          `path:"key"`
+		Container3             *Container3     `path:"container3"`
+		LeafListLeafRefToInt32 []*int32        `path:"leaf-list-with-leafref"`
+		LeafRefToUnion         testutil.Union1 `path:"leaf-ref-to-union"`
 	}
 	type ListElement struct {
 		Key   *int32 `path:"key"`
@@ -242,7 +243,7 @@ func TestValidateLeafRefData(t *testing.T) {
 		Key           *int32                             `path:"key"`
 		Enum          EnumType                           `path:"enum"`
 		Container2    *Container2                        `path:"container2"`
-		Union         Union1                             `path:"union"`
+		Union         testutil.Union1                    `path:"union"`
 	}
 
 	tests := []struct {

--- a/ytypes/leafref_test.go
+++ b/ytypes/leafref_test.go
@@ -216,16 +216,16 @@ func TestValidateLeafRefData(t *testing.T) {
 		LeafRefToList *int32 `path:"int32-ref-to-list"`
 	}
 	type Container2 struct {
-		LeafRefToInt32         *int32          `path:"int32-ref-to-leaf"`
-		LeafRefToEnum          EnumType        `path:"enum-ref-to-leaf"`
-		LeafRefToLeafList      *int32          `path:"int32-ref-to-leaf-list"`
-		LeafListRefToLeafList  []*int32        `path:"leaf-list-ref-to-leaf-list"`
-		LeafRefToList          *int32          `path:"int32-ref-to-list"`
-		LeafRefToListEnumKeyed *int32          `path:"int32-ref-to-list-enum-keyed"`
-		Key                    *int32          `path:"key"`
-		Container3             *Container3     `path:"container3"`
-		LeafListLeafRefToInt32 []*int32        `path:"leaf-list-with-leafref"`
-		LeafRefToUnion         testutil.Union1 `path:"leaf-ref-to-union"`
+		LeafRefToInt32         *int32             `path:"int32-ref-to-leaf"`
+		LeafRefToEnum          EnumType           `path:"enum-ref-to-leaf"`
+		LeafRefToLeafList      *int32             `path:"int32-ref-to-leaf-list"`
+		LeafListRefToLeafList  []*int32           `path:"leaf-list-ref-to-leaf-list"`
+		LeafRefToList          *int32             `path:"int32-ref-to-list"`
+		LeafRefToListEnumKeyed *int32             `path:"int32-ref-to-list-enum-keyed"`
+		Key                    *int32             `path:"key"`
+		Container3             *Container3        `path:"container3"`
+		LeafListLeafRefToInt32 []*int32           `path:"leaf-list-with-leafref"`
+		LeafRefToUnion         testutil.TestUnion `path:"leaf-ref-to-union"`
 	}
 	type ListElement struct {
 		Key   *int32 `path:"key"`
@@ -243,7 +243,7 @@ func TestValidateLeafRefData(t *testing.T) {
 		Key           *int32                             `path:"key"`
 		Enum          EnumType                           `path:"enum"`
 		Container2    *Container2                        `path:"container2"`
-		Union         testutil.Union1                    `path:"union"`
+		Union         testutil.TestUnion                 `path:"union"`
 	}
 
 	tests := []struct {

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
 )
@@ -784,36 +785,36 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 }
 
 type KeyStructMapCreation struct {
-	Key1     string   `path:"key1"`
-	Key2     int32    `path:"key2"`
-	EnumKey  EnumType `path:"key3"`
-	UnionKey Union1   `path:"key4"`
+	Key1     string          `path:"key1"`
+	Key2     int32           `path:"key2"`
+	EnumKey  EnumType        `path:"key3"`
+	UnionKey testutil.Union1 `path:"key4"`
 }
 
 type ListElemStructMapCreation struct {
-	Key1     *string  `path:"key1"`
-	Key2     *int32   `path:"key2"`
-	EnumKey  EnumType `path:"key3"`
-	UnionKey Union1   `path:"key4"`
-	LeafName *int32   `path:"leaf-field"`
+	Key1     *string         `path:"key1"`
+	Key2     *int32          `path:"key2"`
+	EnumKey  EnumType        `path:"key3"`
+	UnionKey testutil.Union1 `path:"key4"`
+	LeafName *int32          `path:"leaf-field"`
 }
 
 type ListElemStructMapCreationLeafrefKeys struct {
-	Key1     *string  `path:"config/key1|key1"`
-	Key2     *int32   `path:"config/key2|key2"`
-	EnumKey  EnumType `path:"config/key3|key3"`
-	UnionKey Union1   `path:"config/key4|key4"`
-	LeafName *int32   `path:"config/leaf-field"`
+	Key1     *string         `path:"config/key1|key1"`
+	Key2     *int32          `path:"config/key2|key2"`
+	EnumKey  EnumType        `path:"config/key3|key3"`
+	UnionKey testutil.Union1 `path:"config/key4|key4"`
+	LeafName *int32          `path:"config/leaf-field"`
 }
 
-func (t *ListElemStructMapCreation) To_Union1(i interface{}) (Union1, error) {
+func (t *ListElemStructMapCreation) To_Union1(i interface{}) (testutil.Union1, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -823,14 +824,14 @@ func (*ListElemStructMapCreation) ΛEnumTypeMap() map[string][]reflect.Type {
 	}
 }
 
-func (t *ListElemStructMapCreationLeafrefKeys) To_Union1(i interface{}) (Union1, error) {
+func (t *ListElemStructMapCreationLeafrefKeys) To_Union1(i interface{}) (testutil.Union1, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -1082,17 +1083,17 @@ func (l *ListUintStruct) String() string {
 }
 
 type ListUnionStruct struct {
-	Key Union1 `path:"key"`
+	Key testutil.Union1 `path:"key"`
 }
 
-func (t *ListUnionStruct) To_Union1(i interface{}) (Union1, error) {
+func (t *ListUnionStruct) To_Union1(i interface{}) (testutil.Union1, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -1275,7 +1276,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 					},
 				},
 			},
-			container: &simpleStruct{KeyList: map[Union1]*ListUnionStruct{}},
+			container: &simpleStruct{KeyList: map[testutil.Union1]*ListUnionStruct{}},
 			want:      &Union1EnumType{EnumType(42)},
 		},
 		{
@@ -1312,7 +1313,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 					},
 				},
 			},
-			container:    &simpleStruct{KeyList: map[Union1]*ListUnionStruct{}},
+			container:    &simpleStruct{KeyList: map[testutil.Union1]*ListUnionStruct{}},
 			errSubstring: "could not find suitable union type",
 		},
 		{
@@ -1530,13 +1531,13 @@ func TestInsertAndGetKey(t *testing.T) {
 }
 
 type unionKeyTestStruct struct {
-	UnionKey map[Union1]*unionKeyTestStructChild `path:"union-key"`
+	UnionKey map[testutil.Union1]*unionKeyTestStructChild `path:"union-key"`
 }
 
 func (*unionKeyTestStruct) IsYANGGoStruct() {}
 
 type unionKeyTestStructChild struct {
-	Key Union1 `path:"key"`
+	Key testutil.Union1 `path:"key"`
 }
 
 func (*unionKeyTestStructChild) IsYANGGoStruct() {}
@@ -1547,7 +1548,7 @@ func (*unionKeyTestStructChild) ΛEnumTypeMap() map[string][]reflect.Type {
 	}
 }
 
-func (*unionKeyTestStructChild) To_Union1(i interface{}) (Union1, error) {
+func (*unionKeyTestStructChild) To_Union1(i interface{}) (testutil.Union1, error) {
 	switch v := i.(type) {
 	case string:
 		return &Union1String{v}, nil
@@ -1556,7 +1557,7 @@ func (*unionKeyTestStructChild) To_Union1(i interface{}) (Union1, error) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to Union1, unknown union type, got: %T, want any of [string, int16, enum]", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T, want any of [string, int16, enum]", i, i)
 	}
 }
 

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -785,36 +785,36 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 }
 
 type KeyStructMapCreation struct {
-	Key1     string          `path:"key1"`
-	Key2     int32           `path:"key2"`
-	EnumKey  EnumType        `path:"key3"`
-	UnionKey testutil.Union1 `path:"key4"`
+	Key1     string             `path:"key1"`
+	Key2     int32              `path:"key2"`
+	EnumKey  EnumType           `path:"key3"`
+	UnionKey testutil.TestUnion `path:"key4"`
 }
 
 type ListElemStructMapCreation struct {
-	Key1     *string         `path:"key1"`
-	Key2     *int32          `path:"key2"`
-	EnumKey  EnumType        `path:"key3"`
-	UnionKey testutil.Union1 `path:"key4"`
-	LeafName *int32          `path:"leaf-field"`
+	Key1     *string            `path:"key1"`
+	Key2     *int32             `path:"key2"`
+	EnumKey  EnumType           `path:"key3"`
+	UnionKey testutil.TestUnion `path:"key4"`
+	LeafName *int32             `path:"leaf-field"`
 }
 
 type ListElemStructMapCreationLeafrefKeys struct {
-	Key1     *string         `path:"config/key1|key1"`
-	Key2     *int32          `path:"config/key2|key2"`
-	EnumKey  EnumType        `path:"config/key3|key3"`
-	UnionKey testutil.Union1 `path:"config/key4|key4"`
-	LeafName *int32          `path:"config/leaf-field"`
+	Key1     *string            `path:"config/key1|key1"`
+	Key2     *int32             `path:"config/key2|key2"`
+	EnumKey  EnumType           `path:"config/key3|key3"`
+	UnionKey testutil.TestUnion `path:"config/key4|key4"`
+	LeafName *int32             `path:"config/leaf-field"`
 }
 
-func (t *ListElemStructMapCreation) To_Union1(i interface{}) (testutil.Union1, error) {
+func (t *ListElemStructMapCreation) To_TestUnion(i interface{}) (testutil.TestUnion, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.TestUnion, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -824,14 +824,14 @@ func (*ListElemStructMapCreation) ΛEnumTypeMap() map[string][]reflect.Type {
 	}
 }
 
-func (t *ListElemStructMapCreationLeafrefKeys) To_Union1(i interface{}) (testutil.Union1, error) {
+func (t *ListElemStructMapCreationLeafrefKeys) To_TestUnion(i interface{}) (testutil.TestUnion, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.TestUnion, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -1083,17 +1083,17 @@ func (l *ListUintStruct) String() string {
 }
 
 type ListUnionStruct struct {
-	Key testutil.Union1 `path:"key"`
+	Key testutil.TestUnion `path:"key"`
 }
 
-func (t *ListUnionStruct) To_Union1(i interface{}) (testutil.Union1, error) {
+func (t *ListUnionStruct) To_TestUnion(i interface{}) (testutil.TestUnion, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	case int16:
 		return &Union1Int16{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.TestUnion, unknown union type, got: %T", i, i)
 	}
 }
 
@@ -1276,7 +1276,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 					},
 				},
 			},
-			container: &simpleStruct{KeyList: map[testutil.Union1]*ListUnionStruct{}},
+			container: &simpleStruct{KeyList: map[testutil.TestUnion]*ListUnionStruct{}},
 			want:      &Union1EnumType{EnumType(42)},
 		},
 		{
@@ -1313,7 +1313,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 					},
 				},
 			},
-			container:    &simpleStruct{KeyList: map[testutil.Union1]*ListUnionStruct{}},
+			container:    &simpleStruct{KeyList: map[testutil.TestUnion]*ListUnionStruct{}},
 			errSubstring: "could not find suitable union type",
 		},
 		{
@@ -1531,13 +1531,13 @@ func TestInsertAndGetKey(t *testing.T) {
 }
 
 type unionKeyTestStruct struct {
-	UnionKey map[testutil.Union1]*unionKeyTestStructChild `path:"union-key"`
+	UnionKey map[testutil.TestUnion]*unionKeyTestStructChild `path:"union-key"`
 }
 
 func (*unionKeyTestStruct) IsYANGGoStruct() {}
 
 type unionKeyTestStructChild struct {
-	Key testutil.Union1 `path:"key"`
+	Key testutil.TestUnion `path:"key"`
 }
 
 func (*unionKeyTestStructChild) IsYANGGoStruct() {}
@@ -1548,7 +1548,7 @@ func (*unionKeyTestStructChild) ΛEnumTypeMap() map[string][]reflect.Type {
 	}
 }
 
-func (*unionKeyTestStructChild) To_Union1(i interface{}) (testutil.Union1, error) {
+func (*unionKeyTestStructChild) To_TestUnion(i interface{}) (testutil.TestUnion, error) {
 	switch v := i.(type) {
 	case string:
 		return &Union1String{v}, nil
@@ -1557,7 +1557,7 @@ func (*unionKeyTestStructChild) To_Union1(i interface{}) (testutil.Union1, error
 	case EnumType:
 		return &Union1EnumType{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T, want any of [string, int16, enum]", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.TestUnion, unknown union type, got: %T, want any of [string, int16, enum]", i, i)
 	}
 }
 

--- a/ytypes/string_type.go
+++ b/ytypes/string_type.go
@@ -17,6 +17,7 @@ package ytypes
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"regexp"
 	"unicode/utf8"
 
@@ -33,11 +34,16 @@ func validateString(schema *yang.Entry, value interface{}) error {
 		return err
 	}
 
+	vv := reflect.ValueOf(value)
+
 	// Check that type of value is the type expected from the schema.
-	stringVal, ok := value.(string)
-	if !ok {
+	if vv.Kind() != reflect.String {
 		return fmt.Errorf("non string type %T with value %v for schema %s", value, value, schema.Name)
 	}
+
+	// This value could be a union typedef string, so convert it to make
+	// sure it's the primitive string type.
+	stringVal := vv.Convert(reflect.TypeOf("")).Interface().(string)
 
 	// Check that the length is within the allowed range.
 	allowedRanges := schema.Type.Length

--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -243,27 +243,27 @@ func TestStringToType(t *testing.T) {
 }
 
 type allKeysListStruct struct {
-	StringKey           *string         `path:"stringKey"`
-	Int8Key             *int8           `path:"int8Key"`
-	Int16Key            *int16          `path:"int16Key"`
-	Int32Key            *int32          `path:"int32Key"`
-	Int64Key            *int64          `path:"int64Key"`
-	Uint8Key            *uint8          `path:"uint8Key"`
-	Uint16Key           *uint16         `path:"uint16Key"`
-	Uint32Key           *uint32         `path:"uint32Key"`
-	Uint64Key           *uint64         `path:"uint64Key"`
-	Decimal64Key        *float64        `path:"decimal64Key"`
-	BoolKey             *bool           `path:"boolKey"`
-	BinaryKey           Binary          `path:"binaryKey"`
-	EnumKey             EnumType        `path:"enumKey"`
-	LeafrefKey          *uint64         `path:"leafrefKey"`
-	LeafrefToLeafrefKey *uint64         `path:"leafrefToLeafrefKey"`
-	LeafrefToUnionKey   testutil.Union1 `path:"leafrefToUnionKey"`
-	UnionKey            testutil.Union1 `path:"unionKey"`
-	UnionLoneTypeKey    *uint32         `path:"unionLoneTypeKey"`
+	StringKey           *string            `path:"stringKey"`
+	Int8Key             *int8              `path:"int8Key"`
+	Int16Key            *int16             `path:"int16Key"`
+	Int32Key            *int32             `path:"int32Key"`
+	Int64Key            *int64             `path:"int64Key"`
+	Uint8Key            *uint8             `path:"uint8Key"`
+	Uint16Key           *uint16            `path:"uint16Key"`
+	Uint32Key           *uint32            `path:"uint32Key"`
+	Uint64Key           *uint64            `path:"uint64Key"`
+	Decimal64Key        *float64           `path:"decimal64Key"`
+	BoolKey             *bool              `path:"boolKey"`
+	BinaryKey           Binary             `path:"binaryKey"`
+	EnumKey             EnumType           `path:"enumKey"`
+	LeafrefKey          *uint64            `path:"leafrefKey"`
+	LeafrefToLeafrefKey *uint64            `path:"leafrefToLeafrefKey"`
+	LeafrefToUnionKey   testutil.TestUnion `path:"leafrefToUnionKey"`
+	UnionKey            testutil.TestUnion `path:"unionKey"`
+	UnionLoneTypeKey    *uint32            `path:"unionLoneTypeKey"`
 }
 
-func (t *allKeysListStruct) To_Union1(i interface{}) (testutil.Union1, error) {
+func (t *allKeysListStruct) To_TestUnion(i interface{}) (testutil.TestUnion, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
@@ -272,7 +272,7 @@ func (t *allKeysListStruct) To_Union1(i interface{}) (testutil.Union1, error) {
 	case string:
 		return &Union1String{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.TestUnion, unknown union type, got: %T", i, i)
 	}
 }
 

--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/ygot"
 )
 
@@ -242,27 +243,27 @@ func TestStringToType(t *testing.T) {
 }
 
 type allKeysListStruct struct {
-	StringKey           *string  `path:"stringKey"`
-	Int8Key             *int8    `path:"int8Key"`
-	Int16Key            *int16   `path:"int16Key"`
-	Int32Key            *int32   `path:"int32Key"`
-	Int64Key            *int64   `path:"int64Key"`
-	Uint8Key            *uint8   `path:"uint8Key"`
-	Uint16Key           *uint16  `path:"uint16Key"`
-	Uint32Key           *uint32  `path:"uint32Key"`
-	Uint64Key           *uint64  `path:"uint64Key"`
-	Decimal64Key        *float64 `path:"decimal64Key"`
-	BoolKey             *bool    `path:"boolKey"`
-	BinaryKey           Binary   `path:"binaryKey"`
-	EnumKey             EnumType `path:"enumKey"`
-	LeafrefKey          *uint64  `path:"leafrefKey"`
-	LeafrefToLeafrefKey *uint64  `path:"leafrefToLeafrefKey"`
-	LeafrefToUnionKey   Union1   `path:"leafrefToUnionKey"`
-	UnionKey            Union1   `path:"unionKey"`
-	UnionLoneTypeKey    *uint32  `path:"unionLoneTypeKey"`
+	StringKey           *string         `path:"stringKey"`
+	Int8Key             *int8           `path:"int8Key"`
+	Int16Key            *int16          `path:"int16Key"`
+	Int32Key            *int32          `path:"int32Key"`
+	Int64Key            *int64          `path:"int64Key"`
+	Uint8Key            *uint8          `path:"uint8Key"`
+	Uint16Key           *uint16         `path:"uint16Key"`
+	Uint32Key           *uint32         `path:"uint32Key"`
+	Uint64Key           *uint64         `path:"uint64Key"`
+	Decimal64Key        *float64        `path:"decimal64Key"`
+	BoolKey             *bool           `path:"boolKey"`
+	BinaryKey           Binary          `path:"binaryKey"`
+	EnumKey             EnumType        `path:"enumKey"`
+	LeafrefKey          *uint64         `path:"leafrefKey"`
+	LeafrefToLeafrefKey *uint64         `path:"leafrefToLeafrefKey"`
+	LeafrefToUnionKey   testutil.Union1 `path:"leafrefToUnionKey"`
+	UnionKey            testutil.Union1 `path:"unionKey"`
+	UnionLoneTypeKey    *uint32         `path:"unionLoneTypeKey"`
 }
 
-func (t *allKeysListStruct) To_Union1(i interface{}) (Union1, error) {
+func (t *allKeysListStruct) To_Union1(i interface{}) (testutil.Union1, error) {
 	switch v := i.(type) {
 	case EnumType:
 		return &Union1EnumType{v}, nil
@@ -271,7 +272,7 @@ func (t *allKeysListStruct) To_Union1(i interface{}) (Union1, error) {
 	case string:
 		return &Union1String{v}, nil
 	default:
-		return nil, fmt.Errorf("cannot convert %v to Union1, unknown union type, got: %T", i, i)
+		return nil, fmt.Errorf("cannot convert %v to testutil.Union1, unknown union type, got: %T", i, i)
 	}
 }
 


### PR DESCRIPTION
Added testutil/types.go for unit-testing new Go union concrete types. These are the same as what would be generated by ygen in a new flag for generating these simpler unions.

Validate functionality is modified to be able to validate either a code on the old union API or the new union API. I use the adjective "simple" to describe the new unions in tests, and added `(wrapper union)` to the descriptors of the tests for the old union types. This helps remove this functionality when we elevate the flag to be the normal behaviour.

This is the first of a series of PRs that add support and unit testing to the ytypes/ygot packages. The new code generation will be added last, after the support code (ytypes/ygot) is ready.