### PR TITLE
Improve Error Message for findMappableEntities

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Install protobuf
-        uses: arduino/setup-protoc@v1.1.0
+        uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
 

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -1026,7 +1026,7 @@ func findMappableEntities(e *yang.Entry, dirs map[string]*yang.Entry, enums map[
 		case ch.Kind == yang.AnyDataEntry:
 			continue
 		default:
-			errs = util.AppendErr(errs, fmt.Errorf("unknown type of entry %v in findMappableEntities for %s", e.Kind, e.Path()))
+			errs = util.AppendErr(errs, fmt.Errorf("unknown type of entry %v in findMappableEntities for %s", ch.Kind, ch.Path()))
 		}
 	}
 	return errs


### PR DESCRIPTION
Resolves #470 

The unsupported node here is the **child node**, so displaying the parent node is confusing.
