### PR TITLE
Specify latest release of staticcheck rather than HEAD.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Install protoc-gen-go
         run: |
-          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go
+          go install google.golang.org/protobuf/cmd/protoc-gen-go
 
       - name: Install goimports
         run: |
-          GO111MODULE=on go install golang.org/x/tools/cmd/goimports
+          go install golang.org/x/tools/cmd/goimports
 
       - name: Install Staticcheck
         run: |
-          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -126,14 +126,14 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.x'
         id: go
 
       - name: Install required static analysis tools
         run: |
-          GO111MODULE=on go install github.com/go-playground/overalls
-          GO111MODULE=on go install github.com/mattn/goveralls
-          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install github.com/go-playground/overalls
+          go install github.com/mattn/goveralls
+          go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Install protoc-gen-go
         run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
       - name: Install goimports
         run: |
-          go install golang.org/x/tools/cmd/goimports
+          go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Install Staticcheck
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -131,8 +131,8 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          go install github.com/go-playground/overalls
-          go install github.com/mattn/goveralls
+          go install github.com/go-playground/overalls@latest
+          go install github.com/mattn/goveralls@latest
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Install protoc-gen-go
         run: |
-          GO111MODULE=on go install -u google.golang.org/protobuf/cmd/protoc-gen-go
+          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go
 
       - name: Install goimports
         run: |
-          GO111MODULE=on go install -u golang.org/x/tools/cmd/goimports
+          GO111MODULE=on go install golang.org/x/tools/cmd/goimports
 
       - name: Install Staticcheck
         run: |
-          GO111MODULE=on go install -u honnef.co/go/tools/cmd/staticcheck
+          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -131,9 +131,9 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          GO111MODULE=on go install -u github.com/go-playground/overalls
-          GO111MODULE=on go install -u github.com/mattn/goveralls
-          GO111MODULE=on go install -u honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go install github.com/go-playground/overalls
+          GO111MODULE=on go install github.com/mattn/goveralls
+          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,11 +31,12 @@ jobs:
       - if: ${{ matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15' }}
         name: Install protoc-gen-go, goimports, Staticcheck
         run: |
-          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest
-          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go get google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          GO111MODULE=on go get golang.org/x/tools/cmd/goimports@latest
+          GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@latest
 
-      - if: ${{ matrix.go != '1.13' && matrix.go != '1.14' && matrix.go == '1.15' }}
+      - if: ${{ !(matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15') }}
+        name: Install protoc-gen-go, goimports, Staticcheck
         run: |
           GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,9 +38,9 @@ jobs:
       - if: ${{ !(matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15') }}
         name: Install protoc-gen-go, goimports, Staticcheck
         run: |
-          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest
-          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install golang.org/x/tools/cmd/goimports@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -133,9 +133,9 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          GO111MODULE=on go install github.com/go-playground/overalls@latest
-          GO111MODULE=on go install github.com/mattn/goveralls@latest
-          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install github.com/go-playground/overalls@latest
+          go install github.com/mattn/goveralls@latest
+          go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,16 +28,17 @@ jobs:
           go-version: ${{ matrix.go }}
         id: go
 
-      - name: Install protoc-gen-go
+      - if: ${{ matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15' }}
+        name: Install protoc-gen-go, goimports, Staticcheck
         run: |
           GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-
-      - name: Install goimports
-        run: |
           GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest
+          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
 
-      - name: Install Staticcheck
+      - if: ${{ matrix.go != '1.13' && matrix.go != '1.14' && matrix.go == '1.15' }}
         run: |
+          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest
           GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out code

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Staticcheck
         run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck
+          go get -u honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
         run: |
           go get -u github.com/go-playground/overalls
           go get -u github.com/mattn/goveralls
-          go get -u honnef.co/go/tools/cmd/staticcheck
+          go get -u honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Install protoc-gen-go
         run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          GO111MODULE=on go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
       - name: Install goimports
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          GO111MODULE=on go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Install Staticcheck
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -131,9 +131,9 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          go install github.com/go-playground/overalls@latest
-          go install github.com/mattn/goveralls@latest
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go install github.com/go-playground/overalls@latest
+          GO111MODULE=on go install github.com/mattn/goveralls@latest
+          GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Install protoc-gen-go
         run: |
-          go get -u google.golang.org/protobuf/cmd/protoc-gen-go
+          GO111MODULE=on go install -u google.golang.org/protobuf/cmd/protoc-gen-go
 
       - name: Install goimports
         run: |
-          go get -u golang.org/x/tools/cmd/goimports
+          GO111MODULE=on go install -u golang.org/x/tools/cmd/goimports
 
       - name: Install Staticcheck
         run: |
-          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go install -u honnef.co/go/tools/cmd/staticcheck
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -131,9 +131,9 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          go get -u github.com/go-playground/overalls
-          go get -u github.com/mattn/goveralls
-          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+          GO111MODULE=on go install -u github.com/go-playground/overalls
+          GO111MODULE=on go install -u github.com/mattn/goveralls
+          GO111MODULE=on go install -u honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Check out ygot code
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently, the scheduled build runs are failing due to unresolved references in the HEAD of staticcheck.
