### PR TITLE
Unmarshal SetRequest and Notification to a root GoStruct.

### DIFF
--- a/ytypes/gnmi.go
+++ b/ytypes/gnmi.go
@@ -13,6 +13,10 @@ import (
 // UnmarshalNotifications unmarshals a Notification on a root GoStruct specified by
 // "schema", and returns a reference to it.
 //
+// It does not make a copy and overwrites this value, so make a copy using
+// ygot.DeepCopy() if you wish to retain the value at schema.Root prior to
+// calling this function.
+//
 // - If preferShadowPath is specified, then the shadow path values are
 // unmarshalled instead of non-shadow path values when GoStructs are generated
 // with shadow paths.
@@ -40,7 +44,11 @@ func UnmarshalNotifications(schema *Schema, ns []*gpb.Notification, preferShadow
 }
 
 // UnmarshalSetRequest applies a SetRequest on a root GoStruct specified by
-// "schema", and returns a reference to it.
+// "schema", and returns a reference to the resulting schema.Root.
+//
+// It does not make a copy and overwrites this value, so make a copy using
+// ygot.DeepCopy() if you wish to retain the value at schema.Root prior to
+// calling this function.
 //
 // - If preferShadowPath is specified, then the shadow path values are
 // unmarshalled instead of non-shadow path values when GoStructs are generated

--- a/ytypes/gnmi_test.go
+++ b/ytypes/gnmi_test.go
@@ -1,0 +1,424 @@
+package ytypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func TestUnmarshalSetRequest(t *testing.T) {
+	tests := []struct {
+		desc               string
+		inSchema           *Schema
+		inReq              *gpb.SetRequest
+		inPreferShadowPath bool
+		want               ygot.GoStruct
+		wantErr            bool
+	}{{
+		desc: "updates to an empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: &gpb.Path{},
+			Update: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+			}, {
+				Path: mustPath("/outer/inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafListName: []int32{42},
+				},
+			},
+		},
+	}, {
+		desc: "updates to non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{100},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: &gpb.Path{},
+			Update: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+			}, {
+				Path: mustPath("/outer/inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafName:     ygot.Int32(43),
+					Int32LeafListName: []int32{42},
+					StringLeafName:    ygot.String("bear"),
+				},
+			},
+		},
+	}, {
+		desc: "replaces and update to a non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: &gpb.Path{},
+			Replace: []*gpb.Update{{
+				Path: mustPath("/outer/inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+			Update: []*gpb.Update{{
+				Path: mustPath("/outer/inner/string-leaf-field"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{
+					StringVal: "foo",
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafListName: []int32{42},
+					StringLeafName:    ygot.String("foo"),
+				},
+			},
+		},
+	}, {
+		desc: "deletes to a non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: &gpb.Path{},
+			Delete: []*gpb.Path{
+				mustPath("/outer"),
+			},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+		},
+	}, {
+		desc: "deletes, replaces and update to a non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: &gpb.Path{},
+			Delete: []*gpb.Path{
+				mustPath("/outer/inner"),
+			},
+			Replace: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "world"}},
+			}},
+			Update: []*gpb.Update{{
+				Path: mustPath("/outer/inner/string-leaf-field"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{
+					StringVal: "foo",
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("world"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					StringLeafName: ygot.String("foo"),
+				},
+			},
+		},
+	}, {
+		desc: "replaces to a non-empty struct with prefix",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1":     simpleSchema(),
+				"OuterContainerType1": simpleSchema().Dir["outer"],
+			},
+		},
+		inReq: &gpb.SetRequest{
+			Prefix: mustPath("/outer"),
+			Replace: []*gpb.Update{{
+				Path: mustPath("inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafListName: []int32{42},
+				},
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := UnmarshalSetRequest(tt.inSchema, tt.inReq, tt.inPreferShadowPath)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Fatalf("got error: %v, want: %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("(-got, +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalNotification(t *testing.T) {
+	tests := []struct {
+		desc               string
+		inSchema           *Schema
+		inReq              *gpb.Notification
+		inPreferShadowPath bool
+		want               ygot.GoStruct
+		wantErr            bool
+	}{{
+		desc: "updates to an empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.Notification{
+			Prefix: &gpb.Path{},
+			Update: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+			}, {
+				Path: mustPath("/outer/inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafListName: []int32{42},
+				},
+			},
+		},
+	}, {
+		desc: "updates to non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{100},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.Notification{
+			Prefix: &gpb.Path{},
+			Update: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+			}, {
+				Path: mustPath("/outer/inner"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{
+					JsonIetfVal: []byte(`
+{
+	"int32-leaf-list": [42]
+}
+					`),
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					Int32LeafName:     ygot.Int32(43),
+					Int32LeafListName: []int32{42},
+					StringLeafName:    ygot.String("bear"),
+				},
+			},
+		},
+	}, {
+		desc: "deletes to a non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.Notification{
+			Prefix: &gpb.Path{},
+			Delete: []*gpb.Path{
+				mustPath("/outer"),
+			},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("hello"),
+		},
+	}, {
+		desc: "deletes and updates to a non-empty struct",
+		inSchema: &Schema{
+			Root: &ListElemStruct1{
+				Key1: ygot.String("hello"),
+				Outer: &OuterContainerType1{
+					Inner: &InnerContainerType1{
+						Int32LeafName:     ygot.Int32(43),
+						Int32LeafListName: []int32{42},
+						StringLeafName:    ygot.String("bear"),
+					},
+				},
+			},
+			SchemaTree: map[string]*yang.Entry{
+				"ListElemStruct1": simpleSchema(),
+			},
+		},
+		inReq: &gpb.Notification{
+			Prefix: &gpb.Path{},
+			Delete: []*gpb.Path{
+				mustPath("/outer/inner"),
+			},
+			Update: []*gpb.Update{{
+				Path: mustPath("/key1"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "world"}},
+			}, {
+				Path: mustPath("/outer/inner/string-leaf-field"),
+				Val: &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{
+					StringVal: "foo",
+				}},
+			}},
+		},
+		want: &ListElemStruct1{
+			Key1: ygot.String("world"),
+			Outer: &OuterContainerType1{
+				Inner: &InnerContainerType1{
+					StringLeafName: ygot.String("foo"),
+				},
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := UnmarshalNotification(tt.inSchema, tt.inReq, tt.inPreferShadowPath)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Fatalf("got error: %v, want: %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("(-got, +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -16,6 +16,7 @@ package ytypes
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -60,7 +61,12 @@ func (l *ListElemStruct1) ΛListKeyMap() (map[string]interface{}, error) {
 }
 func (*ListElemStruct1) IsYANGGoStruct() {}
 
-func (*ListElemStruct1) ΛValidate(...ygot.ValidationOption) error { return nil }
+func (s *ListElemStruct1) ΛValidate(...ygot.ValidationOption) error {
+	if s.Key1 != nil && *s.Key1 == "invalid" {
+		return errors.New("invalid")
+	}
+	return nil
+}
 
 type ContainerStruct1 struct {
 	StructKeyList map[string]*ListElemStruct1 `path:"config/simple-key-list"`

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -60,6 +60,8 @@ func (l *ListElemStruct1) ΛListKeyMap() (map[string]interface{}, error) {
 }
 func (*ListElemStruct1) IsYANGGoStruct() {}
 
+func (*ListElemStruct1) ΛValidate(...ygot.ValidationOption) error { return nil }
+
 type ContainerStruct1 struct {
 	StructKeyList map[string]*ListElemStruct1 `path:"config/simple-key-list"`
 }


### PR DESCRIPTION
Possible use cases:
* Maintaining a schema-aware view of the configuration at a gNMI server.
* Simulating the effects of a SetRequest to compare against results from a server.