### PR TITLE
Add bad-build-check: false to CIFuzz & add 1.19 and 1.20 to Go CI

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -7,11 +7,11 @@ jobs:
     - name: Build Fuzzers
       id: build
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-      bad-build-check: false
       with:
         oss-fuzz-project-name: 'ygot'
         dry-run: false
         language: go
+        bad-build-check: false
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,4 +1,5 @@
 name: CIFuzz
+on: [pull_request]
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
@@ -6,6 +7,7 @@ jobs:
     - name: Build Fuzzers
       id: build
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      bad-build-check: false
       with:
         oss-fuzz-project-name: 'ygot'
         dry-run: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.x']
+        go: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.x']
 
     steps:
       - name: Install protobuf


### PR DESCRIPTION
Fixed as recommended in https://github.com/google/oss-fuzz/issues/9367#issuecomment-1400559396

```
2023-02-06 18:37:56,986 - root - INFO - Fuzzer fuzz_oc_unmarshall finished running without reportable crashes.
```