### PR TITLE
Add Go 1.16 to CI testing.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15']
+        go: ['1.13', '1.14', '1.15', '1.16']
 
     steps:
       - name: Install protobuf

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16']
+        go: ['1.13', '1.14', '1.15', '1.16', '1.x']
 
     steps:
       - name: Install protobuf


### PR DESCRIPTION
Increase coverage to include go1.16.

Going forward, it'd be great to figure out whether there's a go-latest or similar
such that we can include that. Although we say that we support $latest-3 versions,
I think it'd be nice to just keep testing until such time as we find a reason to
need to deprecate the oldest version.

Thoughts?﻿
