### PR TITLE
Hide EscapeHTML behind an option instead of default behaviour.

### DIFF
--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -631,11 +631,23 @@ func TestEmitJSON(t *testing.T) {
 		name: "simple schema JSON output",
 		inStruct: &mapStructTestOne{
 			Child: &mapStructTestOneChild{
-				FieldOne: String("hello"),
+				FieldOne: String("abc -> def"),
 				FieldTwo: Uint32(42),
 			},
 		},
 		wantJSONPath: filepath.Join(TestRoot, "testdata/emitjson_1.json-txt"),
+	}, {
+		name: "simple schema JSON output with safe HTML",
+		inStruct: &mapStructTestOne{
+			Child: &mapStructTestOneChild{
+				FieldOne: String("abc -> def"),
+				FieldTwo: Uint32(42),
+			},
+		},
+		inConfig: &EmitJSONConfig{
+			EscapeHTML: true,
+		},
+		wantJSONPath: filepath.Join(TestRoot, "testdata/emitjson_1_html_safe.json-txt"),
 	}, {
 		name: "schema with a list JSON output",
 		inStruct: &mapStructTestFour{

--- a/ygot/testdata/emitjson_1_html_safe.json-txt
+++ b/ygot/testdata/emitjson_1_html_safe.json-txt
@@ -1,7 +1,7 @@
 {
    "child": {
       "config": {
-         "field-one": "abc -> def",
+         "field-one": "abc -\u003e def",
          "field-two": 42
       }
    }


### PR DESCRIPTION
Alternatively I can remove this option altogether, let me know, I'm fine either way.