### PR TITLE
[ypathgen]: Reduce code snippet size in `TestGenerateDirectorySnippet`.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,13 +67,15 @@ jobs:
         working-directory: go/src/github.com/openconfig/ygot
 
       - name: Check that Go integration test files compile
-        working-directory: go/src/github.com/openconfig/ygot/ygen/testdata
+        working-directory: go/src/github.com/openconfig/ygot
         run: |
           function test-go-build() {
             cwd=$(pwd)
             tmpdir=$(mktemp -d -p $cwd)
-            name=$(basename $1)
-            cp "$1" "$tmpdir"/"${name}.go"
+            for f in "$@"; do
+                name=$(basename $f)
+                cp "$f" "$tmpdir"/"${name}.go"
+            done
             cd $tmpdir
             goimports -w *.go
             go build
@@ -81,24 +83,39 @@ jobs:
             rm -r $tmpdir
           }
 
-          expectFail=(
+          skipped=(
+            # fake ygot and ytype paths specified in generation options.
+            "openconfig-options-explicit.formatted-txt.go"
           )
-          for f in structs/*.formatted-txt; do
-            if [[ ${expectFail[@]} =~ $(basename $f) ]]; then
+          for f in ygen/testdata/schema/*.formatted-txt; do
+            if [[ ${skipped[@]} =~ $(basename $f) ]]; then
               continue
             fi
             test-go-build $f
           done
 
-          expectFail=(
-            # fake ygot and ytype paths specified in generation options.
-            "openconfig-options-explicit.formatted-txt.go"
+          skipped=(
           )
-          for f in schema/*.formatted-txt; do
-            if [[ ${expectFail[@]} =~ $(basename $f) ]]; then
+          for f in ygen/testdata/structs/*.formatted-txt; do
+            if [[ ${skipped[@]} =~ $(basename $f) ]]; then
               continue
             fi
             test-go-build $f
+          done
+
+          skipped=(
+            # GoStructs in a separate package, harder to set-up.
+            "openconfig-augmented.path-txt"
+            "openconfig-withlist-separate-package.path-txt"
+          )
+          for f in ypathgen/testdata/structs/*.path-txt; do
+            if [[ ${skipped[@]} =~ $(basename $f) ]]; then
+              continue
+            fi
+            filename=$(basename $f)
+            f_prefix="${filename%%.*}"
+            ygen_file="ygen/testdata/structs/${f_prefix}.formatted-txt"
+            test-go-build $f $ygen_file
           done
 
   static_analysis:

--- a/ypathgen/pathgen_test.go
+++ b/ypathgen/pathgen_test.go
@@ -87,7 +87,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -98,7 +98,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -109,7 +109,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/parent/child",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -121,7 +121,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "binary",
 				YANGPath:              "/openconfig-simple/parent/child/state/four",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -133,7 +133,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/one",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -145,7 +145,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
 				YANGPath:              "/openconfig-simple/parent/child/state/three",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -157,7 +157,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/parent/child/state/two",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -168,7 +168,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGPath:              "/openconfig-simple/remote-container",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -180,7 +180,7 @@ func TestGeneratePathCode(t *testing.T) {
 				HasDefault:            false,
 				YANGTypeName:          "string",
 				YANGPath:              "/openconfig-simple/remote-container/state/a-leaf",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with preferOperationalState=false",
@@ -188,7 +188,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inShortenEnumLeafNames:                 true,
 		inGenerateWildcardPaths:                true,
 		inUseDefiningModuleForTypedefEnumNames: true,
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-simple-intendedconfig.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-simple.intendedconfig.path-txt"),
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
 		wantNodeDataMap: NodeDataMap{
@@ -197,7 +197,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -207,7 +207,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -217,7 +217,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -228,7 +228,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -239,7 +239,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -250,7 +250,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_TwoPath": {
 				GoTypeName:            "string",
@@ -261,7 +261,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -271,7 +271,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -282,7 +282,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with excludeState=true",
@@ -291,7 +291,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inShortenEnumLeafNames:                 true,
 		inUseDefiningModuleForTypedefEnumNames: true,
 		inGenerateWildcardPaths:                true,
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-simple-excludestate.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-simple.excludestate.path-txt"),
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
 		wantNodeDataMap: NodeDataMap{
@@ -300,7 +300,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -310,7 +310,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -320,7 +320,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_FourPath": {
 				GoTypeName:            "Binary",
@@ -331,7 +331,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "binary",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_OnePath": {
 				GoTypeName:            "string",
@@ -342,7 +342,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_ThreePath": {
 				GoTypeName:            "E_Child_Three",
@@ -353,7 +353,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainerPath": {
 				GoTypeName:            "*RemoteContainer",
@@ -363,7 +363,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"RemoteContainer_ALeafPath": {
 				GoTypeName:            "string",
@@ -374,7 +374,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with list",
@@ -396,7 +396,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
 		inSimplifyWildcardPaths:                true,
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist-simplifyallwc.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.simplifyallwc.path-txt"),
 	}, {
 		name:                                   "simple openconfig test with list without wildcard paths",
 		inFiles:                                []string{filepath.Join(datapath, "openconfig-withlist.yang")},
@@ -406,7 +406,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inGenerateWildcardPaths:                false,
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist-nowildcard.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.nowildcard.path-txt"),
 	}, {
 		name:                                   "simple openconfig test with list in separate package",
 		inFiles:                                []string{filepath.Join(datapath, "openconfig-withlist.yang")},
@@ -427,7 +427,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inGenerateWildcardPaths:                true,
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist-builder.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-withlist.builder.path-txt"),
 	}, {
 		name:                                   "simple openconfig test with union & typedef & identity & enum",
 		inFiles:                                []string{filepath.Join(datapath, "openconfig-unione.yang")},
@@ -444,7 +444,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -454,7 +454,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_DupEnum_A",
@@ -465,7 +465,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_DupEnum_B",
@@ -476,7 +476,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -486,7 +486,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -496,7 +496,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -507,7 +507,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -518,7 +518,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -529,7 +529,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -540,7 +540,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -551,7 +551,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                     "simple openconfig test with union & typedef & identity & enum, with enum names not shortened",
@@ -567,7 +567,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnumPath": {
 				GoTypeName:            "*DupEnum",
@@ -577,7 +577,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnum_APath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_A",
@@ -588,7 +588,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"DupEnum_BPath": {
 				GoTypeName:            "E_OpenconfigUnione_DupEnum_B",
@@ -599,7 +599,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"PlatformPath": {
 				GoTypeName:            "*Platform",
@@ -609,7 +609,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_ComponentPath": {
 				GoTypeName:            "*Platform_Component",
@@ -619,7 +619,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_E1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -630,7 +630,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumtypedef",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_EnumeratedPath": {
 				GoTypeName:            "Platform_Component_Enumerated_Union",
@@ -641,7 +641,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumerated-union-type",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_PowerPath": {
 				GoTypeName:            "Platform_Component_Power_Union",
@@ -652,7 +652,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_R1Path": {
 				GoTypeName:            "Platform_Component_E1_Union",
@@ -663,7 +663,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "leafref",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Platform_Component_TypePath": {
 				GoTypeName:            "Platform_Component_Type_Union",
@@ -674,7 +674,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "union",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with submodule and union list key",
@@ -692,7 +692,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"AListPath": {
 				GoTypeName:            "*AList",
@@ -702,7 +702,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"AList_ValuePath": {
 				GoTypeName:            "AList_Value_Union",
@@ -713,7 +713,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"BListPath": {
 				GoTypeName:            "*BList",
@@ -723,7 +723,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"BList_ValuePath": {
 				GoTypeName:            "BList_Value_Union",
@@ -734,7 +734,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "td",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"CPath": {
 				GoTypeName:            "*C",
@@ -744,7 +744,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"C_ClPath": {
 				GoTypeName:            "E_EnumModule_Cl",
@@ -755,7 +755,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"ParentPath": {
 				GoTypeName:            "*Parent",
@@ -765,7 +765,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_ChildPath": {
 				GoTypeName:            "*Parent_Child",
@@ -775,7 +775,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_IdPath": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -786,7 +786,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            false,
 				YANGTypeName:          "identityref",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_Id2Path": {
 				GoTypeName:            "E_EnumTypes_ID",
@@ -797,7 +797,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "identityref",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_EnumPath": {
 				GoTypeName:            "E_EnumTypes_TdEnum",
@@ -808,7 +808,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "td-enum",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Parent_Child_InlineEnumPath": {
 				GoTypeName:            "E_Child_InlineEnum",
@@ -819,7 +819,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         false,
 				HasDefault:            true,
 				YANGTypeName:          "enumeration",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with choice and cases",
@@ -850,7 +850,7 @@ func TestGeneratePathCode(t *testing.T) {
 				LocalGoTypeName:       "*Device",
 				SubsumingGoStructName: "Device",
 				YANGPath:              "/",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Native": {
 				GoTypeName:            "*oc.Native",
@@ -860,7 +860,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Native_A": {
 				GoTypeName:            "string",
@@ -871,7 +871,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Native_B": {
 				GoTypeName:            "string",
@@ -882,7 +882,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Target": {
 				GoTypeName:            "*oc.Target",
@@ -892,7 +892,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Target_Foo": {
 				GoTypeName:            "*oc.Target_Foo",
@@ -902,7 +902,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsLeaf:                false,
 				IsScalarField:         false,
 				HasDefault:            false,
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			},
 			"Target_Foo_A": {
 				GoTypeName:            "string",
@@ -913,7 +913,7 @@ func TestGeneratePathCode(t *testing.T) {
 				IsScalarField:         true,
 				HasDefault:            false,
 				YANGTypeName:          "string",
-				GoPathPackageName:     "ocpathstructs",
+				GoPathPackageName:     "ocstructs",
 			}},
 	}, {
 		name:                                   "simple openconfig test with camelcase-name extension",
@@ -924,7 +924,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inGenerateWildcardPaths:                true,
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-enumcamelcase.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-enumcamelcase-compress.path-txt"),
 	}, {
 		name:                                   "simple openconfig test with camelcase-name extension in container and leaf",
 		inFiles:                                []string{filepath.Join(datapath, "openconfig-camelcase.yang")},
@@ -934,7 +934,7 @@ func TestGeneratePathCode(t *testing.T) {
 		inGenerateWildcardPaths:                true,
 		inSchemaStructPkgPath:                  "",
 		inPathStructSuffix:                     "Path",
-		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-camelcase.path-txt"),
+		wantStructsCodeFile:                    filepath.Join(TestRoot, "testdata/structs/openconfig-camelcase-compress.path-txt"),
 	}}
 
 	for _, tt := range tests {
@@ -953,6 +953,7 @@ func TestGeneratePathCode(t *testing.T) {
 				cg.UseDefiningModuleForTypedefEnumNames = tt.inUseDefiningModuleForTypedefEnumNames
 				cg.GenerateWildcardPaths = tt.inGenerateWildcardPaths
 				cg.SimplifyWildcardPaths = tt.inSimplifyWildcardPaths
+				cg.PackageName = "ocstructs"
 
 				gotCode, gotNodeDataMap, err := cg.GeneratePathCode(tt.inFiles, tt.inIncludePaths)
 				if err != nil && !tt.wantErr {
@@ -1021,19 +1022,19 @@ func TestGeneratePathCodeSplitFiles(t *testing.T) {
 		inFiles:               []string{filepath.Join(datapath, "openconfig-simple.yang")},
 		inFileNumber:          4,
 		inSchemaStructPkgPath: "github.com/openconfig/ygot/ypathgen/testdata/exampleoc",
-		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/structs/openconfig-simple-40.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-41.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-42.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-43.path-txt")},
+		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-40.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-41.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-42.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-43.path-txt")},
 	}, {
 		name:                  "fileNumber is just under the total number of structs",
 		inFiles:               []string{filepath.Join(datapath, "openconfig-simple.yang")},
 		inFileNumber:          3,
 		inSchemaStructPkgPath: "",
-		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/structs/openconfig-simple-30.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-31.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-32.path-txt")},
+		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-30.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-31.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-32.path-txt")},
 	}, {
 		name:                  "fileNumber is half the total number of structs",
 		inFiles:               []string{filepath.Join(datapath, "openconfig-simple.yang")},
 		inFileNumber:          2,
 		inSchemaStructPkgPath: "github.com/openconfig/ygot/ypathgen/testdata/exampleoc",
-		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/structs/openconfig-simple-0.path-txt"), filepath.Join(TestRoot, "testdata/structs/openconfig-simple-1.path-txt")},
+		wantStructsCodeFiles:  []string{filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-0.path-txt"), filepath.Join(TestRoot, "testdata/splitstructs/openconfig-simple-1.path-txt")},
 	}, {
 		name:                  "single file",
 		inFiles:               []string{filepath.Join(datapath, "openconfig-simple.yang")},
@@ -1062,6 +1063,7 @@ func TestGeneratePathCodeSplitFiles(t *testing.T) {
 				}
 				cg.PreferOperationalState = true
 				cg.GenerateWildcardPaths = true
+				cg.PackageName = "ocstructs"
 
 				gotCode, _, err := cg.GeneratePathCode(tt.inFiles, tt.inIncludePaths)
 				if err != nil {

--- a/ypathgen/testdata/splitstructs/openconfig-simple-0.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-0.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-1.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-1.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-30.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-30.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-31.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-31.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,75 +8,11 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"
 )
-
-// DevicePath represents the /device YANG schema element.
-type DevicePath struct {
-	*ygot.DeviceRootBase
-}
-
-// DeviceRoot returns a new path object from which YANG paths can be constructed.
-func DeviceRoot(id string) *DevicePath {
-	return &DevicePath{ygot.NewDeviceRootBase(id)}
-}
-
-// Parent returns from DevicePath the path struct for its child "parent".
-func (n *DevicePath) Parent() *ParentPath {
-	return &ParentPath{
-		NodePath: ygot.NewNodePath(
-			[]string{"parent"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// RemoteContainer returns from DevicePath the path struct for its child "remote-container".
-func (n *DevicePath) RemoteContainer() *RemoteContainerPath {
-	return &RemoteContainerPath{
-		NodePath: ygot.NewNodePath(
-			[]string{"remote-container"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// ParentPath represents the /openconfig-simple/parent YANG schema element.
-type ParentPath struct {
-	*ygot.NodePath
-}
-
-// ParentPathAny represents the wildcard version of the /openconfig-simple/parent YANG schema element.
-type ParentPathAny struct {
-	*ygot.NodePath
-}
-
-// Child returns from ParentPath the path struct for its child "child".
-func (n *ParentPath) Child() *Parent_ChildPath {
-	return &Parent_ChildPath{
-		NodePath: ygot.NewNodePath(
-			[]string{"child"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// Child returns from ParentPathAny the path struct for its child "child".
-func (n *ParentPathAny) Child() *Parent_ChildPathAny {
-	return &Parent_ChildPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"child"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
 
 // Parent_ChildPath represents the /openconfig-simple/parent/child YANG schema element.
 type Parent_ChildPath struct {
@@ -88,33 +24,43 @@ type Parent_ChildPathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_FourPath represents the /openconfig-simple/parent/child/config/four YANG schema element.
+// Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_FourPath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/config/four YANG schema element.
+// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
 type Parent_Child_FourPathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_OnePath represents the /openconfig-simple/parent/child/config/one YANG schema element.
+// Parent_Child_OnePath represents the /openconfig-simple/parent/child/state/one YANG schema element.
 type Parent_Child_OnePath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/config/one YANG schema element.
+// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
 type Parent_Child_OnePathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/config/three YANG schema element.
+// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/state/three YANG schema element.
 type Parent_Child_ThreePath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/config/three YANG schema element.
+// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
 type Parent_Child_ThreePathAny struct {
+	*ygot.NodePath
+}
+
+// Parent_Child_TwoPath represents the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoPath struct {
+	*ygot.NodePath
+}
+
+// Parent_Child_TwoPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
+type Parent_Child_TwoPathAny struct {
 	*ygot.NodePath
 }
 
@@ -122,7 +68,7 @@ type Parent_Child_ThreePathAny struct {
 func (n *Parent_ChildPath) Four() *Parent_Child_FourPath {
 	return &Parent_Child_FourPath{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "four"},
+			[]string{"state", "four"},
 			map[string]interface{}{},
 			n,
 		),
@@ -133,7 +79,7 @@ func (n *Parent_ChildPath) Four() *Parent_Child_FourPath {
 func (n *Parent_ChildPathAny) Four() *Parent_Child_FourPathAny {
 	return &Parent_Child_FourPathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "four"},
+			[]string{"state", "four"},
 			map[string]interface{}{},
 			n,
 		),
@@ -144,7 +90,7 @@ func (n *Parent_ChildPathAny) Four() *Parent_Child_FourPathAny {
 func (n *Parent_ChildPath) One() *Parent_Child_OnePath {
 	return &Parent_Child_OnePath{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "one"},
+			[]string{"state", "one"},
 			map[string]interface{}{},
 			n,
 		),
@@ -155,7 +101,7 @@ func (n *Parent_ChildPath) One() *Parent_Child_OnePath {
 func (n *Parent_ChildPathAny) One() *Parent_Child_OnePathAny {
 	return &Parent_Child_OnePathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "one"},
+			[]string{"state", "one"},
 			map[string]interface{}{},
 			n,
 		),
@@ -166,7 +112,7 @@ func (n *Parent_ChildPathAny) One() *Parent_Child_OnePathAny {
 func (n *Parent_ChildPath) Three() *Parent_Child_ThreePath {
 	return &Parent_Child_ThreePath{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "three"},
+			[]string{"state", "three"},
 			map[string]interface{}{},
 			n,
 		),
@@ -177,7 +123,29 @@ func (n *Parent_ChildPath) Three() *Parent_Child_ThreePath {
 func (n *Parent_ChildPathAny) Three() *Parent_Child_ThreePathAny {
 	return &Parent_Child_ThreePathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "three"},
+			[]string{"state", "three"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Two returns from Parent_ChildPath the path struct for its child "two".
+func (n *Parent_ChildPath) Two() *Parent_Child_TwoPath {
+	return &Parent_Child_TwoPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "two"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Two returns from Parent_ChildPathAny the path struct for its child "two".
+func (n *Parent_ChildPathAny) Two() *Parent_Child_TwoPathAny {
+	return &Parent_Child_TwoPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "two"},
 			map[string]interface{}{},
 			n,
 		),
@@ -194,12 +162,12 @@ type RemoteContainerPathAny struct {
 	*ygot.NodePath
 }
 
-// RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/config/a-leaf YANG schema element.
+// RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
 type RemoteContainer_ALeafPath struct {
 	*ygot.NodePath
 }
 
-// RemoteContainer_ALeafPathAny represents the wildcard version of the /openconfig-simple/remote-container/config/a-leaf YANG schema element.
+// RemoteContainer_ALeafPathAny represents the wildcard version of the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
 type RemoteContainer_ALeafPathAny struct {
 	*ygot.NodePath
 }
@@ -208,7 +176,7 @@ type RemoteContainer_ALeafPathAny struct {
 func (n *RemoteContainerPath) ALeaf() *RemoteContainer_ALeafPath {
 	return &RemoteContainer_ALeafPath{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "a-leaf"},
+			[]string{"state", "a-leaf"},
 			map[string]interface{}{},
 			n,
 		),
@@ -219,7 +187,7 @@ func (n *RemoteContainerPath) ALeaf() *RemoteContainer_ALeafPath {
 func (n *RemoteContainerPathAny) ALeaf() *RemoteContainer_ALeafPathAny {
 	return &RemoteContainer_ALeafPathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"config", "a-leaf"},
+			[]string{"state", "a-leaf"},
 			map[string]interface{}{},
 			n,
 		),

--- a/ypathgen/testdata/splitstructs/openconfig-simple-32.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-32.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-40.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-40.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-41.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-41.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-42.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-42.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/splitstructs/openconfig-simple-43.path-txt
+++ b/ypathgen/testdata/splitstructs/openconfig-simple-43.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/structs/choice-case-example.path-txt
+++ b/ypathgen/testdata/structs/choice-case-example.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/choice-case-example.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/enum-module.path-txt
+++ b/ypathgen/testdata/structs/enum-module.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/enum-module.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-augmented.path-txt
+++ b/ypathgen/testdata/structs/openconfig-augmented.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -9,7 +9,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple-augment.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/structs/openconfig-camelcase-compress.path-txt
+++ b/ypathgen/testdata/structs/openconfig-camelcase-compress.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-camelcase.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-enumcamelcase-compress.path-txt
+++ b/ypathgen/testdata/structs/openconfig-enumcamelcase-compress.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-enumcamelcase.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-simple.excludestate.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.excludestate.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,11 +8,75 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"
 )
+
+// DevicePath represents the /device YANG schema element.
+type DevicePath struct {
+	*ygot.DeviceRootBase
+}
+
+// DeviceRoot returns a new path object from which YANG paths can be constructed.
+func DeviceRoot(id string) *DevicePath {
+	return &DevicePath{ygot.NewDeviceRootBase(id)}
+}
+
+// Parent returns from DevicePath the path struct for its child "parent".
+func (n *DevicePath) Parent() *ParentPath {
+	return &ParentPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"parent"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// RemoteContainer returns from DevicePath the path struct for its child "remote-container".
+func (n *DevicePath) RemoteContainer() *RemoteContainerPath {
+	return &RemoteContainerPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"remote-container"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// ParentPath represents the /openconfig-simple/parent YANG schema element.
+type ParentPath struct {
+	*ygot.NodePath
+}
+
+// ParentPathAny represents the wildcard version of the /openconfig-simple/parent YANG schema element.
+type ParentPathAny struct {
+	*ygot.NodePath
+}
+
+// Child returns from ParentPath the path struct for its child "child".
+func (n *ParentPath) Child() *Parent_ChildPath {
+	return &Parent_ChildPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"child"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Child returns from ParentPathAny the path struct for its child "child".
+func (n *ParentPathAny) Child() *Parent_ChildPathAny {
+	return &Parent_ChildPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"child"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
 
 // Parent_ChildPath represents the /openconfig-simple/parent/child YANG schema element.
 type Parent_ChildPath struct {
@@ -24,43 +88,33 @@ type Parent_ChildPathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_FourPath represents the /openconfig-simple/parent/child/state/four YANG schema element.
+// Parent_Child_FourPath represents the /openconfig-simple/parent/child/config/four YANG schema element.
 type Parent_Child_FourPath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/four YANG schema element.
+// Parent_Child_FourPathAny represents the wildcard version of the /openconfig-simple/parent/child/config/four YANG schema element.
 type Parent_Child_FourPathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_OnePath represents the /openconfig-simple/parent/child/state/one YANG schema element.
+// Parent_Child_OnePath represents the /openconfig-simple/parent/child/config/one YANG schema element.
 type Parent_Child_OnePath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/one YANG schema element.
+// Parent_Child_OnePathAny represents the wildcard version of the /openconfig-simple/parent/child/config/one YANG schema element.
 type Parent_Child_OnePathAny struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/state/three YANG schema element.
+// Parent_Child_ThreePath represents the /openconfig-simple/parent/child/config/three YANG schema element.
 type Parent_Child_ThreePath struct {
 	*ygot.NodePath
 }
 
-// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/state/three YANG schema element.
+// Parent_Child_ThreePathAny represents the wildcard version of the /openconfig-simple/parent/child/config/three YANG schema element.
 type Parent_Child_ThreePathAny struct {
-	*ygot.NodePath
-}
-
-// Parent_Child_TwoPath represents the /openconfig-simple/parent/child/state/two YANG schema element.
-type Parent_Child_TwoPath struct {
-	*ygot.NodePath
-}
-
-// Parent_Child_TwoPathAny represents the wildcard version of the /openconfig-simple/parent/child/state/two YANG schema element.
-type Parent_Child_TwoPathAny struct {
 	*ygot.NodePath
 }
 
@@ -68,7 +122,7 @@ type Parent_Child_TwoPathAny struct {
 func (n *Parent_ChildPath) Four() *Parent_Child_FourPath {
 	return &Parent_Child_FourPath{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "four"},
+			[]string{"config", "four"},
 			map[string]interface{}{},
 			n,
 		),
@@ -79,7 +133,7 @@ func (n *Parent_ChildPath) Four() *Parent_Child_FourPath {
 func (n *Parent_ChildPathAny) Four() *Parent_Child_FourPathAny {
 	return &Parent_Child_FourPathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "four"},
+			[]string{"config", "four"},
 			map[string]interface{}{},
 			n,
 		),
@@ -90,7 +144,7 @@ func (n *Parent_ChildPathAny) Four() *Parent_Child_FourPathAny {
 func (n *Parent_ChildPath) One() *Parent_Child_OnePath {
 	return &Parent_Child_OnePath{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "one"},
+			[]string{"config", "one"},
 			map[string]interface{}{},
 			n,
 		),
@@ -101,7 +155,7 @@ func (n *Parent_ChildPath) One() *Parent_Child_OnePath {
 func (n *Parent_ChildPathAny) One() *Parent_Child_OnePathAny {
 	return &Parent_Child_OnePathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "one"},
+			[]string{"config", "one"},
 			map[string]interface{}{},
 			n,
 		),
@@ -112,7 +166,7 @@ func (n *Parent_ChildPathAny) One() *Parent_Child_OnePathAny {
 func (n *Parent_ChildPath) Three() *Parent_Child_ThreePath {
 	return &Parent_Child_ThreePath{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "three"},
+			[]string{"config", "three"},
 			map[string]interface{}{},
 			n,
 		),
@@ -123,29 +177,7 @@ func (n *Parent_ChildPath) Three() *Parent_Child_ThreePath {
 func (n *Parent_ChildPathAny) Three() *Parent_Child_ThreePathAny {
 	return &Parent_Child_ThreePathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "three"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// Two returns from Parent_ChildPath the path struct for its child "two".
-func (n *Parent_ChildPath) Two() *Parent_Child_TwoPath {
-	return &Parent_Child_TwoPath{
-		NodePath: ygot.NewNodePath(
-			[]string{"state", "two"},
-			map[string]interface{}{},
-			n,
-		),
-	}
-}
-
-// Two returns from Parent_ChildPathAny the path struct for its child "two".
-func (n *Parent_ChildPathAny) Two() *Parent_Child_TwoPathAny {
-	return &Parent_Child_TwoPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"state", "two"},
+			[]string{"config", "three"},
 			map[string]interface{}{},
 			n,
 		),
@@ -162,12 +194,12 @@ type RemoteContainerPathAny struct {
 	*ygot.NodePath
 }
 
-// RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
+// RemoteContainer_ALeafPath represents the /openconfig-simple/remote-container/config/a-leaf YANG schema element.
 type RemoteContainer_ALeafPath struct {
 	*ygot.NodePath
 }
 
-// RemoteContainer_ALeafPathAny represents the wildcard version of the /openconfig-simple/remote-container/state/a-leaf YANG schema element.
+// RemoteContainer_ALeafPathAny represents the wildcard version of the /openconfig-simple/remote-container/config/a-leaf YANG schema element.
 type RemoteContainer_ALeafPathAny struct {
 	*ygot.NodePath
 }
@@ -176,7 +208,7 @@ type RemoteContainer_ALeafPathAny struct {
 func (n *RemoteContainerPath) ALeaf() *RemoteContainer_ALeafPath {
 	return &RemoteContainer_ALeafPath{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "a-leaf"},
+			[]string{"config", "a-leaf"},
 			map[string]interface{}{},
 			n,
 		),
@@ -187,7 +219,7 @@ func (n *RemoteContainerPath) ALeaf() *RemoteContainer_ALeafPath {
 func (n *RemoteContainerPathAny) ALeaf() *RemoteContainer_ALeafPathAny {
 	return &RemoteContainer_ALeafPathAny{
 		NodePath: ygot.NewNodePath(
-			[]string{"state", "a-leaf"},
+			[]string{"config", "a-leaf"},
 			map[string]interface{}{},
 			n,
 		),

--- a/ypathgen/testdata/structs/openconfig-simple.intendedconfig.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.intendedconfig.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-simple.path-txt
+++ b/ypathgen/testdata/structs/openconfig-simple.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-simple.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-unione.path-txt
+++ b/ypathgen/testdata/structs/openconfig-unione.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-unione.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-withlist.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	oc "github.com/openconfig/ygot/ypathgen/testdata/exampleoc"

--- a/ypathgen/testdata/structs/openconfig-withlist.builder.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.builder.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-withlist.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"
@@ -50,7 +50,7 @@ func (n *ModelPath) MultiKeyAny() *Model_MultiKeyPathAny {
 	return &Model_MultiKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"b", "multi-key"},
-			map[string]interface{}{},
+			map[string]interface{}{"key1": "*", "key2": "*"},
 			n,
 		),
 	}
@@ -61,84 +61,24 @@ func (n *ModelPathAny) MultiKeyAny() *Model_MultiKeyPathAny {
 	return &Model_MultiKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"b", "multi-key"},
-			map[string]interface{}{},
+			map[string]interface{}{"key1": "*", "key2": "*"},
 			n,
 		),
 	}
 }
 
-// MultiKeyAnyKey2 returns from ModelPath the path struct for its child "multi-key".
+// WithKey1 sets Model_MultiKeyPathAny's key "key1" to the specified value.
 // Key1: uint32
-func (n *ModelPath) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyPathAny {
-	return &Model_MultiKeyPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": Key1, "key2": "*"},
-			n,
-		),
-	}
+func (n *Model_MultiKeyPathAny) WithKey1(Key1 uint32) *Model_MultiKeyPathAny {
+	ygot.ModifyKey(n.NodePath, "key1", Key1)
+	return n
 }
 
-// MultiKeyAnyKey2 returns from ModelPathAny the path struct for its child "multi-key".
-// Key1: uint32
-func (n *ModelPathAny) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyPathAny {
-	return &Model_MultiKeyPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": Key1, "key2": "*"},
-			n,
-		),
-	}
-}
-
-// MultiKeyAnyKey1 returns from ModelPath the path struct for its child "multi-key".
+// WithKey2 sets Model_MultiKeyPathAny's key "key2" to the specified value.
 // Key2: uint64
-func (n *ModelPath) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyPathAny {
-	return &Model_MultiKeyPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": "*", "key2": Key2},
-			n,
-		),
-	}
-}
-
-// MultiKeyAnyKey1 returns from ModelPathAny the path struct for its child "multi-key".
-// Key2: uint64
-func (n *ModelPathAny) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyPathAny {
-	return &Model_MultiKeyPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": "*", "key2": Key2},
-			n,
-		),
-	}
-}
-
-// MultiKey returns from ModelPath the path struct for its child "multi-key".
-// Key1: uint32
-// Key2: uint64
-func (n *ModelPath) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyPath {
-	return &Model_MultiKeyPath{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": Key1, "key2": Key2},
-			n,
-		),
-	}
-}
-
-// MultiKey returns from ModelPathAny the path struct for its child "multi-key".
-// Key1: uint32
-// Key2: uint64
-func (n *ModelPathAny) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyPathAny {
-	return &Model_MultiKeyPathAny{
-		NodePath: ygot.NewNodePath(
-			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": Key1, "key2": Key2},
-			n,
-		),
-	}
+func (n *Model_MultiKeyPathAny) WithKey2(Key2 uint64) *Model_MultiKeyPathAny {
+	ygot.ModifyKey(n.NodePath, "key2", Key2)
+	return n
 }
 
 // SingleKeyAny returns from ModelPath the path struct for its child "single-key".
@@ -146,7 +86,7 @@ func (n *ModelPath) SingleKeyAny() *Model_SingleKeyPathAny {
 	return &Model_SingleKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"a", "single-key"},
-			map[string]interface{}{},
+			map[string]interface{}{"key": "*"},
 			n,
 		),
 	}
@@ -157,7 +97,7 @@ func (n *ModelPathAny) SingleKeyAny() *Model_SingleKeyPathAny {
 	return &Model_SingleKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"a", "single-key"},
-			map[string]interface{}{},
+			map[string]interface{}{"key": "*"},
 			n,
 		),
 	}

--- a/ypathgen/testdata/structs/openconfig-withlist.nowildcard.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.nowildcard.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-withlist.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-withlist.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"

--- a/ypathgen/testdata/structs/openconfig-withlist.simplifyallwc.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.simplifyallwc.path-txt
@@ -1,5 +1,5 @@
 /*
-Package ocpathstructs is a generated package which contains definitions
+Package ocstructs is a generated package which contains definitions
 of structs which generate gNMI paths for a YANG schema. The generated paths are
 based on a compressed form of the schema.
 
@@ -8,7 +8,7 @@ using the following YANG input files:
 	- ../testdata/modules/openconfig-withlist.yang
 Imported modules were sourced from:
 */
-package ocpathstructs
+package ocstructs
 
 import (
 	"github.com/openconfig/ygot/ygot"
@@ -50,7 +50,7 @@ func (n *ModelPath) MultiKeyAny() *Model_MultiKeyPathAny {
 	return &Model_MultiKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": "*", "key2": "*"},
+			map[string]interface{}{},
 			n,
 		),
 	}
@@ -61,24 +61,84 @@ func (n *ModelPathAny) MultiKeyAny() *Model_MultiKeyPathAny {
 	return &Model_MultiKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"b", "multi-key"},
-			map[string]interface{}{"key1": "*", "key2": "*"},
+			map[string]interface{}{},
 			n,
 		),
 	}
 }
 
