### PR TITLE
Fix static analysis errors.

### DIFF
--- a/ytypes/choice_test.go
+++ b/ytypes/choice_test.go
@@ -16,7 +16,6 @@ package ytypes
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -332,7 +331,7 @@ func TestUnmarshalChoice(t *testing.T) {
 			var parent ParentContainerStruct
 
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("json unmarshal (%s) : %s", tt.desc, err))
+				t.Fatalf("json unmarshal (%s) : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(tt.schema, &parent, jsonTree)

--- a/ytypes/container_test.go
+++ b/ytypes/container_test.go
@@ -16,7 +16,6 @@ package ytypes
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -447,7 +446,7 @@ func TestUnmarshalContainer(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			if tt.json != "" {
 				if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-					t.Fatal(fmt.Sprintf("json unmarshal (%s) : %s", tt.desc, err))
+					t.Fatalf("json unmarshal (%s) : %s", tt.desc, err)
 				}
 			}
 

--- a/ytypes/leaf_list_test.go
+++ b/ytypes/leaf_list_test.go
@@ -514,7 +514,7 @@ func TestUnmarshalLeafListJSONEncoding(t *testing.T) {
 
 			if tt.json != "" {
 				if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-					t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+					t.Fatalf("%s : %s", tt.desc, err)
 				}
 			}
 

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1628,7 +1628,7 @@ func TestUnmarshalLeafJSONEncoding(t *testing.T) {
 			var parent LeafContainerStruct
 
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+				t.Fatalf("%s : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(containerSchema, &parent, jsonTree)
@@ -1738,7 +1738,7 @@ func TestUnmarshalLeafRef(t *testing.T) {
 			var parent ContainerStruct
 
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+				t.Fatalf("%s : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(containerSchema, &parent, jsonTree)

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -501,7 +501,7 @@ func TestUnmarshalUnkeyedList(t *testing.T) {
 
 			if tt.json != "" {
 				if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-					t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+					t.Fatalf("%s : %s", tt.desc, err)
 				}
 			}
 
@@ -657,7 +657,7 @@ func TestUnmarshalKeyedList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+				t.Fatalf("%s : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(tt.schema, tt.parent, jsonTree, tt.opts...)
@@ -755,7 +755,7 @@ func TestUnmarshalStructKeyedList(t *testing.T) {
 			var parent ContainerStruct
 
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+				t.Fatalf("%s : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(containerWithLeafListSchema, &parent, jsonTree)
@@ -824,7 +824,7 @@ func TestUnmarshalSingleListElement(t *testing.T) {
 			var parent ListElemStruct
 
 			if err := json.Unmarshal([]byte(tt.json), &jsonTree); err != nil {
-				t.Fatal(fmt.Sprintf("%s : %s", tt.desc, err))
+				t.Fatalf("%s : %s", tt.desc, err)
 			}
 
 			err := Unmarshal(listSchema, &parent, jsonTree)


### PR DESCRIPTION
```
﻿ * (M) ytypes/{choice,container,leaf_list,leaf,list)_test.go
  - Use t.Fatalf rather than t.Fatal(fmt.Sprintf(...
```
