### PR TITLE
More accurate enum naming and classification according to namesake type.

### DIFF
--- a/testdata/modules/openconfig-complex.yang
+++ b/testdata/modules/openconfig-complex.yang
@@ -94,7 +94,9 @@ module openconfig-complex {
     }
 
     leaf leaf-default-override {
-      type cyclone-scales;
+      type union {
+        type cyclone-scales;
+      }
       default 3;
     }
   }

--- a/ygen/enumgen.go
+++ b/ygen/enumgen.go
@@ -130,7 +130,7 @@ func (s *enumSet) enumeratedUnionEntry(e *yang.Entry, compressPaths, noUnderscor
 
 			var enumKind EnumeratedValueType
 			switch {
-			case len(enumNameSake.Type) > 0 && util.IsYANGBaseType(e.Type):
+			case len(enumNameSake.Type) > 0 && util.IsYANGBaseType(enumNameSake):
 				enumKind = UnionEnumerationType
 			case len(enumNameSake.Type) > 0:
 				enumKind = DerivedUnionEnumerationType
@@ -143,7 +143,7 @@ func (s *enumSet) enumeratedUnionEntry(e *yang.Entry, compressPaths, noUnderscor
 				entry: &yang.Entry{
 					Name: e.Name,
 					Type: &yang.YangType{
-						Name: e.Type.Name,
+						Name: enumNameSake.Name,
 						Kind: yang.Yenum,
 						Enum: t.Enum,
 					},

--- a/ygen/genir_test.go
+++ b/ygen/genir_test.go
@@ -1475,7 +1475,7 @@ func TestGenerateIR(t *testing.T) {
 								SchemaPath:        "/model/a/single-key/config/leaf-default-override",
 								LeafrefTargetPath: "",
 								Description:       "",
-								Type:              &YANGType{Name: "cyclone-scales"},
+								Type:              &YANGType{Name: "union"},
 							},
 							Type: LeafNode,
 							LangType: &MappedType{
@@ -1705,7 +1705,7 @@ func TestGenerateIR(t *testing.T) {
 				"Complex_WeekendDays": {
 					Name:     "Complex_WeekendDays",
 					Kind:     DerivedEnumerationType,
-					TypeName: "days-of-week",
+					TypeName: "weekend-days",
 					ValToYANGDetails: []ygot.EnumDefinition{
 						{
 							Name:           "SATURDAY",

--- a/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
+++ b/ygen/testdata/proto/enum-union.compress.enums.formatted-txt
@@ -18,7 +18,7 @@ enum EnumUnionCycloneScalesEnum {
   ENUMUNIONCYCLONESCALESENUM_SUPER = 2 [(yext.yang_name) = "SUPER"];
 }
 
-// EnumUnionWeekendDays represents an enumerated type generated for the YANG enumerated type union.
+// EnumUnionWeekendDays represents an enumerated type generated for the YANG enumerated type weekend-days.
 enum EnumUnionWeekendDays {
   ENUMUNIONWEEKENDDAYS_UNSET = 0;
   ENUMUNIONWEEKENDDAYS_SATURDAY = 1 [(yext.yang_name) = "SATURDAY"];


### PR DESCRIPTION
Currently for unions it uses the outer-most union for the name and the type classification, but it should rather use the namesake union instead.

The integration test changes are due to **unused enums** now removed from the generated file because these were inline enums that should never have been generated in the global enum file.