### PR TITLE
Add go_package Annotation to generated protobufs.

### DIFF
--- a/proto_generator/protogenerator.go
+++ b/proto_generator/protogenerator.go
@@ -53,6 +53,7 @@ var (
 	skipEnumDedup                        = flag.Bool("skip_enum_deduplication", false, "If set to true, all leaves of type enumeration will have a unique enum output for them, rather than sharing a common type (default behaviour).")
 	useDefiningModuleForTypedefEnumNames = flag.Bool("typedef_enum_with_defmod", false, "If set to true, all typedefs of type enumeration or identity will be prefixed with the name of its module of definition instead of its residing module.")
 	useConsistentNamesForProtoUnionEnums = flag.Bool("consistent_union_enum_names", false, "If set to true, uses more consistent names for enumerations defined within a union. This flag is only active when typedef_enum_with_defmod is also set.")
+	goPackageName                        = flag.String("go_package", "", "Value to be specified in the go_package file option of the generated protobuf.")
 )
 
 // main parses command-line flags to determine the set of YANG modules for
@@ -126,6 +127,7 @@ func main() {
 			NestedMessages:                       !*packageHierarchy,
 			EnumPackageName:                      *enumPackageName,
 			UseConsistentNamesForProtoUnionEnums: *useConsistentNamesForProtoUnionEnums,
+			GoPackageName:                        *goPackageName,
 		},
 	})
 

--- a/proto_generator/protogenerator.go
+++ b/proto_generator/protogenerator.go
@@ -53,7 +53,7 @@ var (
 	skipEnumDedup                        = flag.Bool("skip_enum_deduplication", false, "If set to true, all leaves of type enumeration will have a unique enum output for them, rather than sharing a common type (default behaviour).")
 	useDefiningModuleForTypedefEnumNames = flag.Bool("typedef_enum_with_defmod", false, "If set to true, all typedefs of type enumeration or identity will be prefixed with the name of its module of definition instead of its residing module.")
 	useConsistentNamesForProtoUnionEnums = flag.Bool("consistent_union_enum_names", false, "If set to true, uses more consistent names for enumerations defined within a union. This flag is only active when typedef_enum_with_defmod is also set.")
-	goPackageName                        = flag.String("go_package", "", "Value to be specified in the go_package file option of the generated protobuf.")
+	goPackageBase                        = flag.String("go_package_base", "", "Base name for the Go packages that are to generated - this value is included in the go_package option of the generated protobufs - and has generated packages' names appended to it.")
 )
 
 // main parses command-line flags to determine the set of YANG modules for
@@ -127,7 +127,7 @@ func main() {
 			NestedMessages:                       !*packageHierarchy,
 			EnumPackageName:                      *enumPackageName,
 			UseConsistentNamesForProtoUnionEnums: *useConsistentNamesForProtoUnionEnums,
-			GoPackageName:                        *goPackageName,
+			GoPackageBase:                        *goPackageBase,
 		},
 	})
 

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -268,6 +268,10 @@ type ProtoOpts struct {
 	// path as the name of enumerations under unions in generated proto
 	// code, and also appends a suffix to non-typedef union enums.
 	UseConsistentNamesForProtoUnionEnums bool
+	// GoPackageName specifies the name that should be used for the go_package
+	// package option within the generated protobuf code. For later versions
+	// of protoc-gen-go this is a required option.
+	GoPackageName string
 }
 
 // NewYANGCodeGenerator returns a new instance of the YANGCodeGenerator
@@ -773,9 +777,10 @@ func (cg *YANGCodeGenerator) GenerateProto3(yangFiles, includePaths []string) (*
 			CallerName:             cg.Config.Caller,
 			YwrapperPath:           ywrapperPath,
 			YextPath:               yextPath,
+			GoPackageName:          cg.Config.ProtoOptions.GoPackageName,
 		})
 		if err != nil {
-			yerr = util.AppendErrs(yerr, errs)
+			yerr = util.AppendErrs(yerr, []error{err})
 			continue
 		}
 		pkg.Header = h

--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -268,10 +268,11 @@ type ProtoOpts struct {
 	// path as the name of enumerations under unions in generated proto
 	// code, and also appends a suffix to non-typedef union enums.
 	UseConsistentNamesForProtoUnionEnums bool
-	// GoPackageName specifies the name that should be used for the go_package
-	// package option within the generated protobuf code. For later versions
-	// of protoc-gen-go this is a required option.
-	GoPackageName string
+	// GoPackageBase specifies the base of the names that are used in
+	// the go_package file option for generated protobufs. Additional
+	// package identifiers are appended to the go_package - such that
+	// the format <base>/<path>/<to>/<package> is used.
+	GoPackageBase string
 }
 
 // NewYANGCodeGenerator returns a new instance of the YANGCodeGenerator
