### PR TITLE
add GoPackage to NodeData

### DIFF
--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -288,7 +288,7 @@ func (cg *GenConfig) GeneratePathCode(yangFiles, includePaths []string) (map[str
 				HasDefault:            false,
 				YANGTypeName:          "",
 				YANGPath:              "/",
-				GoPackage:             goPackageName(directory, cg.SplitByModule, cg.TrimOCPackage, cg.PackageName),
+				GoPathPackageName:     goPackageName(directory, cg.SplitByModule, cg.TrimOCPackage, cg.PackageName),
 			}
 		}
 
@@ -486,8 +486,8 @@ type NodeData struct {
 	YANGTypeName string
 	// YANGPath is the schema path of the YANG node.
 	YANGPath string
-	// GoPackage is the Go package name of a schema node.
-	GoPackage string
+	// GoPathPackageName is the Go package name containing the generated PathStruct for the schema node.
+	GoPathPackageName string
 }
 
 // GetOrderedNodeDataNames returns the alphabetically-sorted slice of keys
@@ -619,8 +619,8 @@ func mustTemplate(name, src string) *template.Template {
 // schema field names of that directory entry (i.e. the same keys as the
 // "Fields" map of the Directory entry). Since ygen provides a *MappedType for
 // every leaf node only, leafTypeMap's value is nil for non-leaf nodes.
-// packageName, splitByModule, and trimOCPackage are used to generate the name of
-// Go package for each output node.
+// packageName, splitByModule, and trimOCPackage are used to determine
+// the generated Go package name for the generated PathStructs.
 // If a directory or field doesn't exist in the leafTypeMap, then an error is returned.
 // Note: Top-level nodes, but *not* the fake root, are part of the output.
 func getNodeDataMap(directories map[string]*ygen.Directory, leafTypeMap map[string]map[string]*ygen.MappedType, schemaStructPkgAccessor, pathStructSuffix, packageName string, splitByModule, trimOCPackage bool) (NodeDataMap, util.Errors) {
@@ -686,7 +686,7 @@ func getNodeDataMap(directories map[string]*ygen.Directory, leafTypeMap map[stri
 				HasDefault:            isLeaf && (field.Default != "" || mType.DefaultValue != nil),
 				YANGTypeName:          yangTypeName,
 				YANGPath:              field.Path(),
-				GoPackage:             goPackageName(dir, splitByModule, trimOCPackage, packageName),
+				GoPathPackageName:     goPackageName(dir, splitByModule, trimOCPackage, packageName),
 			}
 		}
 	}

--- a/ypathgen/pathgen.go
+++ b/ypathgen/pathgen.go
@@ -261,7 +261,7 @@ func (cg *GenConfig) GeneratePathCode(yangFiles, includePaths []string) (map[str
 	}
 
 	// Get NodeDataMap for the schema.
-	nodeDataMap, es := getNodeDataMap(directories, leafTypeMap, schemaStructPkgAccessor, cg.PathStructSuffix)
+	nodeDataMap, es := getNodeDataMap(directories, leafTypeMap, schemaStructPkgAccessor, cg.PathStructSuffix, cg.PackageName, cg.SplitByModule, cg.TrimOCPackage)
 	if es != nil {
 		errs = util.AppendErrs(errs, es)
 	}
@@ -288,6 +288,7 @@ func (cg *GenConfig) GeneratePathCode(yangFiles, includePaths []string) (map[str
 				HasDefault:            false,
 				YANGTypeName:          "",
 				YANGPath:              "/",
+				GoPackage:             goPackageName(directory, cg.SplitByModule, cg.TrimOCPackage, cg.PackageName),
 			}
 		}
 
@@ -485,6 +486,8 @@ type NodeData struct {
 	YANGTypeName string
 	// YANGPath is the schema path of the YANG node.
 	YANGPath string
+	// GoPackage is the Go package name of a schema node.
+	GoPackage string
 }
 
 // GetOrderedNodeDataNames returns the alphabetically-sorted slice of keys
@@ -616,9 +619,11 @@ func mustTemplate(name, src string) *template.Template {
 // schema field names of that directory entry (i.e. the same keys as the
 // "Fields" map of the Directory entry). Since ygen provides a *MappedType for
 // every leaf node only, leafTypeMap's value is nil for non-leaf nodes.
+// packageName, splitByModule, and trimOCPackage are used to generate the name of
+// Go package for each output node.
 // If a directory or field doesn't exist in the leafTypeMap, then an error is returned.
 // Note: Top-level nodes, but *not* the fake root, are part of the output.
-func getNodeDataMap(directories map[string]*ygen.Directory, leafTypeMap map[string]map[string]*ygen.MappedType, schemaStructPkgAccessor, pathStructSuffix string) (NodeDataMap, util.Errors) {
+func getNodeDataMap(directories map[string]*ygen.Directory, leafTypeMap map[string]map[string]*ygen.MappedType, schemaStructPkgAccessor, pathStructSuffix, packageName string, splitByModule, trimOCPackage bool) (NodeDataMap, util.Errors) {
 	nodeDataMap := NodeDataMap{}
 	var errs util.Errors
 	for path, dir := range directories {
@@ -681,6 +686,7 @@ func getNodeDataMap(directories map[string]*ygen.Directory, leafTypeMap map[stri
 				HasDefault:            isLeaf && (field.Default != "" || mType.DefaultValue != nil),
 				YANGTypeName:          yangTypeName,
 				YANGPath:              field.Path(),
+				GoPackage:             goPackageName(dir, splitByModule, trimOCPackage, packageName),
 			}
 		}
 	}

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -87,6 +87,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -97,6 +98,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -107,6 +109,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent/child",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -118,6 +121,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "binary",
 				YANGPath:              "/openconfig-simple/parent/child/state/four",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -129,6 +133,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/one",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -140,6 +145,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
 				YANGPath:              "/openconfig-simple/parent/child/state/three",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -151,6 +157,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/two",
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -161,6 +168,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/remote-container",
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -172,6 +180,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/remote-container/state/a-leaf",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with preferOperationalState=false",
@@ -188,6 +197,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -197,6 +207,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -206,6 +217,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -216,6 +228,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -226,6 +239,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -236,6 +250,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -246,6 +261,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -255,6 +271,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -265,6 +282,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with excludeState=true",
@@ -282,6 +300,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -291,6 +310,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -300,6 +320,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -310,6 +331,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -320,6 +342,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -330,6 +353,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -339,6 +363,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -349,6 +374,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with list",
@@ -418,6 +444,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -427,6 +454,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_DupEnum_A",
@@ -437,6 +465,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_DupEnum_B",
@@ -447,6 +476,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -456,6 +486,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -465,6 +496,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -475,6 +507,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -485,6 +518,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -495,6 +529,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -505,6 +540,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -515,6 +551,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                     "simple openconfig test with union & typedef & identity & enum, with enum names not shortened",
@@ -530,6 +567,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -539,6 +577,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_A",
@@ -549,6 +588,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_B",
@@ -559,6 +599,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -568,6 +609,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -577,6 +619,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -587,6 +630,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -597,6 +641,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -607,6 +652,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -617,6 +663,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
+				GoPackage:             "ocpathstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -627,6 +674,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with submodule and union list key",
@@ -644,6 +692,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"AListPath": {
 				GoTypeName:            "*AList",
@@ -653,6 +702,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"AList_ValuePath": {
 				GoTypeName:            "AList_Value_Union",
@@ -663,6 +713,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
+				GoPackage:             "ocpathstructs",
 			},
 			"BListPath": {
 				GoTypeName:            "*BList",
@@ -672,6 +723,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"BList_ValuePath": {
 				GoTypeName:            "BList_Value_Union",
@@ -682,6 +734,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
+				GoPackage:             "ocpathstructs",
 			},
 			"CPath": {
 				GoTypeName:            "*C",
@@ -691,6 +744,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"C_ClPath": {
 				GoTypeName:            "E_EnumModule_Cl",
@@ -701,6 +755,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -710,6 +765,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -719,6 +775,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_IdPath": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -729,6 +786,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "identityref",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_Id2Path": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -739,6 +797,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "identityref",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_EnumPath": {
 				GoTypeName:            "E_EnumTypes_TdEnum",
@@ -749,6 +808,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "td-enum",
+				GoPackage:             "ocpathstructs",
 			},
 			"Parent_Child_InlineEnumPath": {
 				GoTypeName:            "E_Child_InlineEnum",
@@ -759,6 +819,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "enumeration",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with choice and cases",
@@ -789,6 +850,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
+				GoPackage:             "ocpathstructs",
 			},
 			"Native": {
 				GoTypeName:            "*oc.Native",
@@ -798,6 +860,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Native_A": {
 				GoTypeName:            "string",
@@ -808,6 +871,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			},
 			"Native_B": {
 				GoTypeName:            "string",
@@ -818,6 +882,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			},
 			"Target": {
 				GoTypeName:            "*oc.Target",
@@ -827,6 +892,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Target_Foo": {
 				GoTypeName:            "*oc.Target_Foo",
@@ -836,6 +902,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "ocpathstructs",
 			},
 			"Target_Foo_A": {
 				GoTypeName:            "string",
@@ -846,6 +913,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
+				GoPackage:             "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with camelcase-name extension",
@@ -1598,6 +1666,8 @@ func TestGetNodeDataMap(t *testing.T) {
 		inLeafTypeMap             map[string]map[string]*ygen.MappedType
 		inSchemaStructPkgAccessor string
 		inPathStructSuffix        string
+		inPackageName             string
+		inSplitByModule           bool
 		wantNodeDataMap           NodeDataMap
 		wantSorted                []string
 		wantErrSubstrings         []string
@@ -1684,6 +1754,8 @@ func TestGetNodeDataMap(t *testing.T) {
 		inDirectories:      directories,
 		inLeafTypeMap:      leafTypeMap,
 		inPathStructSuffix: "Path",
+		inSplitByModule:    true,
+		inPackageName:      "device",
 		wantNodeDataMap: NodeDataMap{
 			"ContainerPath": {
 				GoTypeName:            "*Container",
@@ -1693,6 +1765,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "device",
 			},
 			"ContainerWithConfigPath": {
 				GoTypeName:            "*ContainerWithConfig",
@@ -1702,6 +1775,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "device",
 			},
 			"ContainerWithConfig_LeafPath": {
 				GoTypeName:            "Binary",
@@ -1711,6 +1785,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"ContainerWithConfig_LeaflistPath": {
 				GoTypeName:            "[]uint32",
@@ -1720,6 +1795,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"ContainerWithConfig_Leaflist2Path": {
 				GoTypeName:            "[]Binary",
@@ -1729,6 +1805,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"Container_LeafPath": {
 				GoTypeName:            "int32",
@@ -1739,6 +1816,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            true,
 				YANGTypeName:          "int32",
+				GoPackage:             "rootmodule_path",
 			},
 			"LeafPath": {
 				GoTypeName:            "Binary",
@@ -1749,6 +1827,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "ieeefloat32",
+				GoPackage:             "device",
 			},
 			"LeafWithDefaultPath": {
 				GoTypeName:            "string",
@@ -1759,6 +1838,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            true,
 				YANGTypeName:          "string",
+				GoPackage:             "device",
 			},
 			"ListPath": {
 				GoTypeName:            "*List",
@@ -1768,6 +1848,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "device",
 			},
 			"ListWithStatePath": {
 				GoTypeName:            "*ListWithState",
@@ -1777,6 +1858,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "device",
 			},
 			"ListWithState_KeyPath": {
 				GoTypeName:            "float64",
@@ -1786,6 +1868,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         true,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"List_Key1Path": {
 				GoTypeName:            "string",
@@ -1795,6 +1878,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         true,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"List_Key2Path": {
 				GoTypeName:            "Binary",
@@ -1804,6 +1888,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			},
 			"List_UnionKeyPath": {
 				GoTypeName:            "RootModule_List_UnionKey_Union",
@@ -1813,6 +1898,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
+				GoPackage:             "rootmodule_path",
 			}},
 		wantSorted: []string{
 			"ContainerPath",
@@ -1834,7 +1920,7 @@ func TestGetNodeDataMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotErrs := getNodeDataMap(tt.inDirectories, tt.inLeafTypeMap, tt.inSchemaStructPkgAccessor, tt.inPathStructSuffix)
+			got, gotErrs := getNodeDataMap(tt.inDirectories, tt.inLeafTypeMap, tt.inSchemaStructPkgAccessor, tt.inPathStructSuffix, tt.inPackageName, tt.inSplitByModule, false)
 			// TODO(wenbli): Enhance gNMI's errdiff with checking a slice of substrings and use here.
 			var gotErrStrs []string
 			for _, err := range gotErrs {

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -87,7 +87,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -98,7 +98,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -109,7 +109,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent/child",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -121,7 +121,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "binary",
 				YANGPath:              "/openconfig-simple/parent/child/state/four",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -133,7 +133,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/one",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -145,7 +145,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
 				YANGPath:              "/openconfig-simple/parent/child/state/three",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -157,7 +157,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/two",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -168,7 +168,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/remote-container",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -180,7 +180,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/remote-container/state/a-leaf",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with preferOperationalState=false",
@@ -197,7 +197,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -207,7 +207,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -217,7 +217,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -228,7 +228,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -239,7 +239,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -250,7 +250,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -261,7 +261,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -271,7 +271,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -282,7 +282,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with excludeState=true",
@@ -300,7 +300,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -310,7 +310,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -320,7 +320,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -331,7 +331,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -342,7 +342,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -353,7 +353,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -363,7 +363,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -374,7 +374,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with list",
@@ -444,7 +444,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -454,7 +454,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_DupEnum_A",
@@ -465,7 +465,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_DupEnum_B",
@@ -476,7 +476,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -486,7 +486,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -496,7 +496,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -507,7 +507,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -518,7 +518,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -529,7 +529,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -540,7 +540,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -551,7 +551,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                     "simple openconfig test with union & typedef & identity & enum, with enum names not shortened",
@@ -567,7 +567,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -577,7 +577,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_A",
@@ -588,7 +588,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_B",
@@ -599,7 +599,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -609,7 +609,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -619,7 +619,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -630,7 +630,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -641,7 +641,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -652,7 +652,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -663,7 +663,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -674,7 +674,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with submodule and union list key",
@@ -692,7 +692,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"AListPath": {
 				GoTypeName:            "*AList",
@@ -702,7 +702,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"AList_ValuePath": {
 				GoTypeName:            "AList_Value_Union",
@@ -713,7 +713,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"BListPath": {
 				GoTypeName:            "*BList",
@@ -723,7 +723,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"BList_ValuePath": {
 				GoTypeName:            "BList_Value_Union",
@@ -734,7 +734,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"CPath": {
 				GoTypeName:            "*C",
@@ -744,7 +744,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"C_ClPath": {
 				GoTypeName:            "E_EnumModule_Cl",
@@ -755,7 +755,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -765,7 +765,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -775,7 +775,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_IdPath": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -786,7 +786,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "identityref",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_Id2Path": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -797,7 +797,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "identityref",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_EnumPath": {
 				GoTypeName:            "E_EnumTypes_TdEnum",
@@ -808,7 +808,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "td-enum",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Parent_Child_InlineEnumPath": {
 				GoTypeName:            "E_Child_InlineEnum",
@@ -819,7 +819,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "enumeration",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with choice and cases",
@@ -850,7 +850,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Native": {
 				GoTypeName:            "*oc.Native",
@@ -860,7 +860,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Native_A": {
 				GoTypeName:            "string",
@@ -871,7 +871,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Native_B": {
 				GoTypeName:            "string",
@@ -882,7 +882,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Target": {
 				GoTypeName:            "*oc.Target",
@@ -892,7 +892,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Target_Foo": {
 				GoTypeName:            "*oc.Target_Foo",
@@ -902,7 +902,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			},
 			"Target_Foo_A": {
 				GoTypeName:            "string",
@@ -913,7 +913,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPackage:             "ocpathstructs",
+				GoPathPackageName:     "ocpathstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with camelcase-name extension",
@@ -1765,7 +1765,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"ContainerWithConfigPath": {
 				GoTypeName:            "*ContainerWithConfig",
@@ -1775,7 +1775,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"ContainerWithConfig_LeafPath": {
 				GoTypeName:            "Binary",
@@ -1785,7 +1785,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"ContainerWithConfig_LeaflistPath": {
 				GoTypeName:            "[]uint32",
@@ -1795,7 +1795,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"ContainerWithConfig_Leaflist2Path": {
 				GoTypeName:            "[]Binary",
@@ -1805,7 +1805,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"Container_LeafPath": {
 				GoTypeName:            "int32",
@@ -1816,7 +1816,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            true,
 				YANGTypeName:          "int32",
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"LeafPath": {
 				GoTypeName:            "Binary",
@@ -1827,7 +1827,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "ieeefloat32",
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"LeafWithDefaultPath": {
 				GoTypeName:            "string",
@@ -1838,7 +1838,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            true,
 				YANGTypeName:          "string",
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"ListPath": {
 				GoTypeName:            "*List",
@@ -1848,7 +1848,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"ListWithStatePath": {
 				GoTypeName:            "*ListWithState",
@@ -1858,7 +1858,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "device",
+				GoPathPackageName:     "device",
 			},
 			"ListWithState_KeyPath": {
 				GoTypeName:            "float64",
@@ -1868,7 +1868,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         true,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"List_Key1Path": {
 				GoTypeName:            "string",
@@ -1878,7 +1878,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         true,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"List_Key2Path": {
 				GoTypeName:            "Binary",
@@ -1888,7 +1888,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			},
 			"List_UnionKeyPath": {
 				GoTypeName:            "RootModule_List_UnionKey_Union",
@@ -1898,7 +1898,7 @@ func TestGetNodeDataMap(t *testing.T) {
 				IsLeaf:                true,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPackage:             "rootmodule_path",
+				GoPathPackageName:     "rootmodule_path",
 			}},
 		wantSorted: []string{
 			"ContainerPath",


### PR DESCRIPTION
Add GoPackage field to path NodeData so that downstream generators can use the package name.