### PR TITLE
Ensure that we repeatedly run CI without a push.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Ensure that we repeatedly run CI without a push.

 * (M) .github/workflows/go.yml
  - Ensure that we catch any changes in Go versions, or external
    dependencies by running CI on a schedule every day at midnight.
    I am proposing to make this change across our different repos
    since there are changes in Go which we should probably be aware
    of without needing to be changing code.