### PR TITLE
Remove log that is always generated for annotation fields.

### DIFF
--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/golang/glog"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/util"

--- a/ytypes/container.go
+++ b/ytypes/container.go
@@ -158,7 +158,6 @@ func unmarshalStruct(schema *yang.Entry, parent interface{}, jsonTree map[string
 		// Skip annotation fields since they do not have a schema.
 		// TODO(robjs): Implement unmarshalling annotations.
 		if util.IsYgotAnnotation(ft) {
-			log.Infof("ignoring annotation field %s during unmarshalling, unsupported", ft.Name)
 			// We need to find the paths that we should have unmarshalled here to avoid
 			// throwing errors to users whilst there is a TODO above.
 			paths, err := pathTagFromField(ft)


### PR DESCRIPTION
```
 * (M) ytypes/container.go
  - Since schemas that are generated with annotations will always
    generate the log that says that unmarshal into them is unsupported
    the log message produced is extremely low value to a user. To this
    end - just remove it.
```

@wenovus -- I concluded that it was just higher-value to remove this entirely. Given that the user knows that they generated the code with annotations, then I'm not sure they ever will have value from this log.

An alternative would be to check that the annotation field was populated, and then produce this log, but I think this seems like we should just implement unmarshalling annotations. I can look at this as a future task.
