### PR TITLE
Add initial implementation of unmarshalling gNMI Notifications->pb.

### DIFF
--- a/protomap/proto.go
+++ b/protomap/proto.go
@@ -429,6 +429,7 @@ func makeWrapper(msg protoreflect.Message, fd protoreflect.FieldDescriptor, val 
 			return nil, false, fmt.Errorf("got non-string value for string field, field: %s, value: %v", fd.FullName(), val)
 		}
 		return (&wpb.StringValue{Value: nsv}).ProtoReflect(), true, nil
+	default:
+		return nil, false, nil
 	}
-	return nil, false, nil
 }

--- a/protomap/proto.go
+++ b/protomap/proto.go
@@ -360,25 +360,24 @@ func resolvedPath(basePath, annotatedPath *gpb.Path) *gpb.Path {
 	return np
 }
 
-// ProtoFromPaths takes an input proto.Message and adds the values that are specified in the map vals to
-// it, using basePath as the prefix to any paths within the vals map. The message, p, is modified in place.
-// The map, vals, is keyed by the gNMI path to the field which is annotated in the ygot generated protobuf,
-// the complete path is taken to be basePath + the key found in the map.
-func ProtoFromPaths(p proto.Message, vals map[*gpb.Path]interface{}, basePath *gpb.Path) error {
-	m := p.ProtoReflect()
+// ProtoFromPaths takes an input ygot-generated protobuf and unmarshals the values that are specified in the map
+// vals into it, using prefix as the prefix to any paths within the vals map. The message, p, is modified in place.
+// The map, vals, must be keyed by the gNMI path to the field which is annotated in the ygot generated protobuf,
+// the complete path is taken to be prefix + the key found in the map.
+func ProtoFromPaths(p proto.Message, vals map[*gpb.Path]interface{}, prefix *gpb.Path) error {
+	if p == nil {
+		return errors.New("nil protobuf supplied")
+	}
 
 	directCh := map[*gpb.Path]interface{}{}
 	for p, v := range vals {
 		// TODO(robjs): needs fixing for compressed schemas.
-		l := 0
-		if basePath != nil {
-			l = len(basePath.Elem)
-		}
-		if len(p.Elem) == l+1 {
+		if len(p.GetElem()) == len(prefix.GetElem())+1 {
 			directCh[p] = v
 		}
 	}
 
+	m := p.ProtoReflect()
 	var rangeErr error
 	unpopRange{m}.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		annotatedPath, err := annotatedSchemaPath(fd)
@@ -399,7 +398,7 @@ func ProtoFromPaths(p proto.Message, vals map[*gpb.Path]interface{}, basePath *g
 						if !isWrap {
 							// TODO(robjs): recurse into the message if it wasn't a wrapper
 							// type.
-							rangeErr = errors.New("unimplemented: child messages")
+							rangeErr = fmt.Errorf("unimplemented: child messages, field %s", fd.FullName())
 							return false
 						}
 						m.Set(fd, protoreflect.ValueOfMessage(v))
@@ -417,7 +416,7 @@ func ProtoFromPaths(p proto.Message, vals map[*gpb.Path]interface{}, basePath *g
 	return nil
 }
 
-// makeWrapper generates a new message for field fd of the proto message m with the value set to val.
+// makeWrapper generates a new message for field fd of the proto message msg with the value set to val.
 // The field fd must describe a field that has a message type. An error is returned if the wrong
 // type of payload is provided for the message. The second, boolean, return argument specifies whether
 // the message provided was a known wrapper type.

--- a/protomap/proto_test.go
+++ b/protomap/proto_test.go
@@ -290,15 +290,18 @@ func TestPathsFromProtoInternal(t *testing.T) {
 	}
 }
 
-func TestProtoFromPathsInternal(t *testing.T) {
+func TestProtoFromPaths(t *testing.T) {
 	tests := []struct {
 		desc             string
 		inProto          proto.Message
 		inVals           map[*gpb.Path]interface{}
-		inBasePath       *gpb.Path
+		inPrefix         *gpb.Path
 		wantProto        proto.Message
 		wantErrSubstring string
 	}{{
+		desc:             "nil proto",
+		wantErrSubstring: "nil protobuf",
+	}, {
 		desc:    "string field",
 		inProto: &epb.ExampleMessage{},
 		inVals: map[*gpb.Path]interface{}{
@@ -321,11 +324,18 @@ func TestProtoFromPathsInternal(t *testing.T) {
 			mustPath("/message"): &gpb.Path{},
 		},
 		wantErrSubstring: "unimplemented",
+	}, {
+		desc:    "field that is not directly a child",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]interface{}{
+			mustPath("/one/two/three"): "ignored",
+		},
+		wantProto: &epb.ExampleMessage{},
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			err := ProtoFromPaths(tt.inProto, tt.inVals, tt.inBasePath)
+			err := ProtoFromPaths(tt.inProto, tt.inVals, tt.inPrefix)
 			if err != nil {
 				if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
 					t.Fatalf("did not get expected error, %s", diff)

--- a/protomap/proto_test.go
+++ b/protomap/proto_test.go
@@ -289,3 +289,53 @@ func TestPathsFromProtoInternal(t *testing.T) {
 		})
 	}
 }
+
+func TestProtoFromPathsInternal(t *testing.T) {
+	tests := []struct {
+		desc             string
+		inProto          proto.Message
+		inVals           map[*gpb.Path]interface{}
+		inBasePath       *gpb.Path
+		wantProto        proto.Message
+		wantErrSubstring string
+	}{{
+		desc:    "string field",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]interface{}{
+			mustPath("/string"): "hello",
+		},
+		wantProto: &epb.ExampleMessage{
+			Str: &wpb.StringValue{Value: "hello"},
+		},
+	}, {
+		desc:    "wrong field type",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]interface{}{
+			mustPath("/string"): 42,
+		},
+		wantErrSubstring: "got non-string value for string field",
+	}, {
+		desc:    "not a wrapper message",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]interface{}{
+			mustPath("/message"): &gpb.Path{},
+		},
+		wantErrSubstring: "unimplemented",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := ProtoFromPaths(tt.inProto, tt.inVals, tt.inBasePath)
+			if err != nil {
+				if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+					t.Fatalf("did not get expected error, %s", diff)
+				}
+				return
+			}
+
+			if diff := cmp.Diff(tt.inProto, tt.wantProto, protocmp.Transform()); diff != "" {
+				t.Fatalf("did not get expected results, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
``` 
 * (M) proto/proto.go
 * (M) proto/proto_test.go
  - Add support for unmarshalling a map of gNMI.Path->value into
    a ygot-generated protobuf. This is done by ranging over the
    protobuf message and using the annotated paths.
  - Initial implementation just supporting string type.
```

This implementation just handles a simple string type, but TypedValue is to be added later such that we can do this directly from gNMI Notifications.

This change starts to implement the 2nd half of the pipeline of:

(new, this PR) `GoStruct->gNMI Notifications->Protobuf`
 - GoStruct -> gNMI Notifications is `ygot.TogNMINotifications`
 - gNMI Notifications -> Protobuf is `protomap.PathsFromProto`

GoStruct<-gNMI Notifications<-Protobuf
 - Protobuf <- gNMI Notifications is this code.
 - GoStruct <- gNMI Notifications is `ytypes.SetNode`
