### PR TITLE
Run go generate ./... for CI check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,7 +51,7 @@ jobs:
         working-directory: go/src/github.com/openconfig/ygot
 
       - name: Generate dependencies
-        run: make generate
+        run: go generate ./...
         working-directory: go/src/github.com/openconfig/ygot
 
       - name: Build packages

--- a/demo/protobuf_getting_started/demo.go
+++ b/demo/protobuf_getting_started/demo.go
@@ -17,6 +17,8 @@
 // to generate a Protobuf form of the OpenConfig RIB model.
 package main
 
+//go:generate ./update.sh
+
 import (
 	"fmt"
 

--- a/demo/protobuf_getting_started/update.sh
+++ b/demo/protobuf_getting_started/update.sh
@@ -17,8 +17,6 @@ go run ../../proto_generator/protogenerator.go \
   -base_import_path="github.com/openconfig/ygot/demo/protobuf_getting_started/ribproto" \
   -go_package_base="github.com/openconfig/ygot/demo/protobuf_getting_started/ribproto" \
   -path=yang -output_dir=ribproto \
-  -typedef_enum_with_defmod \
-  -consistent_union_enum_names \
   -enum_package_name=enums -package_name=openconfig \
   -exclude_modules=ietf-interfaces \
   yang/rib/openconfig-rib-bgp.yang


### PR DESCRIPTION
Thanks for the comment here: https://github.com/openconfig/ygot/pull/699#pullrequestreview-998955556 I realized we weren't actually checking that the `u?exampleoc` packages actually regenerates with the current CI.