### PR TITLE
Ignore default data values in findSetLeaves

### DIFF
--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -263,7 +263,8 @@ func findSetLeaves(s GoStruct, opts ...DiffOpt) (map[*pathSpec]interface{}, erro
 
 		ni.Annotation = []interface{}{vp}
 
-		if util.IsNilOrInvalidValue(ni.FieldValue) || util.IsValueStructPtr(ni.FieldValue) || util.IsValueMap(ni.FieldValue) {
+		// Ignore non-data, or default data values.
+		if util.IsNilOrInvalidValue(ni.FieldValue) || util.IsValueNilOrDefault(ni.FieldValue.Interface()) || util.IsValueStructPtr(ni.FieldValue) || util.IsValueMap(ni.FieldValue) {
 			return
 		}
 

--- a/ygot/diff_test.go
+++ b/ygot/diff_test.go
@@ -151,6 +151,7 @@ type basicStruct struct {
 	StringValue *string                     `path:"string-value"`
 	StructValue *basicStructTwo             `path:"struct-value"`
 	MapValue    map[string]*basicListMember `path:"map-list"`
+	EmptyValue  YANGEmpty                   `path:"empty-value"`
 }
 
 func (*basicStruct) IsYANGGoStruct() {}
@@ -429,6 +430,16 @@ func TestFindSetLeaves(t *testing.T) {
 		desc:     "struct with fields missing path annotation",
 		inStruct: &errorStruct{Value: String("foo")},
 		wantErr:  "error from ForEachDataField iteration: field Value did not specify a path",
+	}, {
+		desc:     "struct with empty value",
+		inStruct: &basicStruct{EmptyValue: YANGEmpty(true)},
+		want: map[*pathSpec]interface{}{
+			{
+				gNMIPaths: []*gnmipb.Path{{
+					Elem: []*gnmipb.PathElem{{Name: "empty-value"}},
+				}},
+			}: YANGEmpty(true),
+		},
 	}, {
 		desc: "multi-level string values",
 		inStruct: &basicStruct{

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -822,12 +822,6 @@ type renderExampleUnionBinary struct {
 
 func (*renderExampleUnionBinary) IsRenderUnionExample() {}
 
-type renderExampleUnionEmpty struct {
-	YANGEmpty YANGEmpty
-}
-
-func (*renderExampleUnionEmpty) IsRenderUnionExample() {}
-
 // renderExampleUnionInvalid is an invalid union struct.
 type renderExampleUnionInvalid struct {
 	String string

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -838,8 +838,9 @@ func (*renderExampleUnionEnum) IsRenderUnionExample() {}
 
 // renderExampleChild is a child of the renderExample struct.
 type renderExampleChild struct {
-	Val  *uint64  `path:"val"`
-	Enum EnumTest `path:"enum"`
+	Val   *uint64   `path:"val"`
+	Enum  EnumTest  `path:"enum"`
+	Empty YANGEmpty `path:"empty"`
 }
 
 // IsYANGGoStruct implements the GoStruct interface.
@@ -3378,6 +3379,14 @@ func TestMarshal7951(t *testing.T) {
 		desc: "empty type",
 		in:   &renderExample{Empty: true},
 		want: `{"empty":[null]}`,
+	}, {
+		desc: "union empty type",
+		in:   &renderExample{UnionValSimple: testutil.YANGEmpty(true)},
+		want: `{"union-val-simple":[null]}`,
+	}, {
+		desc: "union empty type (wrapped union)",
+		in:   &renderExample{UnionVal: &renderExampleUnionEmpty{true}},
+		want: `{"union-val-simple":[null]}`,
 	}, {
 		desc: "indentation requested",
 		in: &renderExample{

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -822,6 +822,12 @@ type renderExampleUnionBinary struct {
 
 func (*renderExampleUnionBinary) IsRenderUnionExample() {}
 
+type renderExampleUnionEmpty struct {
+	YANGEmpty YANGEmpty
+}
+
+func (*renderExampleUnionEmpty) IsRenderUnionExample() {}
+
 // renderExampleUnionInvalid is an invalid union struct.
 type renderExampleUnionInvalid struct {
 	String string
@@ -3379,14 +3385,6 @@ func TestMarshal7951(t *testing.T) {
 		desc: "empty type",
 		in:   &renderExample{Empty: true},
 		want: `{"empty":[null]}`,
-	}, {
-		desc: "union empty type",
-		in:   &renderExample{UnionValSimple: testutil.YANGEmpty(true)},
-		want: `{"union-val-simple":[null]}`,
-	}, {
-		desc: "union empty type (wrapped union)",
-		in:   &renderExample{UnionVal: &renderExampleUnionEmpty{true}},
-		want: `{"union-val-simple":[null]}`,
 	}, {
 		desc: "indentation requested",
 		in: &renderExample{


### PR DESCRIPTION
Add a check for the default value to the bail condition in `findSetLeaves`. Resolves #473 

Currently, the default value of `false` for `YANGEmpty` is counted as set by `findSetLeaves`. This is clearly not what `findSetLeaves` intended, as the only form of a set `YANGEmpty` is `true`.