### PR TITLE
Add option to call `SetNode` with a JSON-encoded value.

### DIFF
--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -554,9 +554,8 @@ func hasInitMissingElements(opts []SetNodeOpt) bool {
 	return false
 }
 
-// UseJSONEncoding signals SetNode to tolerate inconsistencies for
-// val as if it were converted from JSON. As of right now, this is specifically
-// to deal with uint values being streamed as positive int values.
+// UseJSONEncoding signals SetNode that the input value is in JSON encoding
+// instead of gNMI's typed encoding.
 type UseJSONEncoding struct{}
 
 // IsSetNodeOpt implements the SetNodeOpt interface.
@@ -575,7 +574,8 @@ func hasUseJSONEncoding(opts []SetNodeOpt) bool {
 
 // TolerateJSONInconsistencies signals SetNode to tolerate inconsistencies for
 // val as if it were converted from JSON. As of right now, this is specifically
-// to deal with uint values being streamed as positive int values.
+// to deal with uint values being streamed as positive int values. If
+// useJSONEncoding is true, then this option is not applicable.
 type TolerateJSONInconsistencies struct{}
 
 // IsSetNodeOpt implements the SetNodeOpt interface.


### PR DESCRIPTION
Currently `SetNode` only allows gNMI typed values (aka `GNMIEncoding`)
to be unmarshalled; however, it is possible for a gNMI server implementation to receive
JSON-encoded leaves, which ygot currently doesn't provide the facility
for unmarshalling into a GoStruct. This change adds an option for JSON-encoded leaf
values to be unmarshalled using `SetNode`.