### PR TITLE
Do not Clone `PathElem`s when creating a map value's path.

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -462,13 +462,14 @@ func findUpdatedLeaves(leaves map[*path]interface{}, s GoStruct, parent *gnmiPat
 // key and value. The format of the path returned depends on the input format
 // of the parentPath.
 func mapValuePath(key, value reflect.Value, parentPath *gnmiPath) (*gnmiPath, error) {
-	childPath := &gnmiPath{}
+	var childPath *gnmiPath
 
 	if parentPath == nil {
 		return nil, fmt.Errorf("nil map paths supplied to mapValuePath for %v %v", key.Interface(), value.Interface())
 	}
 
 	if parentPath.isStringSlicePath() {
+		childPath = &gnmiPath{}
 		keyval, err := KeyValueAsString(key.Interface())
 		if err != nil {
 			return nil, fmt.Errorf("can't append path element key: %v", err)
@@ -480,10 +481,8 @@ func mapValuePath(key, value reflect.Value, parentPath *gnmiPath) (*gnmiPath, er
 		return childPath, nil
 	}
 
-	for _, e := range parentPath.pathElemPath {
-		n := proto.Clone(e).(*gnmipb.PathElem)
-		childPath.pathElemPath = append(childPath.pathElemPath, n)
-	}
+	// Only the pointer values are copied for performance.
+	childPath = parentPath.Copy()
 
 	return appendgNMIPathElemKey(value, childPath)
 }

--- a/ygot/schema_tests/schema_test.go
+++ b/ygot/schema_tests/schema_test.go
@@ -490,3 +490,38 @@ func TestNotificationOutput(t *testing.T) {
 		})
 	}
 }
+
+func getBenchmarkDevice() *exampleoc.Device {
+	intfs := []string{"eth0", "eth1", "eth2", "eth3"}
+	d := &exampleoc.Device{}
+	for _, intf := range intfs {
+		d.GetOrCreateInterface(intf)
+		is := d.GetOrCreateLldp().GetOrCreateInterface(intf).GetOrCreateNeighbor("neighbor")
+		is.LastUpdate = ygot.Int64(42)
+	}
+	return d
+}
+
+func BenchmarkNotificationOutput(b *testing.B) {
+	d := getBenchmarkDevice()
+	b.ResetTimer()
+	for i := 0; i != b.N; i++ {
+		if _, err := ygot.TogNMINotifications(d, 0, ygot.GNMINotificationsConfig{
+			UsePathElem: true,
+		}); err != nil {
+			b.Fatalf("cannot marshal input to gNMI Notifications, %v", err)
+		}
+	}
+}
+
+func BenchmarkNotificationOutputElement(b *testing.B) {
+	d := getBenchmarkDevice()
+	b.ResetTimer()
+	for i := 0; i != b.N; i++ {
+		if _, err := ygot.TogNMINotifications(d, 0, ygot.GNMINotificationsConfig{
+			UsePathElem: false,
+		}); err != nil {
+			b.Fatalf("cannot marshal input to gNMI Notifications, %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This seems to significantly improve the performance for a particular use case we have.

I didn't see any real concerns for removing the deep copy from the user's perspective. Already we're doing a shallow copy for the `parentPath` when going down a container, so I don't see why we can't do the same for each list value:
https://github.com/openconfig/ygot/blob/032d1f4934c23eef44b0460b010e1be9a93a8015/ygot/struct_validation_map.go#L63-L66

### Before
```
BenchmarkNotificationOutput-12                     10000            107130 ns/op <-
BenchmarkNotificationOutputElement-12              14344             83329 ns/op
```
### After
```
BenchmarkNotificationOutput-12                     12613             95651 ns/op <-
BenchmarkNotificationOutputElement-12              14298             84451 ns/op
```
## Using ldsbparse's benchmark
https://github.com/openconfig/lsdbparse/commit/a26f2872fad3d3833e42a2af5bc755d2f6effed6, improvement is seen in all cases:

### Before
```
BenchmarkRenderLSP/simple_example/usePathElem=false-12             30980             40603 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=false-12              4941            232762 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=false-12     52735             23445 ns/op
BenchmarkRenderLSP/simple_example/usePathElem=true-12              16990             69896 ns/op <-
BenchmarkRenderLSP/larger_example/usePathElem=true-12               3920            310921 ns/op <-
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=true-12      29058             46190 ns/op <-
```
### After
```
BenchmarkRenderLSP/simple_example/usePathElem=false-12             31563             39916 ns/op
BenchmarkRenderLSP/larger_example/usePathElem=false-12              5887            231510 ns/op
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=false-12     49760             24016 ns/op
BenchmarkRenderLSP/simple_example/usePathElem=true-12              20020             57853 ns/op <-
BenchmarkRenderLSP/larger_example/usePathElem=true-12               4416            285974 ns/op <-
BenchmarkRenderLSP/simple_-_pathelem_path/usePathElem=true-12      30146             41773 ns/op <-
```

I checked that for the case of `simple_-_pathelem_path`, one of the reasons it's taking longer after this optimization is due to this line, which gets called more by the benchmark since it's a smaller example:
```go
p, err := ygot.StringToStructuredPath(fmt.Sprintf("/network-instances/network-instance[name=%s]/protocols/protocol[identifier=ISIS][name=%s]/isis/levels/level[level-number=%d]/link-state-database/lsp[lsp-id=%s]", args.NetworkInstance, args.ProtocolInstance, args.Level, *lsp.LspId))
```