### PR TITLE
Use bash instead of overalls

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -131,7 +131,6 @@ jobs:
 
       - name: Install required static analysis tools
         run: |
-          go install github.com/go-playground/overalls@latest
           go install github.com/mattn/goveralls@latest
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
@@ -150,16 +149,16 @@ jobs:
             go test -covermode count -coverprofile profile.coverprofile -outputdir $dir $p
           done
 
-          echo 'mode: count' > overalls.coverprofile
+          echo 'mode: count' > concatenated.coverprofile
           for p in $pkgs; do
             dir=$(echo $p | sed -e 's/^github\.com\/openconfig\/ygot\///')
-            tail -n +2 $dir/profile.coverprofile >> overalls.coverprofile
+            tail -n +2 $dir/profile.coverprofile >> concatenated.coverprofile
           done
 
       - name: Submit coverage
         uses: shogo82148/actions-goveralls@v1
         with:
-          path-to-profile: overalls.coverprofile
+          path-to-profile: concatenated.coverprofile
 
       - name: Go vet
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -144,7 +144,17 @@ jobs:
 
       - name: Run coverage
         run: |
-          overalls -project ${GITHUB_WORKSPACE} -covermode=count -ignore=".git,vendor,integration_tests,ygot/schema_tests,ygen/schema_tests,ypathgen/path_tests,demo,experimental/ygotutils,generator,ytypes/schema_tests,ypathgen/generator"
+          pkgs="$(go list ./... | grep -v 'github.com/openconfig/ygot/exampleoc' | grep -v 'github.com/openconfig/ygot/uexampleoc' | grep -v 'github.com/openconfig/ygot/proto/' | grep -v 'github.com/openconfig/ygot/demo/' | grep -v 'github.com/openconfig/ygot/integration_tests' | grep -v 'github.com/openconfig/ygot/generator' | tr '\n' ' ')"
+          for p in $pkgs; do
+            dir=$(echo $p | sed -e 's/^github\.com\/openconfig\/ygot\///')
+            go test -covermode count -coverprofile profile.coverprofile -outputdir $dir $p
+          done
+
+          echo 'mode: count' > overalls.coverprofile
+          for p in $pkgs; do
+            dir=$(echo $p | sed -e 's/^github\.com\/openconfig\/ygot\///')
+            tail -n +2 $dir/profile.coverprofile >> overalls.coverprofile
+          done
 
       - name: Submit coverage
         uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION
Exactly the same results:
* before: https://coveralls.io/builds/49771275
* after: https://coveralls.io/builds/49782021

This is to enable more flexible coverage reporting if there are cross-package unit tests.