### PR TITLE
Use reflect.DeepEqual instead of cmp.Equal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/*
 *.vscode*
 .vscode/*
+tags

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 
@@ -451,7 +450,7 @@ func DeepEqualDerefPtrs(a, b interface{}) bool {
 	if !IsValueNil(b) && reflect.TypeOf(b).Kind() == reflect.Ptr {
 		bb = reflect.ValueOf(b).Elem().Interface()
 	}
-	return cmp.Equal(aa, bb)
+	return reflect.DeepEqual(aa, bb)
 }
 
 // ChildSchema returns the schema for the struct field f, if f contains a valid

--- a/ygen/directory.go
+++ b/ygen/directory.go
@@ -20,9 +20,9 @@ package ygen
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/genutil"
 	"github.com/openconfig/ygot/util"
@@ -243,7 +243,7 @@ func findMapPaths(parent *Directory, fieldName string, compressPaths, shadowSche
 		// Note: if k is a leafref, buildListKey() would have already
 		// resolved it the field that the leafref points to. So, we
 		// compare their absolute paths for equality.
-		if k.Parent.Parent.Dir[k.Name].Type.Kind == yang.Yleafref && cmp.Equal(util.SchemaPathNoChoiceCase(k), fieldSlicePath) {
+		if k.Parent.Parent.Dir[k.Name].Type.Kind == yang.Yleafref && reflect.DeepEqual(util.SchemaPathNoChoiceCase(k), fieldSlicePath) {
 			// The path of the key element is simply the name of the leaf under the
 			// list, since the YANG specification enforces that keys are direct
 			// children of the list.

--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/ygot/util"
 	"google.golang.org/protobuf/proto"
@@ -214,7 +213,7 @@ func findSetLeaves(s GoStruct, opts ...DiffOpt) (map[*pathSpec]interface{}, erro
 	processedPaths := map[string]bool{}
 
 	findSetIterFunc := func(ni *util.NodeInfo, in, out interface{}) (errs util.Errors) {
-		if cmp.Equal(ni.StructField, reflect.StructField{}) {
+		if reflect.DeepEqual(ni.StructField, reflect.StructField{}) {
 			return
 		}
 
@@ -436,7 +435,7 @@ func Diff(original, modified GoStruct, opts ...DiffOpt) (*gnmipb.Notification, e
 				// is equal.
 				matched[modPath] = true
 				origMatched = true
-				if !cmp.Equal(origVal, modVal) {
+				if !reflect.DeepEqual(origVal, modVal) {
 					// The contents of the value should indicate that value a has changed
 					// to value b.
 					if err := appendUpdate(n, origPath, modVal); err != nil {

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -261,7 +261,7 @@ func pruneBranchesInternal(t reflect.Type, v reflect.Value) bool {
 				// Ensure that if the field value was actually nil, we skip over this
 				// field since its already nil.
 				continue
-			case cmp.Equal(zVal.Interface(), fVal.Elem().Interface()):
+			case reflect.DeepEqual(zVal.Interface(), fVal.Elem().Interface()):
 				// In the case that the zero value's interface is the same as the
 				// dereferenced field value's nil value, then we set it to the zero value
 				// of the field type. The fType contains a pointer to the struct, so
@@ -321,7 +321,7 @@ func pruneBranchesInternal(t reflect.Type, v reflect.Value) bool {
 				v = v.Elem()
 				t = t.Elem()
 			}
-			if v.IsValid() && !cmp.Equal(reflect.Zero(t).Interface(), v.Interface()) {
+			if v.IsValid() && !reflect.DeepEqual(reflect.Zero(t).Interface(), v.Interface()) {
 				allChildrenPruned = false
 			}
 		}
@@ -870,7 +870,7 @@ func copySliceField(dstField, srcField reflect.Value, opts ...MergeOpt) error {
 	}
 
 	if _, ok := srcField.Interface().([]Annotation); !ok {
-		if cmp.Equal(srcField.Interface(), dstField.Interface()) {
+		if reflect.DeepEqual(srcField.Interface(), dstField.Interface()) {
 			return nil
 		}
 
@@ -918,7 +918,7 @@ func uniqueSlices(a, b reflect.Value) (bool, error) {
 
 	for i := 0; i < a.Len(); i++ {
 		for j := 0; j < b.Len(); j++ {
-			if cmp.Equal(a.Index(i).Interface(), b.Index(j).Interface()) {
+			if reflect.DeepEqual(a.Index(i).Interface(), b.Index(j).Interface()) {
 				return false, nil
 			}
 		}

--- a/ytypes/leafref.go
+++ b/ytypes/leafref.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
-	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
@@ -319,7 +318,7 @@ func matchesNodes(ni *util.NodeInfo, matchNodes []interface{}) (bool, error) {
 				// This is an interface value, which is represented as a struct pointer.
 				ovv := ov.Elem().FieldByIndex([]int{0})
 				svv := ni.FieldValue.Elem().Elem().FieldByIndex([]int{0})
-				if cmp.Equal(ovv.Interface(), svv.Interface()) {
+				if reflect.DeepEqual(ovv.Interface(), svv.Interface()) {
 					return true, nil
 				}
 			}

--- a/ytypes/util_json.go
+++ b/ytypes/util_json.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"
 )
@@ -37,7 +36,7 @@ func getJSONTreeValForField(parentSchema, schema *yang.Entry, f reflect.StructFi
 	var outPath []string
 	for _, p := range ps {
 		if jr, ok := getJSONTreeValForPath(tree, p); ok {
-			if out != nil && !cmp.Equal(out, jr) {
+			if out != nil && !reflect.DeepEqual(out, jr) {
 				return nil, fmt.Errorf("values at paths %v and %v are different: %v != %v", outPath, p, out, jr)
 			}
 			out = jr


### PR DESCRIPTION
From [cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp):
```
This package is intended to be a more powerful and safer alternative to
reflect.DeepEqual for comparing whether two values are semantically
equal. It is intended to only be used in tests, as performance is not a
goal and it may panic if it cannot compare the values. Its propensity
towards panicking means that its unsuitable for production environments
where a spurious panic may be fatal.
```