@@ -768,6 +769,10 @@ func (cg *YANGCodeGenerator) GenerateProto3(yangFiles, includePaths []string) (*
 	}
 
 	for n, pkg := range genProto.Packages {
+		var gpn string
+		if cg.Config.ProtoOptions.GoPackageBase != "" {
+			gpn = fmt.Sprintf("%s/%s", cg.Config.ProtoOptions.GoPackageBase, strings.ReplaceAll(n, ".", "/"))
+		}
 		h, err := writeProto3Header(proto3Header{
 			PackageName:            n,
 			Imports:                stringKeys(pkgImports[n]),
@@ -777,7 +782,7 @@ func (cg *YANGCodeGenerator) GenerateProto3(yangFiles, includePaths []string) (*
 			CallerName:             cg.Config.Caller,
 			YwrapperPath:           ywrapperPath,
 			YextPath:               yextPath,
-			GoPackageName:          cg.Config.ProtoOptions.GoPackageName,
+			GoPackageName:          gpn,
 		})
 		if err != nil {
 			yerr = util.AppendErrs(yerr, []error{err})

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -2037,6 +2037,7 @@ func TestGenerateProto3(t *testing.T) {
 				AnnotateEnumNames:                    true,
 				NestedMessages:                       true,
 				UseConsistentNamesForProtoUnionEnums: true,
+				GoPackageBase:                        "github.com/foo/bar",
 			},
 		},
 		wantOutputFiles: map[string]string{
@@ -2054,6 +2055,11 @@ func TestGenerateProto3(t *testing.T) {
 	}, {
 		name:    "yang schema with simple enumerations",
 		inFiles: []string{filepath.Join(TestRoot, "testdata", "proto", "proto-test-c.yang")},
+		inConfig: GeneratorConfig{
+			ProtoOptions: ProtoOpts{
+				GoPackageBase: "github.com/foo/baz",
+			},
+		},
 		wantOutputFiles: map[string]string{
 			"openconfig.proto_test_c":              filepath.Join(TestRoot, "testdata", "proto", "proto-test-c.proto-test-c.formatted-txt"),
 			"openconfig.proto_test_c.entity":       filepath.Join(TestRoot, "testdata", "proto", "proto-test-c.proto-test-c.entity.formatted-txt"),
@@ -2285,7 +2291,7 @@ func TestGenerateProto3(t *testing.T) {
 				AnnotateEnumNames:   true,
 				AnnotateSchemaPaths: true,
 				NestedMessages:      true,
-				GoPackageName:       "github.com/openconfig/a/package",
+				GoPackageBase:       "github.com/openconfig/a/package",
 			},
 		},
 		wantOutputFiles: map[string]string{

--- a/ygen/codegen_test.go
+++ b/ygen/codegen_test.go
@@ -2285,6 +2285,7 @@ func TestGenerateProto3(t *testing.T) {
 				AnnotateEnumNames:   true,
 				AnnotateSchemaPaths: true,
 				NestedMessages:      true,
+				GoPackageName:       "github.com/openconfig/a/package",
 			},
 		},
 		wantOutputFiles: map[string]string{

--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -188,7 +188,7 @@ import "{{ $importedProto }}";
 
 {{- if ne .GoPackageName "" }}
 
-go_package = "{{ .GoPackageName }}";
+option go_package = "{{ .GoPackageName }}";
 {{- end }}
 `)
 

--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -186,7 +186,7 @@ import "{{ .YextPath }}/yext.proto";
 import "{{ $importedProto }}";
 {{- end -}}
 
-{{- if ne .GoPackageName "" }}
+{{- if .GoPackageName }}
 
 option go_package = "{{ .GoPackageName }}";
 {{- end }}

--- a/ygen/protogen.go
+++ b/ygen/protogen.go
@@ -154,6 +154,7 @@ type proto3Header struct {
 	CallerName             string   // CallerName indicates the name of the entity initiating code generation.
 	YwrapperPath           string   // YwrapperPath is the path to the ywrapper.proto file, excluding the filename.
 	YextPath               string   // YextPath is the path to the yext.proto file, excluding the filename.
+	GoPackageName          string   // GoPackageName is the contents of the go_package fileoption in the generated protobuf.
 }
 
 var disallowedInProtoIDRegexp = regexp.MustCompile(`[^a-zA-Z0-9_]`)
@@ -183,6 +184,11 @@ import "{{ .YwrapperPath }}/ywrapper.proto";
 import "{{ .YextPath }}/yext.proto";
 {{- range $importedProto := .Imports }}
 import "{{ $importedProto }}";
+{{- end -}}
+
+{{- if ne .GoPackageName "" }}
+
+go_package = "{{ .GoPackageName }}";
 {{- end }}
 `)
 

--- a/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
+++ b/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
@@ -10,7 +10,7 @@ package openconfig.enums;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
-go_package = "github.com/foo/bar/openconfig/enums";
+option go_package = "github.com/foo/bar/openconfig/enums";
 
 // EnumUnionCycloneScalesEnum represents an enumerated type generated for the YANG enumerated type cyclone-scales.
 enum EnumUnionCycloneScalesEnum {

--- a/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
+++ b/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
@@ -10,6 +10,8 @@ package openconfig.enums;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
+go_package = "github.com/foo/bar/openconfig/enums";
+
 // EnumUnionCycloneScalesEnum represents an enumerated type generated for the YANG enumerated type cyclone-scales.
 enum EnumUnionCycloneScalesEnum {
   ENUMUNIONCYCLONESCALESENUM_UNSET = 0;

--- a/ygen/testdata/proto/enum-union.compress.formatted-txt
+++ b/ygen/testdata/proto/enum-union.compress.formatted-txt
@@ -11,7 +11,7 @@ import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/enums/enums.proto";
 
-go_package = "github.com/foo/bar/openconfig";
+option go_package = "github.com/foo/bar/openconfig";
 
 message Device {
   Outer outer = 468106409;

--- a/ygen/testdata/proto/enum-union.compress.formatted-txt
+++ b/ygen/testdata/proto/enum-union.compress.formatted-txt
@@ -11,6 +11,8 @@ import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/enums/enums.proto";
 
+go_package = "github.com/foo/bar/openconfig";
+
 message Device {
   Outer outer = 468106409;
 }

--- a/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
+++ b/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
@@ -10,7 +10,7 @@ package openconfig;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
-go_package = "github.com/openconfig/a/package";
+go_package = "github.com/openconfig/a/package/openconfig";
 
 message Device {
   A a = 213815547 [(yext.schemapath) = "/a"];

--- a/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
+++ b/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
@@ -10,6 +10,8 @@ package openconfig;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
+go_package = "github.com/openconfig/a/package";
+
 message Device {
   A a = 213815547 [(yext.schemapath) = "/a"];
 }

--- a/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
+++ b/ygen/testdata/proto/excluded-config-false.uncompressed.formatted-txt
@@ -10,7 +10,7 @@ package openconfig;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
-go_package = "github.com/openconfig/a/package/openconfig";
+option go_package = "github.com/openconfig/a/package/openconfig";
 
 message Device {
   A a = 213815547 [(yext.schemapath) = "/a"];

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
@@ -10,7 +10,7 @@ package openconfig.proto_test_c.elists.elist;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
-go_package = "github.com/foo/baz/openconfig/proto_test_c/elists/elist";
+option go_package = "github.com/foo/baz/openconfig/proto_test_c/elists/elist";
 
 // Config represents the /proto-test-c/elists/elist/config YANG schema element.
 message Config {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
@@ -10,6 +10,8 @@ package openconfig.proto_test_c.elists.elist;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
+go_package = "github.com/foo/baz/openconfig/proto_test_c/elists/elist";
+
 // Config represents the /proto-test-c/elists/elist/config YANG schema element.
 message Config {
   enum One {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.elists.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.elists.formatted-txt
@@ -11,6 +11,8 @@ import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/proto_test_c/elists/elist/elist.proto";
 
+go_package = "github.com/foo/baz/openconfig/proto_test_c/elists";
+
 // Elist represents the /proto-test-c/elists/elist YANG schema element.
 message Elist {
   elist.Config config = 319399671;

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.elists.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.elists.formatted-txt
@@ -11,7 +11,7 @@ import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/proto_test_c/elists/elist/elist.proto";
 
-go_package = "github.com/foo/baz/openconfig/proto_test_c/elists";
+option go_package = "github.com/foo/baz/openconfig/proto_test_c/elists";
 
 // Elist represents the /proto-test-c/elists/elist YANG schema element.
 message Elist {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.entity.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.entity.formatted-txt
@@ -10,7 +10,7 @@ package openconfig.proto_test_c.entity;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
-go_package = "github.com/foo/baz/openconfig/proto_test_c/entity";
+option go_package = "github.com/foo/baz/openconfig/proto_test_c/entity";
 
 // Config represents the /proto-test-c/entity/config YANG schema element.
 message Config {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.entity.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.entity.formatted-txt
@@ -10,6 +10,8 @@ package openconfig.proto_test_c.entity;
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
 import "github.com/openconfig/ygot/proto/yext/yext.proto";
 
+go_package = "github.com/foo/baz/openconfig/proto_test_c/entity";
+
 // Config represents the /proto-test-c/entity/config YANG schema element.
 message Config {
   enum EnumeratedLeaf {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
@@ -12,6 +12,8 @@ import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/proto_test_c/elists/elists.proto";
 import "openconfig/proto_test_c/entity/entity.proto";
 
+go_package = "github.com/foo/baz/openconfig/proto_test_c";
+
 // ElistKey represents the /proto-test-c/elists/elist YANG schema element.
 message ElistKey {
   enum One {

--- a/ygen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
+++ b/ygen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
@@ -12,7 +12,7 @@ import "github.com/openconfig/ygot/proto/yext/yext.proto";
 import "openconfig/proto_test_c/elists/elists.proto";
 import "openconfig/proto_test_c/entity/entity.proto";
 
-go_package = "github.com/foo/baz/openconfig/proto_test_c";
+option go_package = "github.com/foo/baz/openconfig/proto_test_c";
 
 // ElistKey represents the /proto-test-c/elists/elist YANG schema element.
 message ElistKey {


### PR DESCRIPTION
`protoc-gen-go` now requires an explicit `go_package` annotation to specify the name of the package that is being generated. This change adds this to protobuf packages that are generated by ygot.

A new `go_package_base` option is added to the `proto_generator` binary and the name of the package put into generated packages.