### PR TITLE
ygen: Option to include descriptions in generated schema

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -328,10 +328,10 @@ func main() {
 				ShortenEnumLeafNames:                 *shortenEnumLeafNames,
 				EnumOrgPrefixesToTrim:                enumOrgPrefixesToTrim,
 				UseDefiningModuleForTypedefEnumNames: *useDefiningModuleForTypedefEnumNames,
-				IncludeDescriptions:                  *includeDescriptions,
 			},
-			PackageName:        *packageName,
-			GenerateJSONSchema: *generateSchema,
+			PackageName:         *packageName,
+			GenerateJSONSchema:  *generateSchema,
+			IncludeDescriptions: *includeDescriptions,
 			GoOptions: ygen.GoOpts{
 				YgotImportPath:                      *ygotImportPath,
 				YtypesImportPath:                    *ytypesImportPath,

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -74,6 +74,7 @@ var (
 	appendEnumSuffixForSimpleUnionEnums  = flag.Bool("enum_suffix_for_simple_union_enums", false, "If set to true when typedef_enum_with_defmod is also true, all inlined enumerations within unions will be suffixed with \"Enum\", instead of adding the suffix only for inlined enumerations within typedef unions.")
 	ygotImportPath                       = flag.String("ygot_path", genutil.GoDefaultYgotImportPath, "The import path to use for ygot.")
 	trimEnumOpenConfigPrefix             = flag.Bool("trim_enum_openconfig_prefix", false, `If set to true when compressPaths=true, the organizational prefix "openconfig-" is trimmed from the module part of the name of enumerated names in the generated code`)
+	includeDescriptions                  = flag.Bool("include_descriptions", false, "If set to true when generateSchema=true, the YANG descriptions will be included in the generated code artefact.")
 	enumOrgPrefixesToTrim                []string
 
 	// Flags used for GoStruct generation only.
@@ -327,6 +328,7 @@ func main() {
 				ShortenEnumLeafNames:                 *shortenEnumLeafNames,
 				EnumOrgPrefixesToTrim:                enumOrgPrefixesToTrim,
 				UseDefiningModuleForTypedefEnumNames: *useDefiningModuleForTypedefEnumNames,
+				IncludeDescriptions:                  *includeDescriptions,
 			},
 			PackageName:        *packageName,
 			GenerateJSONSchema: *generateSchema,

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -67,6 +67,9 @@ type GeneratorConfig struct {
 	GoOptions GoOpts
 	// ProtoOptions stores a struct which contains Protobuf specific options.
 	ProtoOptions ProtoOpts
+	// IncludeDescriptions specifies that YANG entry descriptions are added
+	// to the JSON schema. Is false by default, to reduce the size of generated schema
+	IncludeDescriptions bool
 }
 
 // DirectoryGenConfig contains the configuration necessary to generate a set of
@@ -159,9 +162,6 @@ type TransformationOpts struct {
 	// to prefix typedef enumerated types instead of the module where the
 	// typedef enumerated value is used.
 	UseDefiningModuleForTypedefEnumNames bool
-	// IncludeDescriptions specifies that YANG entry descriptions are added
-	// to the JSON schema. Set to false to reduces the size of generated schema
-	IncludeDescriptions bool
 }
 
 // GoOpts stores Go specific options for the code generation library.
@@ -479,7 +479,7 @@ func (cg *YANGCodeGenerator) GenerateGoCode(yangFiles, includePaths []string) (*
 	if cg.Config.GenerateJSONSchema {
 		var err error
 		rawSchema, err = buildJSONTree(mdef.modules, gogen.uniqueDirectoryNames, mdef.directoryEntries["/"],
-			cg.Config.TransformationOptions.CompressBehaviour.CompressEnabled(), cg.Config.TransformationOptions.IncludeDescriptions)
+			cg.Config.TransformationOptions.CompressBehaviour.CompressEnabled(), cg.Config.IncludeDescriptions)
 		if err != nil {
 			codegenErr = util.AppendErr(codegenErr, fmt.Errorf("error marshalling JSON schema: %v", err))
 		}

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -159,6 +159,9 @@ type TransformationOpts struct {
 	// to prefix typedef enumerated types instead of the module where the
 	// typedef enumerated value is used.
 	UseDefiningModuleForTypedefEnumNames bool
+	// IncludeDescriptions specifies that YANG entry descriptions are added
+	// to the JSON schema. Set to false to reduces the size of generated schema
+	IncludeDescriptions bool
 }
 
 // GoOpts stores Go specific options for the code generation library.
@@ -475,7 +478,8 @@ func (cg *YANGCodeGenerator) GenerateGoCode(yangFiles, includePaths []string) (*
 	var enumTypeMapCode string
 	if cg.Config.GenerateJSONSchema {
 		var err error
-		rawSchema, err = buildJSONTree(mdef.modules, gogen.uniqueDirectoryNames, mdef.directoryEntries["/"], cg.Config.TransformationOptions.CompressBehaviour.CompressEnabled())
+		rawSchema, err = buildJSONTree(mdef.modules, gogen.uniqueDirectoryNames, mdef.directoryEntries["/"],
+			cg.Config.TransformationOptions.CompressBehaviour.CompressEnabled(), cg.Config.TransformationOptions.IncludeDescriptions)
 		if err != nil {
 			codegenErr = util.AppendErr(codegenErr, fmt.Errorf("error marshalling JSON schema: %v", err))
 		}

--- a/ygen/schemaparse.go
+++ b/ygen/schemaparse.go
@@ -94,7 +94,7 @@ func annotateChildren(e *yang.Entry, dn map[string]string, inclDescriptions bool
 
 // annotateEntry modifies the yang.Entry e to:
 //  - set the description to be the nil string to reduce
-//    filesizes of serialised schemas.
+//    filesizes of serialised schemas (only when inclDescriptions=false)
 //  - add the struct name corresponding to the path of the entry
 //    in the supplied dn map to the annotations.
 //  - add the YANG schema path to the annotations, where e

--- a/ygen/schemaparse.go
+++ b/ygen/schemaparse.go
@@ -36,13 +36,13 @@ import (
 // they correspond to in the generated code, and the absolute schema path that
 // the entry corresponds to. In the case that the fake root struct that is provided
 // is nil, a synthetic root entry is used to store the schema tree.
-func buildJSONTree(ms []*yang.Entry, dn map[string]string, fakeroot *yang.Entry, compressed bool) ([]byte, error) {
+func buildJSONTree(ms []*yang.Entry, dn map[string]string, fakeroot *yang.Entry, compressed bool, inclDescriptions bool) ([]byte, error) {
 	rootEntry := &yang.Entry{
 		Dir:        map[string]*yang.Entry{},
 		Annotation: map[string]interface{}{},
 	}
 	for _, m := range ms {
-		annotateChildren(m, dn)
+		annotateChildren(m, dn, inclDescriptions)
 		for _, ch := range util.Children(m) {
 			if _, ex := rootEntry.Dir[ch.Name]; ex {
 				return nil, fmt.Errorf("overlapping root children for key %s", ch.Name)
@@ -80,14 +80,14 @@ func buildJSONTree(ms []*yang.Entry, dn map[string]string, fakeroot *yang.Entry,
 // to its path in the supplied dn map. The dn map is assumed to contain the
 // names of unique directories that are generated within the code to be output.
 // The children of e are recursively annotated.
-func annotateChildren(e *yang.Entry, dn map[string]string) {
-	annotateEntry(e, dn)
+func annotateChildren(e *yang.Entry, dn map[string]string, inclDescriptions bool) {
+	annotateEntry(e, dn, inclDescriptions)
 	for _, ch := range util.Children(e) {
-		annotateEntry(ch, dn)
+		annotateEntry(ch, dn, inclDescriptions)
 		if ch.IsDir() {
 			ch.Annotation["schemapath"] = ch.Path()
 			// Recurse to annotate the children of this entry.
-			annotateChildren(ch, dn)
+			annotateChildren(ch, dn, inclDescriptions)
 		}
 	}
 }
@@ -99,8 +99,10 @@ func annotateChildren(e *yang.Entry, dn map[string]string) {
 //    in the supplied dn map to the annotations.
 //  - add the YANG schema path to the annotations, where e
 //    corresponds to a YANG directory.
-func annotateEntry(e *yang.Entry, dn map[string]string) {
-	e.Description = ""
+func annotateEntry(e *yang.Entry, dn map[string]string, inclDescriptions bool) {
+	if !inclDescriptions {
+		e.Description = ""
+	}
 	if e.Annotation == nil {
 		e.Annotation = map[string]interface{}{}
 	}

--- a/ygen/schemaparse_test.go
+++ b/ygen/schemaparse_test.go
@@ -30,50 +30,58 @@ import (
 func TestBuildJSONTree(t *testing.T) {
 	// Simple YANG hierarchy for test case.
 	simpleModule := &yang.Entry{
-		Name: "a-module",
-		Kind: yang.DirectoryEntry,
+		Name:        "a-module",
+		Kind:        yang.DirectoryEntry,
+		Description: "A module",
 	}
 	simpleContainer := &yang.Entry{
-		Name:   "simple-container",
-		Kind:   yang.DirectoryEntry,
-		Parent: simpleModule,
+		Name:        "simple-container",
+		Kind:        yang.DirectoryEntry,
+		Parent:      simpleModule,
+		Description: "Simple Container",
 	}
 	simpleLeaf := &yang.Entry{
-		Name:   "simple-leaf",
-		Kind:   yang.LeafEntry,
-		Parent: simpleContainer,
+		Name:        "simple-leaf",
+		Kind:        yang.LeafEntry,
+		Parent:      simpleContainer,
+		Description: "Simple Leaf",
 	}
 	simpleContainer.Dir = map[string]*yang.Entry{"simple-leaf": simpleLeaf}
 	simpleModule.Dir = map[string]*yang.Entry{"simple-container": simpleContainer}
 
 	// More complex YANG hierarchy with multiple modules, and children.
 	moduleTwo := &yang.Entry{
-		Name: "a-module",
-		Kind: yang.DirectoryEntry,
+		Name:        "a-module",
+		Kind:        yang.DirectoryEntry,
+		Description: "A Module",
 	}
 	moduleTwoContainerOne := &yang.Entry{
-		Name:   "container-one",
-		Kind:   yang.DirectoryEntry,
-		Parent: moduleTwo,
+		Name:        "container-one",
+		Kind:        yang.DirectoryEntry,
+		Parent:      moduleTwo,
+		Description: "Container One",
 	}
 	moduleTwoContainerOne.Dir = map[string]*yang.Entry{
 		"ch-one": {
-			Name:   "ch-one",
-			Kind:   yang.LeafEntry,
-			Type:   &yang.YangType{Kind: yang.Ystring},
-			Parent: moduleTwoContainerOne,
+			Name:        "ch-one",
+			Kind:        yang.LeafEntry,
+			Type:        &yang.YangType{Kind: yang.Ystring},
+			Parent:      moduleTwoContainerOne,
+			Description: "Ch One",
 		},
 		"ch-two": {
-			Name:   "ch-two",
-			Kind:   yang.LeafEntry,
-			Type:   &yang.YangType{Kind: yang.Yuint32},
-			Parent: moduleTwoContainerOne,
+			Name:        "ch-two",
+			Kind:        yang.LeafEntry,
+			Type:        &yang.YangType{Kind: yang.Yuint32},
+			Parent:      moduleTwoContainerOne,
+			Description: "Ch Two",
 		},
 	}
 	moduleTwoContainerTwo := &yang.Entry{
-		Name:   "container-two",
-		Kind:   yang.DirectoryEntry,
-		Parent: moduleTwo,
+		Name:        "container-two",
+		Kind:        yang.DirectoryEntry,
+		Parent:      moduleTwo,
+		Description: "Container Two",
 	}
 	moduleTwoContainerTwo.Dir = map[string]*yang.Entry{
 		"ch2-leafone": {
@@ -81,6 +89,7 @@ func TestBuildJSONTree(t *testing.T) {
 			Kind:   yang.LeafEntry,
 			Type:   &yang.YangType{Kind: yang.Ystring},
 			Parent: moduleTwoContainerTwo,
+			// No description
 		},
 	}
 	moduleTwo.Dir = map[string]*yang.Entry{
@@ -89,20 +98,22 @@ func TestBuildJSONTree(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		inEntries        []*yang.Entry
-		inDirectoryNames map[string]string
-		inFakeRoot       *yang.Entry
-		inCompressed     bool
-		want             string
-		wantErr          string
+		name                  string
+		inEntries             []*yang.Entry
+		inDirectoryNames      map[string]string
+		inFakeRoot            *yang.Entry
+		inCompressed          bool
+		inIncludeDescriptions bool
+		want                  string
+		wantErr               string
 	}{{
 		name:      "simple module entry",
 		inEntries: []*yang.Entry{simpleModule},
 		inDirectoryNames: map[string]string{
 			"/a-module/simple-container": "SimpleContainer",
 		},
-		inCompressed: true,
+		inCompressed:          true,
+		inIncludeDescriptions: false,
 		want: `{
     "Name": "",
     "Kind": 0,
@@ -138,6 +149,7 @@ func TestBuildJSONTree(t *testing.T) {
 			"/module-two/container-one":  "C1",
 			"/module-two/container-two":  "C2",
 		},
+		inIncludeDescriptions: true, // Descriptions of simpleModule will have been overwritten during first set of tests
 		want: `{
     "Name": "",
     "Kind": 0,
@@ -145,11 +157,13 @@ func TestBuildJSONTree(t *testing.T) {
     "Dir": {
         "container-one": {
             "Name": "container-one",
+            "Description": "Container One",
             "Kind": 1,
             "Config": 0,
             "Dir": {
                 "ch-one": {
                     "Name": "ch-one",
+                    "Description": "Ch One",
                     "Kind": 0,
                     "Config": 0,
                     "Type": {
@@ -159,6 +173,7 @@ func TestBuildJSONTree(t *testing.T) {
                 },
                 "ch-two": {
                     "Name": "ch-two",
+                    "Description": "Ch Two",
                     "Kind": 0,
                     "Config": 0,
                     "Type": {
@@ -173,6 +188,7 @@ func TestBuildJSONTree(t *testing.T) {
         },
         "container-two": {
             "Name": "container-two",
+            "Description": "Container Two",
             "Kind": 1,
             "Config": 0,
             "Dir": {
@@ -259,7 +275,7 @@ func TestBuildJSONTree(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		gotb, err := buildJSONTree(tt.inEntries, tt.inDirectoryNames, tt.inFakeRoot, tt.inCompressed)
+		gotb, err := buildJSONTree(tt.inEntries, tt.inDirectoryNames, tt.inFakeRoot, tt.inCompressed, tt.inIncludeDescriptions)
 		if err != nil && err.Error() != tt.wantErr {
 			t.Errorf("%s: buildJSONTree(%v, %v): did not get expected error, got: %v, want: %v", tt.name, tt.inEntries, tt.inDirectoryNames, err, tt.wantErr)
 		}
@@ -436,15 +452,16 @@ func TestSchemaRoundtrip(t *testing.T) {
 	annotatedFakeRootContainerEntry.Dir["leaf"] = annotatedFakeRootLeafEntry
 
 	tests := []struct {
-		name             string
-		inEntries        []*yang.Entry
-		inFakeRoot       *yang.Entry
-		inDirectoryNames map[string]string
-		inCompressed     bool
-		want             map[string]*yang.Entry
-		wantJSONErr      string
-		wantGzipErr      string
-		wantSchemaErr    string
+		name               string
+		inEntries          []*yang.Entry
+		inFakeRoot         *yang.Entry
+		inDirectoryNames   map[string]string
+		inCompressed       bool
+		inInclDescriptions bool
+		want               map[string]*yang.Entry
+		wantJSONErr        string
+		wantGzipErr        string
+		wantSchemaErr      string
 	}{{
 		name:      "simple schema",
 		inEntries: []*yang.Entry{moduleEntry},
@@ -466,10 +483,11 @@ func TestSchemaRoundtrip(t *testing.T) {
 			"Container": annotatedFakeRootContainerEntry,
 			"Device":    annotatedFakeRootEntry,
 		},
+		inInclDescriptions: true,
 	}}
 
 	for _, tt := range tests {
-		gotByte, err := buildJSONTree(tt.inEntries, tt.inDirectoryNames, tt.inFakeRoot, tt.inCompressed)
+		gotByte, err := buildJSONTree(tt.inEntries, tt.inDirectoryNames, tt.inFakeRoot, tt.inCompressed, tt.inInclDescriptions)
 		if err != nil && err.Error() != tt.wantJSONErr {
 			t.Errorf("%s: buildJSONTree(%v, %v): did not get expected error, got: %v, want: %v", tt.name, tt.inEntries, tt.inDirectoryNames, err, tt.wantJSONErr)
 			continue

--- a/ygen/schemaparse_test.go
+++ b/ygen/schemaparse_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/ygot"
@@ -281,7 +280,7 @@ func TestBuildJSONTree(t *testing.T) {
 		}
 
 		got := string(gotb)
-		if diff := pretty.Compare(got, tt.want); diff != "" {
+		if diff := cmp.Diff(got, tt.want); diff != "" {
 			if diffl, err := testutil.GenerateUnifiedDiff(tt.want, got); err == nil {
 				diff = diffl
 			}


### PR DESCRIPTION
Currently YANG descriptions are dropped to reduce the size of generated schema.
Sometimes the descriptions are needed in the generated schema.
This patch adds the ability to specify an `-include_descriptions` flag on the `generate` command