### PR TITLE
[ypathgen] ResolvePath should return a non-nil PathElem message.

### DIFF
--- a/ygot/path_types.go
+++ b/ygot/path_types.go
@@ -94,7 +94,7 @@ func (d *DeviceRootBase) PutCustomData(key string, val interface{}) {
 // ResolvePath is a helper which returns the resolved *gpb.Path of a PathStruct
 // node as well as the root node's customData.
 func ResolvePath(n PathStruct) (*gpb.Path, map[string]interface{}, []error) {
-	var p []*gpb.PathElem
+	p := []*gpb.PathElem{}
 	var errs []error
 	for ; n.parent() != nil; n = n.parent() {
 		rel, es := n.relPath()

--- a/ygot/path_types_test.go
+++ b/ygot/path_types_test.go
@@ -101,6 +101,10 @@ func TestResolvePath(t *testing.T) {
 				t.Errorf("ResolvePath returned diff (-want, +got):\n%s", diff)
 			}
 
+			if gotPath.Elem == nil {
+				t.Errorf("gotPath.PathElem is nil, but should not be")
+			}
+
 			if diff := cmp.Diff(wantCustomData, gotCustomData); diff != "" {
 				t.Errorf("ResolvePath: customData is not same as expected (-want, +got)\n%s", diff)
 			}


### PR DESCRIPTION
Per the spec it should be `path := []*PathElem{}` rather than `nil` as
it currently is.
https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-path-conventions.md#constructing-paths