### PR TITLE
Add PathAndStruct helper for generated non-leaf PathStruct types.

### DIFF
--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -15,7 +15,9 @@
 package ypathgen
 
 import (
+	"fmt"
 	"io/ioutil"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -914,6 +916,11 @@ func TestGeneratePathCodeSplitFiles(t *testing.T) {
 			} else {
 				for i := range gotCode {
 					if gotCode[i] != wantCode[i] {
+						// FIXME(wenbli): debug
+						if err := ioutil.WriteFile(fmt.Sprintf("/usr/local/google/home/wenbli/tmp/%s", path.Base(tt.wantStructsCodeFiles[i])), []byte(gotCode[i]), 0644); err != nil {
+							panic(err)
+						}
+
 						// Use difflib to generate a unified diff between the
 						// two code snippets such that this is simpler to debug
 						// in the test output.
@@ -1612,6 +1619,11 @@ type ContainerWithConfigAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.ContainerWithConfig for the path "/root-module/container-with-config".
+func (n *ContainerWithConfig) PathAndStruct() (*ContainerWithConfig, *oc.ContainerWithConfig) {
+	return n, &oc.ContainerWithConfig{}
+}
+
 // ContainerWithConfig_Leaf represents the /root-module/container-with-config/state/leaf YANG schema element.
 type ContainerWithConfig_Leaf struct {
 	*ygot.NodePath
@@ -1718,6 +1730,11 @@ type ContainerWithConfig struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.ContainerWithConfig for the path "/root-module/container-with-config".
+func (n *ContainerWithConfig) PathAndStruct() (*ContainerWithConfig, *oc.ContainerWithConfig) {
+	return n, &oc.ContainerWithConfig{}
+}
+
 // ContainerWithConfig_Leaf represents the /root-module/container-with-config/state/leaf YANG schema element.
 type ContainerWithConfig_Leaf struct {
 	*ygot.NodePath
@@ -1783,6 +1800,11 @@ type RootPath struct {
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *RootPath {
 	return &RootPath{ygot.NewDeviceRootBase(id)}
+}
+
+// PathAndStruct returns the path struct and an empty oc.Root for the path "/root".
+func (n *RootPath) PathAndStruct() (*RootPath, *oc.Root) {
+	return n, &oc.Root{}
 }
 
 // LeafPath represents the /root-module/leaf YANG schema element.
@@ -1866,6 +1888,11 @@ func DeviceRoot(id string) *RootPath {
 	return &RootPath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty oc.Root for the path "/root".
+func (n *RootPath) PathAndStruct() (*RootPath, *oc.Root) {
+	return n, &oc.Root{}
+}
+
 // LeafPath represents the /root-module/leaf YANG schema element.
 type LeafPath struct {
 	*ygot.NodePath
@@ -1932,6 +1959,11 @@ type List struct {
 // ListAny represents the wildcard version of the /root-module/list-container/list YANG schema element.
 type ListAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.List for the path "/root-module/list-container/list".
+func (n *List) PathAndStruct() (*List, *oc.List) {
+	return n, &oc.List{}
 }
 
 // List_Key1 represents the /root-module/list-container/list/key1 YANG schema element.
@@ -2038,6 +2070,11 @@ func (n *ListAny) UnionKey() *List_UnionKeyAny {
 // List represents the /root-module/list-container/list YANG schema element.
 type List struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.List for the path "/root-module/list-container/list".
+func (n *List) PathAndStruct() (*List, *oc.List) {
+	return n, &oc.List{}
 }
 
 // List_Key1 represents the /root-module/list-container/list/key1 YANG schema element.

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -24,6 +24,11 @@ type ChoiceCaseAnonymousCasePathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty ChoiceCaseAnonymousCase for the path "/choice-case-example/choice-case-anonymous-case".
+func (n *ChoiceCaseAnonymousCasePath) PathAndStruct() (*ChoiceCaseAnonymousCasePath, *ChoiceCaseAnonymousCase) {
+	return n, &ChoiceCaseAnonymousCase{}
+}
+
 // ChoiceCaseAnonymousCase_APath represents the /choice-case-example/choice-case-anonymous-case/foo/a/a YANG schema element.
 type ChoiceCaseAnonymousCase_APath struct {
 	*ygot.NodePath
@@ -96,6 +101,11 @@ type ChoiceCaseWithLeafrefPath struct {
 // ChoiceCaseWithLeafrefPathAny represents the wildcard version of the /choice-case-example/choice-case-with-leafref YANG schema element.
 type ChoiceCaseWithLeafrefPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty ChoiceCaseWithLeafref for the path "/choice-case-example/choice-case-with-leafref".
+func (n *ChoiceCaseWithLeafrefPath) PathAndStruct() (*ChoiceCaseWithLeafrefPath, *ChoiceCaseWithLeafref) {
+	return n, &ChoiceCaseWithLeafref{}
 }
 
 // ChoiceCaseWithLeafref_PtrPath represents the /choice-case-example/choice-case-with-leafref/foo/bar/ptr YANG schema element.
@@ -172,6 +182,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // ChoiceCaseAnonymousCase returns from DevicePath the path struct for its child "choice-case-anonymous-case".
 func (n *DevicePath) ChoiceCaseAnonymousCase() *ChoiceCaseAnonymousCasePath {
 	return &ChoiceCaseAnonymousCasePath{
@@ -213,6 +228,11 @@ type SimpleChoiceCasePath struct {
 // SimpleChoiceCasePathAny represents the wildcard version of the /choice-case-example/simple-choice-case YANG schema element.
 type SimpleChoiceCasePathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty SimpleChoiceCase for the path "/choice-case-example/simple-choice-case".
+func (n *SimpleChoiceCasePath) PathAndStruct() (*SimpleChoiceCasePath, *SimpleChoiceCase) {
+	return n, &SimpleChoiceCase{}
 }
 
 // SimpleChoiceCase_APath represents the /choice-case-example/simple-choice-case/foo/bar/a YANG schema element.

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -24,6 +24,11 @@ type AListPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty AList for the path "/enum-module/a-lists/a-list".
+func (n *AListPath) PathAndStruct() (*AListPath, *AList) {
+	return n, &AList{}
+}
+
 // AList_ValuePath represents the /enum-module/a-lists/a-list/state/value YANG schema element.
 type AList_ValuePath struct {
 	*ygot.NodePath
@@ -64,6 +69,11 @@ type BListPath struct {
 // BListPathAny represents the wildcard version of the /enum-module/b-lists/b-list YANG schema element.
 type BListPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty BList for the path "/enum-module/b-lists/b-list".
+func (n *BListPath) PathAndStruct() (*BListPath, *BList) {
+	return n, &BList{}
 }
 
 // BList_ValuePath represents the /enum-module/b-lists/b-list/state/value YANG schema element.
@@ -108,6 +118,11 @@ type CPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty C for the path "/enum-module/c".
+func (n *CPath) PathAndStruct() (*CPath, *C) {
+	return n, &C{}
+}
+
 // C_ClPath represents the /enum-module/c/cl YANG schema element.
 type C_ClPath struct {
 	*ygot.NodePath
@@ -148,6 +163,11 @@ type DevicePath struct {
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
+}
+
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
 }
 
 // AListAny returns from DevicePath the path struct for its child "a-list".
@@ -228,6 +248,11 @@ type ParentPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Parent for the path "/enum-module/parent".
+func (n *ParentPath) PathAndStruct() (*ParentPath, *Parent) {
+	return n, &Parent{}
+}
+
 // Child returns from ParentPath the path struct for its child "child".
 func (n *ParentPath) Child() *Parent_ChildPath {
 	return &Parent_ChildPath{
@@ -258,6 +283,11 @@ type Parent_ChildPath struct {
 // Parent_ChildPathAny represents the wildcard version of the /enum-module/parent/child YANG schema element.
 type Parent_ChildPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Parent_Child for the path "/enum-module/parent/child".
+func (n *Parent_ChildPath) PathAndStruct() (*Parent_ChildPath, *Parent_Child) {
+	return n, &Parent_Child{}
 }
 
 // Parent_Child_EnumPath represents the /enum-module/parent/child/state/enum YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -26,6 +26,11 @@ func DeviceRoot(id string) *Device {
 	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty oc.Device for the path "/device".
+func (n *Device) PathAndStruct() (*Device, *oc.Device) {
+	return n, &oc.Device{}
+}
+
 // Native returns from Device the path struct for its child "native".
 func (n *Device) Native() *Native {
 	return &Native{
@@ -56,6 +61,11 @@ type Native struct {
 // NativeAny represents the wildcard version of the /openconfig-simple-target/native YANG schema element.
 type NativeAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.Native for the path "/openconfig-simple-target/native".
+func (n *Native) PathAndStruct() (*Native, *oc.Native) {
+	return n, &oc.Native{}
 }
 
 // Native_A represents the /openconfig-simple-target/native/state/a YANG schema element.
@@ -100,6 +110,11 @@ type TargetAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.Target for the path "/openconfig-simple-target/target".
+func (n *Target) PathAndStruct() (*Target, *oc.Target) {
+	return n, &oc.Target{}
+}
+
 // Foo returns from Target the path struct for its child "foo".
 func (n *Target) Foo() *Target_Foo {
 	return &Target_Foo{
@@ -130,6 +145,11 @@ type Target_Foo struct {
 // Target_FooAny represents the wildcard version of the /openconfig-simple-target/target/foo YANG schema element.
 type Target_FooAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.Target_Foo for the path "/openconfig-simple-target/target/foo".
+func (n *Target_Foo) PathAndStruct() (*Target_Foo, *oc.Target_Foo) {
+	return n, &oc.Target_Foo{}
 }
 
 // Target_Foo_A represents the /openconfig-simple-target/target/foo/state/a YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-camelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase.path-txt
@@ -24,6 +24,11 @@ type BGPPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty BGP for the path "/openconfig-camelcase/bgp".
+func (n *BGPPath) PathAndStruct() (*BGPPath, *BGP) {
+	return n, &BGP{}
+}
+
 // NeighborAny returns from BGPPath the path struct for its child "neighbor".
 func (n *BGPPath) NeighborAny() *BGP_NeighborPathAny {
 	return &BGP_NeighborPathAny{
@@ -80,6 +85,11 @@ type BGP_NeighborPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty BGP_Neighbor for the path "/openconfig-camelcase/bgp/neighbors/neighbor".
+func (n *BGP_NeighborPath) PathAndStruct() (*BGP_NeighborPath, *BGP_Neighbor) {
+	return n, &BGP_Neighbor{}
+}
+
 // BGP_Neighbor_PeerIPPath represents the /openconfig-camelcase/bgp/neighbors/neighbor/state/peer-ip YANG schema element.
 type BGP_Neighbor_PeerIPPath struct {
 	*ygot.NodePath
@@ -120,6 +130,11 @@ type DevicePath struct {
 // DeviceRoot returns a new path object from which YANG paths can be constructed.
 func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
+}
+
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
 }
 
 // BGP returns from DevicePath the path struct for its child "bgp".

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Foo returns from DevicePath the path struct for its child "foo".
 func (n *DevicePath) Foo() *FooPath {
 	return &FooPath{
@@ -43,6 +48,11 @@ type FooPath struct {
 // FooPathAny represents the wildcard version of the /openconfig-enumcamelcase/foo YANG schema element.
 type FooPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Foo for the path "/openconfig-enumcamelcase/foo".
+func (n *FooPath) PathAndStruct() (*FooPath, *Foo) {
+	return n, &Foo{}
 }
 
 // Foo_BarPath represents the /openconfig-enumcamelcase/foo/bar YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-simple-0.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-0.path-txt
@@ -25,6 +25,11 @@ func DeviceRoot(id string) *Device {
 	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty oc.Device for the path "/device".
+func (n *Device) PathAndStruct() (*Device, *oc.Device) {
+	return n, &oc.Device{}
+}
+
 // Parent returns from Device the path struct for its child "parent".
 func (n *Device) Parent() *Parent {
 	return &Parent{
@@ -55,6 +60,11 @@ type Parent struct {
 // ParentAny represents the wildcard version of the /openconfig-simple/parent YANG schema element.
 type ParentAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.Parent for the path "/openconfig-simple/parent".
+func (n *Parent) PathAndStruct() (*Parent, *oc.Parent) {
+	return n, &oc.Parent{}
 }
 
 // Child returns from Parent the path struct for its child "child".

--- a/ypathgen/testdata/structs/openconfig-simple-1.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-1.path-txt
@@ -25,6 +25,11 @@ type Parent_ChildAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_Child) PathAndStruct() (*Parent_Child, *oc.Parent_Child) {
+	return n, &oc.Parent_Child{}
+}
+
 // Parent_Child_Four represents the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_Four struct {
 	*ygot.NodePath
@@ -161,6 +166,11 @@ type RemoteContainer struct {
 // RemoteContainerAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainerAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainer) PathAndStruct() (*RemoteContainer, *oc.RemoteContainer) {
+	return n, &oc.RemoteContainer{}
 }
 
 // RemoteContainer_ALeaf represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-simple-30.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-30.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Parent returns from DevicePath the path struct for its child "parent".
 func (n *DevicePath) Parent() *ParentPath {
 	return &ParentPath{
@@ -54,6 +59,11 @@ type ParentPath struct {
 // ParentPathAny represents the wildcard version of the /openconfig-simple/parent YANG schema element.
 type ParentPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Parent for the path "/openconfig-simple/parent".
+func (n *ParentPath) PathAndStruct() (*ParentPath, *Parent) {
+	return n, &Parent{}
 }
 
 // Child returns from ParentPath the path struct for its child "child".

--- a/ypathgen/testdata/structs/openconfig-simple-31.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-31.path-txt
@@ -24,6 +24,11 @@ type Parent_ChildPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_ChildPath) PathAndStruct() (*Parent_ChildPath, *Parent_Child) {
+	return n, &Parent_Child{}
+}
+
 // Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_FourPath struct {
 	*ygot.NodePath
@@ -160,6 +165,11 @@ type RemoteContainerPath struct {
 // RemoteContainerPathAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainerPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainerPath) PathAndStruct() (*RemoteContainerPath, *RemoteContainer) {
+	return n, &RemoteContainer{}
 }
 
 // RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-simple-40.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-40.path-txt
@@ -25,6 +25,11 @@ func DeviceRoot(id string) *Device {
 	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty oc.Device for the path "/device".
+func (n *Device) PathAndStruct() (*Device, *oc.Device) {
+	return n, &oc.Device{}
+}
+
 // Parent returns from Device the path struct for its child "parent".
 func (n *Device) Parent() *Parent {
 	return &Parent{

--- a/ypathgen/testdata/structs/openconfig-simple-41.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-41.path-txt
@@ -25,6 +25,11 @@ type ParentAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.Parent for the path "/openconfig-simple/parent".
+func (n *Parent) PathAndStruct() (*Parent, *oc.Parent) {
+	return n, &oc.Parent{}
+}
+
 // Child returns from Parent the path struct for its child "child".
 func (n *Parent) Child() *Parent_Child {
 	return &Parent_Child{

--- a/ypathgen/testdata/structs/openconfig-simple-42.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-42.path-txt
@@ -25,6 +25,11 @@ type Parent_ChildAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_Child) PathAndStruct() (*Parent_Child, *oc.Parent_Child) {
+	return n, &oc.Parent_Child{}
+}
+
 // Parent_Child_Four represents the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_Four struct {
 	*ygot.NodePath

--- a/ypathgen/testdata/structs/openconfig-simple-43.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-43.path-txt
@@ -25,6 +25,11 @@ type RemoteContainerAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainer) PathAndStruct() (*RemoteContainer, *oc.RemoteContainer) {
+	return n, &oc.RemoteContainer{}
+}
+
 // RemoteContainer_ALeaf represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
 type RemoteContainer_ALeaf struct {
 	*ygot.NodePath

--- a/ypathgen/testdata/structs/openconfig-simple-excludestate.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-excludestate.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Parent returns from DevicePath the path struct for its child "parent".
 func (n *DevicePath) Parent() *ParentPath {
 	return &ParentPath{
@@ -56,6 +61,11 @@ type ParentPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Parent for the path "/openconfig-simple/parent".
+func (n *ParentPath) PathAndStruct() (*ParentPath, *Parent) {
+	return n, &Parent{}
+}
+
 // Child returns from ParentPath the path struct for its child "child".
 func (n *ParentPath) Child() *Parent_ChildPath {
 	return &Parent_ChildPath{
@@ -86,6 +96,11 @@ type Parent_ChildPath struct {
 // Parent_ChildPathAny represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
 type Parent_ChildPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_ChildPath) PathAndStruct() (*Parent_ChildPath, *Parent_Child) {
+	return n, &Parent_Child{}
 }
 
 // Parent_Child_FourPath represents the /openconfig-simple/parent/child/config/four YANG schema element.
@@ -192,6 +207,11 @@ type RemoteContainerPath struct {
 // RemoteContainerPathAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainerPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainerPath) PathAndStruct() (*RemoteContainerPath, *RemoteContainer) {
+	return n, &RemoteContainer{}
 }
 
 // RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/config/a-leaf YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple-intendedconfig.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Parent returns from DevicePath the path struct for its child "parent".
 func (n *DevicePath) Parent() *ParentPath {
 	return &ParentPath{
@@ -56,6 +61,11 @@ type ParentPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Parent for the path "/openconfig-simple/parent".
+func (n *ParentPath) PathAndStruct() (*ParentPath, *Parent) {
+	return n, &Parent{}
+}
+
 // Child returns from ParentPath the path struct for its child "child".
 func (n *ParentPath) Child() *Parent_ChildPath {
 	return &Parent_ChildPath{
@@ -86,6 +96,11 @@ type Parent_ChildPath struct {
 // Parent_ChildPathAny represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
 type Parent_ChildPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_ChildPath) PathAndStruct() (*Parent_ChildPath, *Parent_Child) {
+	return n, &Parent_Child{}
 }
 
 // Parent_Child_FourPath represents the /openconfig-simple/parent/child/config/four YANG schema element.
@@ -224,6 +239,11 @@ type RemoteContainerPath struct {
 // RemoteContainerPathAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainerPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainerPath) PathAndStruct() (*RemoteContainerPath, *RemoteContainer) {
+	return n, &RemoteContainer{}
 }
 
 // RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/config/a-leaf YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Parent returns from DevicePath the path struct for its child "parent".
 func (n *DevicePath) Parent() *ParentPath {
 	return &ParentPath{
@@ -56,6 +61,11 @@ type ParentPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Parent for the path "/openconfig-simple/parent".
+func (n *ParentPath) PathAndStruct() (*ParentPath, *Parent) {
+	return n, &Parent{}
+}
+
 // Child returns from ParentPath the path struct for its child "child".
 func (n *ParentPath) Child() *Parent_ChildPath {
 	return &Parent_ChildPath{
@@ -86,6 +96,11 @@ type Parent_ChildPath struct {
 // Parent_ChildPathAny represents the wildcard version of the /openconfig-simple/parent/child YANG schema element.
 type Parent_ChildPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Parent_Child for the path "/openconfig-simple/parent/child".
+func (n *Parent_ChildPath) PathAndStruct() (*Parent_ChildPath, *Parent_Child) {
+	return n, &Parent_Child{}
 }
 
 // Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
@@ -224,6 +239,11 @@ type RemoteContainerPath struct {
 // RemoteContainerPathAny represents the wildcard version of the /openconfig-simple/remote-container YANG schema element.
 type RemoteContainerPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty RemoteContainer for the path "/openconfig-simple/remote-container".
+func (n *RemoteContainerPath) PathAndStruct() (*RemoteContainerPath, *RemoteContainer) {
+	return n, &RemoteContainer{}
 }
 
 // RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // DupEnum returns from DevicePath the path struct for its child "dup-enum".
 func (n *DevicePath) DupEnum() *DupEnumPath {
 	return &DupEnumPath{
@@ -54,6 +59,11 @@ type DupEnumPath struct {
 // DupEnumPathAny represents the wildcard version of the /openconfig-unione/dup-enum YANG schema element.
 type DupEnumPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty DupEnum for the path "/openconfig-unione/dup-enum".
+func (n *DupEnumPath) PathAndStruct() (*DupEnumPath, *DupEnum) {
+	return n, &DupEnum{}
 }
 
 // DupEnum_APath represents the /openconfig-unione/dup-enum/state/A YANG schema element.
@@ -130,6 +140,11 @@ type PlatformPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Platform for the path "/openconfig-unione/platform".
+func (n *PlatformPath) PathAndStruct() (*PlatformPath, *Platform) {
+	return n, &Platform{}
+}
+
 // Component returns from PlatformPath the path struct for its child "component".
 func (n *PlatformPath) Component() *Platform_ComponentPath {
 	return &Platform_ComponentPath{
@@ -160,6 +175,11 @@ type Platform_ComponentPath struct {
 // Platform_ComponentPathAny represents the wildcard version of the /openconfig-unione/platform/component YANG schema element.
 type Platform_ComponentPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Platform_Component for the path "/openconfig-unione/platform/component".
+func (n *Platform_ComponentPath) PathAndStruct() (*Platform_ComponentPath, *Platform_Component) {
+	return n, &Platform_Component{}
 }
 
 // Platform_Component_E1Path represents the /openconfig-unione/platform/component/state/e1 YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-builder.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Model returns from DevicePath the path struct for its child "model".
 func (n *DevicePath) Model() *ModelPath {
 	return &ModelPath{
@@ -43,6 +48,11 @@ type ModelPath struct {
 // ModelPathAny represents the wildcard version of the /openconfig-withlist/model YANG schema element.
 type ModelPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model for the path "/openconfig-withlist/model".
+func (n *ModelPath) PathAndStruct() (*ModelPath, *Model) {
+	return n, &Model{}
 }
 
 // MultiKeyAny returns from ModelPath the path struct for its child "multi-key".
@@ -137,6 +147,11 @@ type Model_MultiKeyPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Model_MultiKey for the path "/openconfig-withlist/model/b/multi-key".
+func (n *Model_MultiKeyPath) PathAndStruct() (*Model_MultiKeyPath, *Model_MultiKey) {
+	return n, &Model_MultiKey{}
+}
+
 // Model_MultiKey_Key1Path represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
 type Model_MultiKey_Key1Path struct {
 	*ygot.NodePath
@@ -209,6 +224,11 @@ type Model_SingleKeyPath struct {
 // Model_SingleKeyPathAny represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKeyPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model_SingleKey for the path "/openconfig-withlist/model/a/single-key".
+func (n *Model_SingleKeyPath) PathAndStruct() (*Model_SingleKeyPath, *Model_SingleKey) {
+	return n, &Model_SingleKey{}
 }
 
 // Model_SingleKey_KeyPath represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-withlist-nowildcard.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-nowildcard.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Model returns from DevicePath the path struct for its child "model".
 func (n *DevicePath) Model() *ModelPath {
 	return &ModelPath{
@@ -38,6 +43,11 @@ func (n *DevicePath) Model() *ModelPath {
 // ModelPath represents the /openconfig-withlist/model YANG schema element.
 type ModelPath struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model for the path "/openconfig-withlist/model".
+func (n *ModelPath) PathAndStruct() (*ModelPath, *Model) {
+	return n, &Model{}
 }
 
 // MultiKey returns from ModelPath the path struct for its child "multi-key".
@@ -68,6 +78,11 @@ func (n *ModelPath) SingleKey(Key string) *Model_SingleKeyPath {
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model_MultiKey for the path "/openconfig-withlist/model/b/multi-key".
+func (n *Model_MultiKeyPath) PathAndStruct() (*Model_MultiKeyPath, *Model_MultiKey) {
+	return n, &Model_MultiKey{}
 }
 
 // Model_MultiKey_Key1Path represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
@@ -105,6 +120,11 @@ func (n *Model_MultiKeyPath) Key2() *Model_MultiKey_Key2Path {
 // Model_SingleKeyPath represents the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKeyPath struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model_SingleKey for the path "/openconfig-withlist/model/a/single-key".
+func (n *Model_SingleKeyPath) PathAndStruct() (*Model_SingleKeyPath, *Model_SingleKey) {
+	return n, &Model_SingleKey{}
 }
 
 // Model_SingleKey_KeyPath represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
@@ -25,6 +25,11 @@ func DeviceRoot(id string) *Device {
 	return &Device{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty oc.Device for the path "/device".
+func (n *Device) PathAndStruct() (*Device, *oc.Device) {
+	return n, &oc.Device{}
+}
+
 // Model returns from Device the path struct for its child "model".
 func (n *Device) Model() *Model {
 	return &Model{
@@ -44,6 +49,11 @@ type Model struct {
 // ModelAny represents the wildcard version of the /openconfig-withlist/model YANG schema element.
 type ModelAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.Model for the path "/openconfig-withlist/model".
+func (n *Model) PathAndStruct() (*Model, *oc.Model) {
+	return n, &oc.Model{}
 }
 
 // MultiKeyAny returns from Model the path struct for its child "multi-key".
@@ -198,6 +208,11 @@ type Model_MultiKeyAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty oc.Model_MultiKey for the path "/openconfig-withlist/model/b/multi-key".
+func (n *Model_MultiKey) PathAndStruct() (*Model_MultiKey, *oc.Model_MultiKey) {
+	return n, &oc.Model_MultiKey{}
+}
+
 // Model_MultiKey_Key1 represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
 type Model_MultiKey_Key1 struct {
 	*ygot.NodePath
@@ -270,6 +285,11 @@ type Model_SingleKey struct {
 // Model_SingleKeyAny represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKeyAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty oc.Model_SingleKey for the path "/openconfig-withlist/model/a/single-key".
+func (n *Model_SingleKey) PathAndStruct() (*Model_SingleKey, *oc.Model_SingleKey) {
+	return n, &oc.Model_SingleKey{}
 }
 
 // Model_SingleKey_Key represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-withlist-simplifyallwc.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-simplifyallwc.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Model returns from DevicePath the path struct for its child "model".
 func (n *DevicePath) Model() *ModelPath {
 	return &ModelPath{
@@ -43,6 +48,11 @@ type ModelPath struct {
 // ModelPathAny represents the wildcard version of the /openconfig-withlist/model YANG schema element.
 type ModelPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model for the path "/openconfig-withlist/model".
+func (n *ModelPath) PathAndStruct() (*ModelPath, *Model) {
+	return n, &Model{}
 }
 
 // MultiKeyAny returns from ModelPath the path struct for its child "multi-key".
@@ -197,6 +207,11 @@ type Model_MultiKeyPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Model_MultiKey for the path "/openconfig-withlist/model/b/multi-key".
+func (n *Model_MultiKeyPath) PathAndStruct() (*Model_MultiKeyPath, *Model_MultiKey) {
+	return n, &Model_MultiKey{}
+}
+
 // Model_MultiKey_Key1Path represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
 type Model_MultiKey_Key1Path struct {
 	*ygot.NodePath
@@ -269,6 +284,11 @@ type Model_SingleKeyPath struct {
 // Model_SingleKeyPathAny represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKeyPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model_SingleKey for the path "/openconfig-withlist/model/a/single-key".
+func (n *Model_SingleKeyPath) PathAndStruct() (*Model_SingleKeyPath, *Model_SingleKey) {
+	return n, &Model_SingleKey{}
 }
 
 // Model_SingleKey_KeyPath represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -24,6 +24,11 @@ func DeviceRoot(id string) *DevicePath {
 	return &DevicePath{ygot.NewDeviceRootBase(id)}
 }
 
+// PathAndStruct returns the path struct and an empty Device for the path "/device".
+func (n *DevicePath) PathAndStruct() (*DevicePath, *Device) {
+	return n, &Device{}
+}
+
 // Model returns from DevicePath the path struct for its child "model".
 func (n *DevicePath) Model() *ModelPath {
 	return &ModelPath{
@@ -43,6 +48,11 @@ type ModelPath struct {
 // ModelPathAny represents the wildcard version of the /openconfig-withlist/model YANG schema element.
 type ModelPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model for the path "/openconfig-withlist/model".
+func (n *ModelPath) PathAndStruct() (*ModelPath, *Model) {
+	return n, &Model{}
 }
 
 // MultiKeyAny returns from ModelPath the path struct for its child "multi-key".
@@ -197,6 +207,11 @@ type Model_MultiKeyPathAny struct {
 	*ygot.NodePath
 }
 
+// PathAndStruct returns the path struct and an empty Model_MultiKey for the path "/openconfig-withlist/model/b/multi-key".
+func (n *Model_MultiKeyPath) PathAndStruct() (*Model_MultiKeyPath, *Model_MultiKey) {
+	return n, &Model_MultiKey{}
+}
+
 // Model_MultiKey_Key1Path represents the /openconfig-withlist/model/b/multi-key/state/key1 YANG schema element.
 type Model_MultiKey_Key1Path struct {
 	*ygot.NodePath
@@ -269,6 +284,11 @@ type Model_SingleKeyPath struct {
 // Model_SingleKeyPathAny represents the wildcard version of the /openconfig-withlist/model/a/single-key YANG schema element.
 type Model_SingleKeyPathAny struct {
 	*ygot.NodePath
+}
+
+// PathAndStruct returns the path struct and an empty Model_SingleKey for the path "/openconfig-withlist/model/a/single-key".
+func (n *Model_SingleKeyPath) PathAndStruct() (*Model_SingleKeyPath, *Model_SingleKey) {
+	return n, &Model_SingleKey{}
 }
 
 // Model_SingleKey_KeyPath represents the /openconfig-withlist/model/a/single-key/state/key YANG schema element.


### PR DESCRIPTION
A common use case is where a user would like to construct a path and populate its corresponding `GoStruct` at the same time. This helper obviates the need to retrieve the struct using the `GetOrCreateXXX` functions on top of using the path API.

#### Example
```
p, addr := pathAPI.Interface("Ethernet0").Subinterface(0).Ipv4().Address("10.10.10.10").PathAndStruct()
addr.PrefixLength = ygot.Uint8(24)
```

This is not generated for leaves, since their types can be accessed using `ygot` helper functions such as `ygot.Int32()`.