### PR TITLE
Remove expectation that nil maps and slices (YANG lists) are initialized by `BuildEmptyTree`

### DIFF
--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -793,8 +793,6 @@ func TestBuildEmptyTree(t *testing.T) {
 		name:     "struct with children",
 		inStruct: &emptyTreeTestTwo{},
 		want: &emptyTreeTestTwo{
-			SliceVal:     []*emptyTreeTestTwoChild{},
-			MapVal:       map[string]*emptyTreeTestTwoChild{},
 			StructVal:    &emptyTreeTestTwoChild{},
 			StructValTwo: &emptyTreeTestTwoChild{},
 		},
@@ -815,7 +813,7 @@ func TestBuildEmptyTree(t *testing.T) {
 
 	for _, tt := range tests {
 		BuildEmptyTree(tt.inStruct)
-		if diff := pretty.Compare(tt.inStruct, tt.want); diff != "" {
+		if diff := cmp.Diff(tt.inStruct, tt.want); diff != "" {
 			t.Errorf("%s: did not get expected output, diff(-got,+want):\n%s", tt.name, diff)
 		}
 	}


### PR DESCRIPTION
Using `pretty.Compare` has masked this issue. Since it's possible users might have already depending on the current behaviour I wanted to be conservative and just keep the current behaviour, which I think is reasonable -- given the current generated code essentially we're saying we'd initialize containers but not lists.