### PR TITLE
Add authentication token for setup-protoc.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,7 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
```
* (M) .github/workflows/go.yml
   - Add authentication token to avoid failures due to API rate limit.
```

This fixes the failing cron'd CI runs.
