### PR TITLE
Fix syntax error in CIFuzz workflow.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,4 @@
 name: CIFuzz
-on: []
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apologies, missed that the empty triggers are not valid.