-// WithKey1 sets Model_MultiKeyPathAny's key "key1" to the specified value.
+// MultiKeyAnyKey2 returns from ModelPath the path struct for its child "multi-key".
 // Key1: uint32
-func (n *Model_MultiKeyPathAny) WithKey1(Key1 uint32) *Model_MultiKeyPathAny {
-	ygot.ModifyKey(n.NodePath, "key1", Key1)
-	return n
+func (n *ModelPath) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyPathAny {
+	return &Model_MultiKeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": "*"},
+			n,
+		),
+	}
 }
 
-// WithKey2 sets Model_MultiKeyPathAny's key "key2" to the specified value.
+// MultiKeyAnyKey2 returns from ModelPathAny the path struct for its child "multi-key".
+// Key1: uint32
+func (n *ModelPathAny) MultiKeyAnyKey2(Key1 uint32) *Model_MultiKeyPathAny {
+	return &Model_MultiKeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": "*"},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey1 returns from ModelPath the path struct for its child "multi-key".
 // Key2: uint64
-func (n *Model_MultiKeyPathAny) WithKey2(Key2 uint64) *Model_MultiKeyPathAny {
-	ygot.ModifyKey(n.NodePath, "key2", Key2)
-	return n
+func (n *ModelPath) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyPathAny {
+	return &Model_MultiKeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": Key2},
+			n,
+		),
+	}
+}
+
+// MultiKeyAnyKey1 returns from ModelPathAny the path struct for its child "multi-key".
+// Key2: uint64
+func (n *ModelPathAny) MultiKeyAnyKey1(Key2 uint64) *Model_MultiKeyPathAny {
+	return &Model_MultiKeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": "*", "key2": Key2},
+			n,
+		),
+	}
+}
+
+// MultiKey returns from ModelPath the path struct for its child "multi-key".
+// Key1: uint32
+// Key2: uint64
+func (n *ModelPath) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyPath {
+	return &Model_MultiKeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": Key2},
+			n,
+		),
+	}
+}
+
+// MultiKey returns from ModelPathAny the path struct for its child "multi-key".
+// Key1: uint32
+// Key2: uint64
+func (n *ModelPathAny) MultiKey(Key1 uint32, Key2 uint64) *Model_MultiKeyPathAny {
+	return &Model_MultiKeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"b", "multi-key"},
+			map[string]interface{}{"key1": Key1, "key2": Key2},
+			n,
+		),
+	}
 }
 
 // SingleKeyAny returns from ModelPath the path struct for its child "single-key".
@@ -86,7 +146,7 @@ func (n *ModelPath) SingleKeyAny() *Model_SingleKeyPathAny {
 	return &Model_SingleKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"a", "single-key"},
-			map[string]interface{}{"key": "*"},
+			map[string]interface{}{},
 			n,
 		),
 	}
@@ -97,7 +157,7 @@ func (n *ModelPathAny) SingleKeyAny() *Model_SingleKeyPathAny {
 	return &Model_SingleKeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"a", "single-key"},
-			map[string]interface{}{"key": "*"},
+			map[string]interface{}{},
 			n,
 		),
 	}


### PR DESCRIPTION
Intention is to simplify the tests a bit.

Deduplicate some snippets, and allow some test cases to be skipped:
```go
2137                 // want may be omitted to skip testing.                                                                                                                                                                                                                                                                                               
2138                 want []GoPathStructCodeSnippet                                                                                                                                                                                                                                                                                                        
2139                 // wantNoWildcard may be omitted to skip testing.                                                                                                                                                                                                                                                                                     
2140                 wantNoWildcard []GoPathStructCodeSnippet                                                                                                                                                                                                                                                                                              
```

FIXED #585