### PR TITLE
Ensure that path annotations are created for leaf-list of unions.

### DIFF
--- a/protogen/protogen_test.go
+++ b/protogen/protogen_test.go
@@ -315,10 +315,18 @@ func TestGenProto3Msg(t *testing.T) {
 						Tag:  225170402,
 						Name: "field_one_sint64",
 						Type: "sint64",
+						Options: []*protoOption{{
+							Name:  "(yext.schemapath)",
+							Value: `"/field-one"`,
+						}},
 					}, {
 						Tag:  299030977,
 						Name: "field_one_string",
 						Type: "string",
+						Options: []*protoOption{{
+							Name:  "(yext.schemapath)",
+							Value: `"/field-one"`,
+						}},
 					}},
 				}},
 			},
@@ -1930,14 +1938,15 @@ func TestUnionFieldToOneOf(t *testing.T) {
 		inName  string
 		inField *ygen.NodeDetails
 		// inPath is populated with field.YANGDetails.Path if not set.
-		inPath              string
-		inMappedType        *ygen.MappedType
-		inEnums             map[string]*ygen.EnumeratedYANGType
-		inAnnotateEnumNames bool
-		wantFields          []*protoMsgField
-		wantEnums           map[string]*protoMsgEnum
-		wantRepeatedMsg     *protoMsg
-		wantErr             bool
+		inPath                string
+		inMappedType          *ygen.MappedType
+		inEnums               map[string]*ygen.EnumeratedYANGType
+		inAnnotateEnumNames   bool
+		inAnnotateSchemaPaths bool
+		wantFields            []*protoMsgField
+		wantEnums             map[string]*protoMsgEnum
+		wantRepeatedMsg       *protoMsg
+		wantErr               bool
 	}{{
 		name:   "simple string union",
 		inName: "FieldName",
@@ -2188,6 +2197,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 				Name: "field-name",
 				Path: "/parent/field-name",
 			},
+			MappedPaths: [][]string{{"", "parent", "field-name"}},
 			LangType: &ygen.MappedType{
 				UnionTypes: map[string]ygen.MappedUnionSubtype{
 					"string": {
@@ -2209,6 +2219,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 				},
 			},
 		},
+		inAnnotateSchemaPaths: true,
 		wantRepeatedMsg: &protoMsg{
 			Name:     "FieldNameUnion",
 			YANGPath: "/parent/field-name union field field-name",
@@ -2216,10 +2227,18 @@ func TestUnionFieldToOneOf(t *testing.T) {
 				Tag:  85114709,
 				Name: "FieldName_string",
 				Type: "string",
+				Options: []*protoOption{{
+					Name:  "(yext.schemapath)",
+					Value: `"/parent/field-name"`,
+				}},
 			}, {
 				Tag:  192993976,
 				Name: "FieldName_uint64",
 				Type: "uint64",
+				Options: []*protoOption{{
+					Name:  "(yext.schemapath)",
+					Value: `"/parent/field-name"`,
+				}},
 			}},
 		},
 	}}
@@ -2228,7 +2247,7 @@ func TestUnionFieldToOneOf(t *testing.T) {
 		if tt.inPath == "" {
 			tt.inPath = tt.inField.YANGDetails.Path
 		}
-		got, err := unionFieldToOneOf(tt.inName, tt.inField, tt.inPath, tt.inMappedType, tt.inEnums, tt.inAnnotateEnumNames)
+		got, err := unionFieldToOneOf(tt.inName, tt.inField, tt.inPath, tt.inMappedType, tt.inEnums, tt.inAnnotateEnumNames, tt.inAnnotateSchemaPaths)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%s: unionFieldToOneOf(%s, %v, %v, %v): did not get expected error, got: %v, wanted err: %v", tt.name, tt.inName, tt.inField, tt.inMappedType, tt.inAnnotateEnumNames, err, tt.wantErr)
 		}

--- a/protogen/testdata/proto/nested-messages.compressed.nested_messages.formatted-txt
+++ b/protogen/testdata/proto/nested-messages.compressed.nested_messages.formatted-txt
@@ -42,8 +42,8 @@ message TopLevel {
   }
   message Idref {
     message UUnion {
-      string u_string = 44885770;
-      uint64 u_uint64 = 423874955;
+      string u_string = 44885770 [(yext.schemapath) = "/top-level/idrefsc/idref/config/u"];
+      uint64 u_uint64 = 423874955 [(yext.schemapath) = "/top-level/idrefsc/idref/config/u"];
     }
     ywrapper.StringValue l = 372609659 [(yext.schemapath) = "/top-level/idrefsc/idref/config/l"];
     repeated UUnion u = 372609634 [(yext.schemapath) = "/top-level/idrefsc/idref/config/u"];

--- a/protogen/testdata/proto/nested-messages.nested_messages.formatted-txt
+++ b/protogen/testdata/proto/nested-messages.nested_messages.formatted-txt
@@ -74,8 +74,8 @@ message TopLevel {
     message Idref {
       message Config {
         message UUnion {
-          string u_string = 44885770;
-          uint64 u_uint64 = 423874955;
+          string u_string = 44885770 [(yext.schemapath) = "/top-level/idrefsc/idref/config/u"];
+          uint64 u_uint64 = 423874955 [(yext.schemapath) = "/top-level/idrefsc/idref/config/u"];
         }
         openconfig.enums.NestedMessagesKEY i = 372609662 [(yext.schemapath) = "/top-level/idrefsc/idref/config/i"];
         ywrapper.StringValue l = 372609659 [(yext.schemapath) = "/top-level/idrefsc/idref/config/l"];
@@ -83,8 +83,8 @@ message TopLevel {
       }
       message State {
         message UUnion {
-          string u_string = 362654037;
-          uint64 u_uint64 = 470533304;
+          string u_string = 362654037 [(yext.schemapath) = "/top-level/idrefsc/idref/state/u"];
+          uint64 u_uint64 = 470533304 [(yext.schemapath) = "/top-level/idrefsc/idref/state/u"];
         }
         openconfig.enums.NestedMessagesKEY i = 500927979 [(yext.schemapath) = "/top-level/idrefsc/idref/state/i"];
         ywrapper.StringValue l = 500927982 [(yext.schemapath) = "/top-level/idrefsc/idref/state/l"];


### PR DESCRIPTION
```
 * (M) protogen/protogen(_test)?.go
  - Add support for adding schema path annotations for unions that
    are within leaf-lists. This is represented as a repeated
    message rather than a single oneof.
 * (M) protogen/testdata/*
  - Update testing data.
```
