### PR TITLE
Update to goyang 0.2.0 and change type of Min/Max Elements

### DIFF
--- a/experimental/ygotutils/getnode_test.go
+++ b/experimental/ygotutils/getnode_test.go
@@ -89,7 +89,7 @@ func TestGetNodeSimpleKeyedList(t *testing.T) {
 					"simple-key-list": &yang.Entry{
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 						Key:      "key1",
 						Config:   yang.TSTrue,
 						Dir: map[string]*yang.Entry{
@@ -341,7 +341,7 @@ func TestGetNodeStructKeyedList(t *testing.T) {
 			"struct-key-list": &yang.Entry{
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2 key3",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.4.1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be
-	github.com/openconfig/goyang v0.0.0-20200803193518-78bac27bdff1
+	github.com/openconfig/goyang v0.2.0
 	github.com/pmezard/go-difflib v1.0.0
 	golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 // indirect
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapN
 github.com/openconfig/goyang v0.0.0-20200115183954-d0a48929f0ea/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/goyang v0.0.0-20200803193518-78bac27bdff1 h1:qWqJWq75QvJcn/RJJraNgBOzgzqL7FXgeqChxOBH6MU=
 github.com/openconfig/goyang v0.0.0-20200803193518-78bac27bdff1/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
+github.com/openconfig/goyang v0.2.0 h1:Fm4tFfELrS0aiqJFVlG3+Mly40+6qoknqQoLBwONeu8=
+github.com/openconfig/goyang v0.2.0/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3 h1:YtFkrqsMEj7YqpIhRteVxJxCeC3jJBieuLr0d4C4rSA=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/util/debug_test.go
+++ b/util/debug_test.go
@@ -142,7 +142,7 @@ func TestSchemaTypeStr(t *testing.T) {
 			schema: &yang.Entry{
 				Kind:     yang.DirectoryEntry,
 				Dir:      map[string]*yang.Entry{},
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 			},
 			want: "list",
 		},
@@ -155,14 +155,14 @@ func TestSchemaTypeStr(t *testing.T) {
 		{
 			schema: &yang.Entry{
 				Kind:     yang.LeafEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 			},
 			want: "leaf-list",
 		},
 		{
 			schema: &yang.Entry{
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 			},
 			want: "other",
 		},
@@ -210,7 +210,7 @@ func TestYangTypeToDebugString(t *testing.T) {
 func TestSchemaTreeString(t *testing.T) {
 	schema := &yang.Entry{
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Key:      "key_field_name",
 		Config:   yang.TSTrue,
 		Dir: map[string]*yang.Entry{
@@ -238,7 +238,7 @@ func TestDataSchemaTreesString(t *testing.T) {
 			"key-list": {
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -1504,7 +1504,7 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 						Key:      "key1",
 						Config:   yang.TSTrue,
 						Dir: map[string]*yang.Entry{
@@ -1595,7 +1595,7 @@ func TestGetNodesSimpleKeyedList(t *testing.T) {
 			"simple-key-list": {
 				Name:     "simple-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "enum-key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1930,7 +1930,7 @@ func TestGetNodesStructKeyedList(t *testing.T) {
 			"struct-key-list": {
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{

--- a/util/yang_test.go
+++ b/util/yang_test.go
@@ -961,7 +961,7 @@ func TestIsOrNotKeyedList(t *testing.T) {
 			desc: "keyed list",
 			schema: &yang.Entry{
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Dir:      map[string]*yang.Entry{},
 			},
@@ -972,7 +972,7 @@ func TestIsOrNotKeyedList(t *testing.T) {
 			desc: "unkeyed list",
 			schema: &yang.Entry{
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Dir:      map[string]*yang.Entry{},
 			},
 			wantKeyedList:   false,
@@ -1727,12 +1727,12 @@ func TestValidateLeafRefData(t *testing.T) {
 				Name:     "leaf-list",
 				Kind:     yang.LeafEntry,
 				Type:     &yang.YangType{Kind: yang.Yint32},
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 			},
 			"list": {
 				Name:     "list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Dir: map[string]*yang.Entry{
 					"key": {
@@ -1813,7 +1813,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "../../int32",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"absolute-to-int32": {
 						Name: "absolute-to-int32",
@@ -1822,7 +1822,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "/int32",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"recursive": {
 						Name: "recursive",
@@ -1831,7 +1831,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "../leaf-list-with-leafref",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"bad-path": {
 						Name: "bad-path",
@@ -1840,7 +1840,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "../../missing",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"missing-path": {
 						Name: "missing-path",
@@ -1848,7 +1848,7 @@ func TestValidateLeafRefData(t *testing.T) {
 						Type: &yang.YangType{
 							Kind: yang.Yleafref,
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 				},
 			},

--- a/ytypes/common_test.go
+++ b/ytypes/common_test.go
@@ -103,43 +103,43 @@ func TestValidateListAttr(t *testing.T) {
 		Name:     "min1",
 		Kind:     yang.LeafEntry,
 		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "1"}},
+		ListAttr: &yang.ListAttr{MinElements: 1},
 	}
 	validLeafListSchemaMax3 := &yang.Entry{
 		Name:     "max3",
 		Kind:     yang.LeafEntry,
 		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MaxElements: &yang.Value{Name: "3"}},
+		ListAttr: &yang.ListAttr{MaxElements: 3},
 	}
 	validLeafListSchemaMin1Max3 := &yang.Entry{
 		Name:     "min1max3",
 		Kind:     yang.LeafEntry,
 		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "1"}, MaxElements: &yang.Value{Name: "3"}},
+		ListAttr: &yang.ListAttr{MinElements: 1, MaxElements: 3},
 	}
 	invalidLeafListSchemaNoAttr := &yang.Entry{
 		Name: "no_attr",
 		Kind: yang.LeafEntry,
 		Type: &yang.YangType{Kind: yang.Ystring},
 	}
-	invalidLeafListSchemaBadRange := &yang.Entry{
-		Name:     "bad_range",
-		Kind:     yang.LeafEntry,
-		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "bad"}},
-	}
-	invalidLeafListSchemaNegativeMinRange := &yang.Entry{
-		Name:     "negative_min_range",
-		Kind:     yang.LeafEntry,
-		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "-1"}},
-	}
-	invalidLeafListSchemaNegativeMaxRange := &yang.Entry{
-		Name:     "negative_min_range",
-		Kind:     yang.LeafEntry,
-		Type:     &yang.YangType{Kind: yang.Ystring},
-		ListAttr: &yang.ListAttr{MaxElements: &yang.Value{Name: "-1"}},
-	}
+	// invalidLeafListSchemaBadRange := &yang.Entry{
+	// 	Name:     "bad_range",
+	// 	Kind:     yang.LeafEntry,
+	// 	Type:     &yang.YangType{Kind: yang.Ystring},
+	// 	ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "bad"}},
+	// }
+	// invalidLeafListSchemaNegativeMinRange := &yang.Entry{
+	// 	Name:     "negative_min_range",
+	// 	Kind:     yang.LeafEntry,
+	// 	Type:     &yang.YangType{Kind: yang.Ystring},
+	// 	ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "-1"}},
+	// }
+	// invalidLeafListSchemaNegativeMaxRange := &yang.Entry{
+	// 	Name:     "negative_min_range",
+	// 	Kind:     yang.LeafEntry,
+	// 	Type:     &yang.YangType{Kind: yang.Ystring},
+	// 	ListAttr: &yang.ListAttr{MaxElements: &yang.Value{Name: "-1"}},
+	// }
 
 	tests := []struct {
 		desc    string
@@ -157,21 +157,21 @@ func TestValidateListAttr(t *testing.T) {
 			schema:  invalidLeafListSchemaNoAttr,
 			wantErr: true,
 		},
-		{
-			desc:    "bad range value",
-			schema:  invalidLeafListSchemaBadRange,
-			wantErr: true,
-		},
-		{
-			desc:    "negative min range value",
-			schema:  invalidLeafListSchemaNegativeMinRange,
-			wantErr: true,
-		},
-		{
-			desc:    "negative max range value",
-			schema:  invalidLeafListSchemaNegativeMaxRange,
-			wantErr: true,
-		},
+		// {
+		// 	desc:    "bad range value",
+		// 	schema:  invalidLeafListSchemaBadRange,
+		// 	wantErr: true,
+		// },
+		// {
+		// 	desc:    "negative min range value",
+		// 	schema:  invalidLeafListSchemaNegativeMinRange,
+		// 	wantErr: true,
+		// },
+		// {
+		// 	desc:    "negative max range value",
+		// 	schema:  invalidLeafListSchemaNegativeMaxRange,
+		// 	wantErr: true,
+		// },
 		{
 			desc:    "bad value type",
 			schema:  validLeafListSchemaMin1,
@@ -296,7 +296,7 @@ func TestForEachSchemaNode(t *testing.T) {
 			"list1": {
 				Kind:     yang.DirectoryEntry,
 				Name:     "list1",
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Dir: map[string]*yang.Entry{
 					"string": {
 						Kind: yang.LeafEntry,

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -33,7 +33,7 @@ var validLeafListSchema = &yang.Entry{
 	Name:     "valid-leaf-list-schema",
 	Kind:     yang.LeafEntry,
 	Type:     &yang.YangType{Kind: yang.Ystring},
-	ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+	ListAttr: &yang.ListAttr{MinElements: 0},
 }
 
 func TestValidateLeafListSchema(t *testing.T) {
@@ -82,7 +82,7 @@ func TestValidateLeafListSchema(t *testing.T) {
 func TestValidateLeafList(t *testing.T) {
 	leafListSchema := &yang.Entry{
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type:     &yang.YangType{Kind: yang.Ystring},
 		Name:     "leaf-list-schema",
 	}
@@ -210,7 +210,7 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		Parent:   containerSchema,
 		Name:     "int32-leaf-list",
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type:     &yang.YangType{Kind: yang.Yint32},
 	}
 
@@ -218,7 +218,7 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		Parent:   containerSchema,
 		Name:     "enum-leaf-list",
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type:     &yang.YangType{Kind: yang.Yenum},
 	}
 
@@ -226,7 +226,7 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		Parent:   containerSchema,
 		Name:     "union-leaflist",
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type: &yang.YangType{
 			Kind: yang.Yunion,
 			Type: []*yang.YangType{
@@ -249,7 +249,7 @@ func TestUnmarshalLeafListGNMIEncoding(t *testing.T) {
 		Parent:   containerSchema,
 		Name:     "union-leaflist-simple",
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type: &yang.YangType{
 			Kind: yang.Yunion,
 			Type: []*yang.YangType{
@@ -458,13 +458,13 @@ func TestUnmarshalLeafListJSONEncoding(t *testing.T) {
 			"int32-leaf-list": {
 				Name:     "int32-leaf-list",
 				Kind:     yang.LeafEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Type:     &yang.YangType{Kind: yang.Yint32},
 			},
 			"enum-leaf-list": {
 				Name:     "enum-leaf-list",
 				Kind:     yang.LeafEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Type:     &yang.YangType{Kind: yang.Yenum},
 			},
 		},

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1507,7 +1507,7 @@ func TestUnmarshalLeafJSONEncoding(t *testing.T) {
 		Name:     "int8-leaflist",
 		Kind:     yang.LeafEntry,
 		Type:     &yang.YangType{Kind: yang.Yint8},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 	}
 
 	unionSingleEnumSchema := &yang.Entry{
@@ -1841,7 +1841,7 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 		Name:     "int8-leaflist",
 		Kind:     yang.LeafEntry,
 		Type:     &yang.YangType{Kind: yang.Yint8},
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 	}
 
 	tests := []struct {

--- a/ytypes/leafref_test.go
+++ b/ytypes/leafref_test.go
@@ -42,12 +42,12 @@ func TestValidateLeafRefData(t *testing.T) {
 				Name:     "leaf-list",
 				Kind:     yang.LeafEntry,
 				Type:     &yang.YangType{Kind: yang.Yint32},
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 			},
 			"list": {
 				Name:     "list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Dir: map[string]*yang.Entry{
 					"key": {
@@ -65,7 +65,7 @@ func TestValidateLeafRefData(t *testing.T) {
 			"list-enum-keyed": {
 				Name:     "list-enum-keyed",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Dir: map[string]*yang.Entry{
 					"key": {
@@ -154,7 +154,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "../../../leaf-list",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"int32-ref-to-list": {
 						Name: "int32-ref-to-list",
@@ -198,7 +198,7 @@ func TestValidateLeafRefData(t *testing.T) {
 							Kind: yang.Yleafref,
 							Path: "../../int32",
 						},
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 					},
 					"leaf-ref-to-union": {
 						Name: "leaf-ref-to-union",

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -31,7 +31,7 @@ import (
 var validListSchema = &yang.Entry{
 	Name:     "valid-list-schema",
 	Kind:     yang.DirectoryEntry,
-	ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+	ListAttr: &yang.ListAttr{MinElements: 0},
 	Key:      "key_field_name",
 	Config:   yang.TSTrue,
 	Dir: map[string]*yang.Entry{
@@ -78,7 +78,7 @@ func TestValidateListSchema(t *testing.T) {
 			schema: &yang.Entry{
 				Name:     "missing-key-field-schema",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
 					"key_field_name": {
@@ -95,7 +95,7 @@ func TestValidateListSchema(t *testing.T) {
 			schema: &yang.Entry{
 				Name:     "missing-key-leaf-schema",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key_field_name",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -146,7 +146,7 @@ func TestValidateListNoKey(t *testing.T) {
 	listSchema := &yang.Entry{
 		Name:     "list-schema",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Dir: map[string]*yang.Entry{
 			"leaf-name": {
 				Kind: yang.LeafEntry,
@@ -219,7 +219,7 @@ func TestValidateListSimpleKey(t *testing.T) {
 	listSchema := &yang.Entry{
 		Name:     "list-schema",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Key:      "keyfield-name",
 		Config:   yang.TSTrue,
 		Dir: map[string]*yang.Entry{
@@ -294,7 +294,7 @@ func TestValidateListStructKey(t *testing.T) {
 	listSchemaStructKey := &yang.Entry{
 		Name:     "list-schema-struct-key",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Key:      "Key1 Key2",
 		Config:   yang.TSTrue,
 		Dir: map[string]*yang.Entry{
@@ -428,7 +428,7 @@ func TestUnmarshalUnkeyedList(t *testing.T) {
 			"struct-list": {
 				Name:     "struct-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Dir: map[string]*yang.Entry{
 					"leaf-field": {
 						Kind: yang.LeafEntry,
@@ -528,7 +528,7 @@ func TestUnmarshalKeyedList(t *testing.T) {
 			"key-list": {
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -625,7 +625,7 @@ func TestUnmarshalStructKeyedList(t *testing.T) {
 			"struct-key-list": {
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2 key3",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -719,7 +719,7 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 	listSchema := &yang.Entry{
 		Name:     "struct-list",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Dir: map[string]*yang.Entry{
 			"leaf-field": {
 				Kind: yang.LeafEntry,
@@ -886,7 +886,7 @@ func TestStructMapKeyValueCreation(t *testing.T) {
 			"struct-key-list": {
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2 key3 key4",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -957,7 +957,7 @@ func TestStructMapKeyValueCreation(t *testing.T) {
 			"struct-key-list-leafref-keys": {
 				Name:     "struct-key-list-leafref-keys",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2 key3 key4",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1243,7 +1243,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1263,7 +1263,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1283,7 +1283,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1303,7 +1303,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1323,7 +1323,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1348,7 +1348,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1373,7 +1373,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1421,7 +1421,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1466,7 +1466,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1511,7 +1511,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1556,7 +1556,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1593,7 +1593,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1640,7 +1640,7 @@ func TestSimpleMapKeyValueCreation(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "missing-key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1705,7 +1705,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1725,7 +1725,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Config:   yang.TSTrue,
 				Dir:      map[string]*yang.Entry{},
 			},
@@ -1736,7 +1736,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1755,7 +1755,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "missing-key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1774,7 +1774,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{
@@ -1794,7 +1794,7 @@ func TestInsertAndGetKey(t *testing.T) {
 			inSchema: &yang.Entry{
 				Name:     "struct-key-list",
 				Kind:     yang.DirectoryEntry,
-				ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+				ListAttr: &yang.ListAttr{MinElements: 0},
 				Key:      "key1 key2 key3",
 				Config:   yang.TSTrue,
 				Dir: map[string]*yang.Entry{

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -142,7 +142,7 @@ var containerWithStringKey = &yang.Entry{
 				"simple-key-list": {
 					Name:     "simple-key-list",
 					Kind:     yang.DirectoryEntry,
-					ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+					ListAttr: &yang.ListAttr{MinElements: 0},
 					Key:      "key1",
 					Config:   yang.TSTrue,
 					Dir: map[string]*yang.Entry{
@@ -171,7 +171,7 @@ var containerWithStringKey = &yang.Entry{
 												"int32-leaf-list": {
 													Name:     "int32-leaf-list",
 													Kind:     yang.LeafEntry,
-													ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+													ListAttr: &yang.ListAttr{MinElements: 0},
 													Type:     &yang.YangType{Kind: yang.Yint32},
 												},
 												"string-leaf-field": {
@@ -209,7 +209,7 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 						Key:      "key1",
 						Config:   yang.TSTrue,
 						Dir: map[string]*yang.Entry{
@@ -269,7 +269,7 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 						Key:      "key1",
 						Config:   yang.TSTrue,
 						Dir: map[string]*yang.Entry{
@@ -296,7 +296,7 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					"simple-key-list": {
 						Name:     "simple-key-list",
 						Kind:     yang.DirectoryEntry,
-						ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+						ListAttr: &yang.ListAttr{MinElements: 0},
 						Key:      "key1",
 						Config:   yang.TSTrue,
 						Dir: map[string]*yang.Entry{
@@ -544,7 +544,7 @@ var containerWithMultiKeyedList *yang.Entry = &yang.Entry{
 		"struct-key-list": {
 			Name:     "struct-key-list",
 			Kind:     yang.DirectoryEntry,
-			ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+			ListAttr: &yang.ListAttr{MinElements: 0},
 			Key:      "key1 key2 key3",
 			Config:   yang.TSTrue,
 			Dir: map[string]*yang.Entry{
@@ -583,7 +583,7 @@ var containerWithMultiKeyedList *yang.Entry = &yang.Entry{
 										"int32-leaf-list": {
 											Name:     "int32-leaf-list",
 											Kind:     yang.LeafEntry,
-											ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+											ListAttr: &yang.ListAttr{MinElements: 0},
 											Type:     &yang.YangType{Kind: yang.Yint32},
 										},
 										"string-leaf-field": {
@@ -716,7 +716,7 @@ var simpleSchema = &yang.Entry{
 								"int32-leaf-list": {
 									Name:     "int32-leaf-list",
 									Kind:     yang.LeafEntry,
-									ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+									ListAttr: &yang.ListAttr{MinElements: 0},
 									Type:     &yang.YangType{Kind: yang.Yint32},
 								},
 								"string-leaf-field": {
@@ -932,7 +932,7 @@ func TestGetNode(t *testing.T) {
 	leafListSchema := &yang.Entry{
 		Name:     "int32-leaf-list",
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type:     &yang.YangType{Kind: yang.Yint32},
 	}
 	rootSchema.Dir["int32-leaf-list"] = leafListSchema

--- a/ytypes/util_schema.go
+++ b/ytypes/util_schema.go
@@ -103,27 +103,18 @@ func validateListAttr(schema *yang.Entry, value interface{}) util.Errors {
 	// If min/max element attr is present in the schema, this must be a list or
 	// leaf-list. Check that the data tree falls within the required size
 	// bounds.
-	if v := schema.ListAttr.MinElements; v != nil {
-		if minN, err := yang.ParseInt(v.Name); err != nil {
-			errors = util.AppendErr(errors, err)
-		} else if min, err := minN.Int(); err != nil {
-			errors = util.AppendErr(errors, err)
-		} else if min < 0 {
-			errors = util.AppendErr(errors, fmt.Errorf("list %s has negative min required elements", schema.Name))
-		} else if int64(size) < min {
-			errors = util.AppendErr(errors, fmt.Errorf("list %s contains fewer than min required elements: %d < %d", schema.Name, size, min))
-		}
+	min := schema.ListAttr.MinElements
+	if min < 0 {
+		errors = util.AppendErr(errors, fmt.Errorf("list %s has negative min required elements", schema.Name))
+	} else if uint64(size) < min {
+		errors = util.AppendErr(errors, fmt.Errorf("list %s contains fewer than min required elements: %d < %d", schema.Name, size, min))
 	}
-	if v := schema.ListAttr.MaxElements; v != nil {
-		if maxN, err := yang.ParseInt(v.Name); err != nil {
-			errors = util.AppendErr(errors, err)
-		} else if max, err := maxN.Int(); err != nil {
-			errors = util.AppendErr(errors, err)
-		} else if max < 0 {
-			errors = util.AppendErr(errors, fmt.Errorf("list %s has negative max required elements", schema.Name))
-		} else if int64(size) > max {
-			errors = util.AppendErr(errors, fmt.Errorf("list %s contains more than max allowed elements: %d > %d", schema.Name, size, max))
-		}
+
+	max := schema.ListAttr.MaxElements
+	if max < 0 {
+		errors = util.AppendErr(errors, fmt.Errorf("list %s has negative max required elements", schema.Name))
+	} else if uint64(size) > max {
+		errors = util.AppendErr(errors, fmt.Errorf("list %s contains more than max allowed elements: %d > %d", schema.Name, size, max))
 	}
 
 	return errors

--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -304,7 +304,7 @@ func TestStringToKeyType(t *testing.T) {
 	listSchema := &yang.Entry{
 		Name:     "struct-key-list",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Key:      "every key, but irrelevant in this test",
 		Config:   yang.TSTrue,
 		Dir: map[string]*yang.Entry{

--- a/ytypes/validate_test.go
+++ b/ytypes/validate_test.go
@@ -83,7 +83,7 @@ func TestValidate(t *testing.T) {
 
 	leafListSchema := &yang.Entry{
 		Kind:     yang.LeafEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Type:     &yang.YangType{Kind: yang.Ystring},
 		Name:     "leaf-list-schema",
 	}
@@ -91,7 +91,7 @@ func TestValidate(t *testing.T) {
 	listSchema := &yang.Entry{
 		Name:     "list-schema",
 		Kind:     yang.DirectoryEntry,
-		ListAttr: &yang.ListAttr{MinElements: &yang.Value{Name: "0"}},
+		ListAttr: &yang.ListAttr{MinElements: 0},
 		Dir: map[string]*yang.Entry{
 			"leaf-name": {
 				Kind: yang.LeafEntry,


### PR DESCRIPTION
Recently the type of MinElements and MaxElements in the `goyang` repository was changed to uint64 (see this [PR](https://github.com/openconfig/goyang/pull/125)). It was released in v0.2.0.

I've updated the version used in `ygot` to use the v0.2.0 release and changed the usage of MinElements and MaxElements accordingly. I've commented out three tests that I think are no longer in scope, but maybe I should just change them a bit.

This PR is a draft, because I don't know what the policy is for upgrading dependencies and backwards compatibility.

