### PR TITLE
Cache regexp compilations during string validation.

### DIFF
--- a/ytypes/schema_tests/posix_regex_benchmark_test.go
+++ b/ytypes/schema_tests/posix_regex_benchmark_test.go
@@ -24,10 +24,10 @@ import (
 func BenchmarkPOSIXPattern(b *testing.B) {
 	d := &oc.Device{}
 	prefixSet := d.GetOrCreateRoutingPolicy().GetOrCreateDefinedSets().GetOrCreatePrefixSet("foo")
-	for i := 0; i != 100; i++ {
+	for i := 0; i != 256; i++ {
 		prefixSet.NewPrefix(fmt.Sprintf("%d.%d.%d.0/24", i, i, i), "exact")
 	}
-	for i := 0; i != 100; i++ {
+	for i := 0; i != 256; i++ {
 		prefixSet.NewPrefix(fmt.Sprintf("FFFF:%d:EEEE:AAAA::/64", i), "60..64")
 	}
 

--- a/ytypes/schema_tests/posix_regex_benchmark_test.go
+++ b/ytypes/schema_tests/posix_regex_benchmark_test.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	oc "github.com/openconfig/ygot/exampleoc"
+)
+
+func BenchmarkPOSIXPattern(b *testing.B) {
+	d := &oc.Device{}
+	prefixSet := d.GetOrCreateRoutingPolicy().GetOrCreateDefinedSets().GetOrCreatePrefixSet("foo")
+	for i := 0; i != 100; i++ {
+		prefixSet.NewPrefix(fmt.Sprintf("%d.%d.%d.0/24", i, i, i), "exact")
+	}
+	for i := 0; i != 100; i++ {
+		prefixSet.NewPrefix(fmt.Sprintf("FFFF:%d:EEEE:AAAA::/64", i), "60..64")
+	}
+
+	b.ResetTimer()
+	for i := 0; i != b.N; i++ {
+		if err := d.Validate(); err != nil {
+			b.Fatalf("d.Validate() failed: %v", err)
+		}
+	}
+}

--- a/ytypes/string_type.go
+++ b/ytypes/string_type.go
@@ -66,10 +66,11 @@ func compilePattern(pattern string, isPOSIX bool) (*regexp.Regexp, error) {
 		if err != nil {
 			return nil, err
 		}
-		// It's true that there may be multiple writers into the map at the same time.
-		// This, however, doesn't impact correctness, since all
-		// compiled Regexp objects are acceptable, and the object is
-		// simply dropped at the end of this function.
+		// It's true that there may be multiple writers into the map at
+		// the same time. This, however, doesn't impact correctness,
+		// since any compiled Regexp objects are acceptable, and
+		// displaced objects are simply dropped at the end of this
+		// function.
 		regexMutex.Lock()
 		regexCache[pattern] = r
 		regexMutex.Unlock()


### PR DESCRIPTION
If there are a lot of routing prefixes to be validated, regexp compilation can become a performance bottleneck.

Aside: This could be because Go's regexp implementation might be relatively slow compared to other languages: https://github.com/golang/go/issues/11646