### PR TITLE
Add `ConfigFalse` field to IR's `ParsedDirectories`.

### DIFF
--- a/ygen/directory.go
+++ b/ygen/directory.go
@@ -186,6 +186,7 @@ func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory
 			BelongingModule:   belongingModule,
 			DefiningModule:    definingModuleName,
 			RootElementModule: rootModule,
+			ConfigFalse:       !util.IsConfig(dir.Entry),
 		}
 		switch {
 		case dir.Entry.IsList():

--- a/ygen/genir_test.go
+++ b/ygen/genir_test.go
@@ -1002,6 +1002,7 @@ func TestGenerateIR(t *testing.T) {
 					BelongingModule:   "openconfig-simple",
 					RootElementModule: "openconfig-simple",
 					DefiningModule:    "openconfig-simple",
+					ConfigFalse:       true,
 				},
 				"/openconfig-simple/remote-container": {
 					Name: "OpenconfigSimple_RemoteContainer",
@@ -1122,6 +1123,7 @@ func TestGenerateIR(t *testing.T) {
 					BelongingModule:   "openconfig-simple",
 					RootElementModule: "openconfig-simple",
 					DefiningModule:    "openconfig-remote",
+					ConfigFalse:       true,
 				},
 			},
 			Enums: map[string]*EnumeratedYANGType{

--- a/ygen/ir.go
+++ b/ygen/ir.go
@@ -260,6 +260,9 @@ type ParsedDirectory struct {
 	// DefiningModule is the module that contains the text definition of
 	// the field.
 	DefiningModule string
+	// ConfigFalse represents whether the node is state data as opposed to
+	// configuration data.
+	ConfigFalse bool
 }
 
 // OrderedFieldNames returns the YANG name of all fields belonging to the

--- a/ygen/ir.go
+++ b/ygen/ir.go
@@ -262,6 +262,9 @@ type ParsedDirectory struct {
 	DefiningModule string
 	// ConfigFalse represents whether the node is state data as opposed to
 	// configuration data.
+	// The meaning of "config" is exactly the same as the "config"
+	// statement in YANG:
+	// https://datatracker.ietf.org/doc/html/rfc7950#section-7.21.1
 	ConfigFalse bool
 }
 


### PR DESCRIPTION
This value corresponds to
https://datatracker.ietf.org/doc/html/rfc7950#section-7.21.1

This is needed in order to finish refactoring ygnmi to use IR, which needs this value to know whether to allow a user to multiplex a path using a `dut.Telemetry().Interfaces("foo").Config()` and `dut.Telemetry().Interfaces("foo").State()`.

The reason I chose `ConfigFalse` instead of just `Config` is because "config true" is the default value and is much more common in the OpenConfig models.