### PR TITLE
fixes #526, encode empty list as empty list when using RFC7951 encoding

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -1258,6 +1258,10 @@ func mapJSON(field reflect.Value, parentMod string, args jsonOutputConfig) (inte
 	sort.Strings(mapKeys)
 
 	if len(mapKeys) == 0 {
+		// empty list should be encoded as empty list
+		if args.jType == RFC7951 {
+			return []interface{}{}, nil
+		}
 		return nil, nil
 	}
 

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1990,7 +1990,7 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantIETF: map[string]interface{}{
 			"ch": map[string]interface{}{"val": "42"},
-			// RFC7951 Section 5.4, the list is a name /array pair, an array must be [], not null RFC8259 Sectiob 5
+			/// RFC7951 Section 5.4 defines a YANG list as an JSON array. Per RFC 8259 Section 5 an empty array should be [] rather than 'null'.
 			"list": []interface{}{},
 		},
 		wantInternal: map[string]interface{}{

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1990,6 +1990,22 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantIETF: map[string]interface{}{
 			"ch": map[string]interface{}{"val": "42"},
+			// RFC7951 Section 5.4, the list is a name /array pair, an array must be [], not null RFC8259 Sectiob 5
+			"list": []interface{}{},
+		},
+		wantInternal: map[string]interface{}{
+			"ch": map[string]interface{}{"val": 42},
+		},
+	}, {
+		name: "empty map nil",
+		in: &renderExample{
+			Ch: &renderExampleChild{
+				Val: Uint64(42),
+			},
+			List: nil,
+		},
+		wantIETF: map[string]interface{}{
+			"ch": map[string]interface{}{"val": "42"},
 		},
 		wantInternal: map[string]interface{}{
 			"ch": map[string]interface{}{"val": 42},
@@ -3370,7 +3386,8 @@ func TestMarshal7951(t *testing.T) {
 	}, {
 		desc: "empty map",
 		in:   map[string]*renderExample{},
-		want: `null`,
+		// null as empty array is not valid, RFC7951 section 5.4 specify that the array must be an array, and JSON empty arrays are not null value
+		want: `[]`,
 	}, {
 		desc: "nil string pointer",
 		in:   (*string)(nil),


### PR DESCRIPTION
Encode empty list as empty list for RFC7951. Correct formating