### PR TITLE
Add utility `flattenOCJSON` in package `gnmidiff`

### DIFF
--- a/gnmidiff/json.go
+++ b/gnmidiff/json.go
@@ -1,0 +1,134 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmidiff
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/openconfig/ygot/ygot"
+)
+
+// flattenOCJSON outputs all leaf path-value pairs in the root per RFC7951.
+//
+// It assumes the input JSON is with respect to OpenConfig-compliant YANG.
+// See the following for checking compliance:
+// * https://github.com/openconfig/oc-pyang
+// * https://github.com/openconfig/public/blob/master/doc/openconfig_style_guide.md
+//
+// Output path format is per gNMI's path conventions.
+//
+// e.g.
+// {
+//   "openconfig-network-instance:config": {
+//     "description": "VRF RED",
+//     "enabled": true,
+//     "enabled-address-families": [
+//       "openconfig-types:IPV4",
+//       "openconfig-types:IPV6"
+//     ],
+//     "name": "RED",
+//     "type": "openconfig-network-instance-types:L3VRF"
+//     },
+//   "openconfig-network-instance:name": "RED"
+// }
+//
+// returns
+// {
+//   "openconfig-network-instance:config/description": "VRF RED",
+//   "openconfig-network-instance:config/enabled": true,
+//   "openconfig-network-instance:config/enabled-address-families": ["openconfig-types:IPV4", "openconfig-types:IPV6"],
+//   "openconfig-network-instance:config/name": "RED",
+//   "openconfig-network-instance:config/type": "openconfig-network-instance-types:L3VRF",
+//   "openconfig-network-instance:name": "RED",
+// }
+func flattenOCJSON(json7951 []byte) (map[string]interface{}, error) {
+	// TODO: Add option to remove the namespace on paths of returned updates.
+	var root interface{}
+	if err := json.Unmarshal(json7951, &root); err != nil {
+		return nil, fmt.Errorf("gnmidiff: %v", err)
+	}
+	leaves := map[string]interface{}{}
+	if err := flattenOCJSONAux(root, "", leaves); err != nil {
+		return nil, err
+	}
+	return leaves, nil
+}
+
+func flattenOCJSONAux(root interface{}, path string, leaves map[string]interface{}) error {
+	switch v := root.(type) {
+	case bool, float64, string:
+		leaves[path] = root
+	case []interface{}:
+		if len(v) == 0 {
+			// These must be leaf-lists since you can't set a
+			// list to nothing, only delete it or update descendant leaves.
+			leaves[path] = root
+			// If this assumption is wrong, and the list is later updated, an
+			// error will be returned due to a prefix-match in the flattened updates.
+		} else {
+			switch v[0].(type) {
+			case bool, float64, string:
+				leaves[path] = root
+			case []interface{}:
+				return fmt.Errorf("invalid RFC7951 JSON: list within a list: %v contains %v", v, v[0])
+			case map[string]interface{}:
+				// v is a list.
+				for _, ele := range v {
+					listele, ok := ele.(map[string]interface{})
+					if !ok {
+						return fmt.Errorf("invalid RFC7951 JSON: array has different element types: %v", v)
+					}
+					keyVals := map[string]string{}
+					var keyNames []string
+					for name, subv := range listele {
+						// Here we assume that the JSON follows OpenConfig YANG style guidelines
+						// and so the direct leafs MUST exactly be the list keys.
+						// To keep consistent, we write them in order in the path.
+						switch subsubv := subv.(type) {
+						case bool, float64, string:
+							var err error
+							if keyVals[name], err = ygot.KeyValueAsString(subsubv); err != nil {
+								return fmt.Errorf("gnmidiff cannot convert key value to string: %v", err)
+							}
+							keyNames = append(keyNames, name)
+						}
+					}
+					sort.Strings(keyNames)
+					var listelepath string
+					for _, name := range keyNames {
+						listelepath += fmt.Sprintf("[%s=%s]", name, keyVals[name])
+					}
+					if err := flattenOCJSONAux(listele, path+listelepath, leaves); err != nil {
+						return err
+					}
+				}
+			default:
+				return fmt.Errorf("unrecognized JSON type: (%T, %v)", v[0], v[0])
+			}
+		}
+	case map[string]interface{}:
+		// This is a container or a list element.
+		for subpath, subv := range v {
+			if err := flattenOCJSONAux(subv, path+"/"+subpath, leaves); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unrecognized JSON type: (%T, %v)", root, root)
+	}
+	return nil
+}

--- a/gnmidiff/json.go
+++ b/gnmidiff/json.go
@@ -78,7 +78,7 @@ func flattenOCJSONAux(root interface{}, path string, leaves map[string]interface
 			// list to nothing, only delete it or update descendant leaves.
 			leaves[path] = root
 			// If this assumption is wrong, and the list is later updated, an
-			// error will be returned due to a prefix-match in the flattened updates.
+			// error prefix matching can detect this invalid operation.
 		} else {
 			switch v[0].(type) {
 			case bool, float64, string:

--- a/gnmidiff/json_test.go
+++ b/gnmidiff/json_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestFlattenOCJSON(t *testing.T) {
+	// TODO: increase coverage of error code paths.
 	tests := []struct {
 		desc   string
 		inJSON string
@@ -68,7 +69,8 @@ func TestFlattenOCJSON(t *testing.T) {
       ]
     },
     "name": "RED",
-    "type": "openconfig-network-instance-types:L3VRF"
+    "type": "openconfig-network-instance-types:L3VRF",
+    "leaf-list": []
     },
   "openconfig-network-instance:name": "RED"
 }
@@ -94,6 +96,7 @@ func TestFlattenOCJSON(t *testing.T) {
 			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/id":                float64(3),
 			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/name":              "BGP",
 			"/openconfig-network-instance:config/type":                                                 "openconfig-network-instance-types:L3VRF",
+			"/openconfig-network-instance:config/leaf-list":                                            []interface{}{},
 			"/openconfig-network-instance:name":                                                        "RED",
 		},
 	}}

--- a/gnmidiff/json_test.go
+++ b/gnmidiff/json_test.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmidiff
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFlattenOCJSON(t *testing.T) {
+	tests := []struct {
+		desc   string
+		inJSON string
+		want   map[string]interface{}
+	}{{
+		desc: "basic",
+		inJSON: `
+{
+  "openconfig-network-instance:config": {
+    "description": "VRF RED",
+    "enabled": true,
+    "enabled-address-families": [
+      "openconfig-types:IPV4",
+      "openconfig-types:IPV6"
+    ],
+    "protocols": {
+      "protocol": [
+        {
+	  "name": "STATIC",
+	  "id": 1,
+	  "config": {
+	    "name": "STATIC",
+	    "id": 1,
+	    "enabled": true
+	  }
+        },
+        {
+	  "id": 2,
+	  "name": "IS-IS",
+	  "config": {
+	    "id": 2,
+	    "name": "IS-IS",
+	    "enabled": false
+	  }
+        },
+        {
+	  "name": "BGP",
+	  "id": 3,
+	  "config": {
+	    "id": 3,
+	    "name": "BGP",
+	    "enabled": false
+	  }
+        }
+      ]
+    },
+    "name": "RED",
+    "type": "openconfig-network-instance-types:L3VRF"
+    },
+  "openconfig-network-instance:name": "RED"
+}
+`,
+		want: map[string]interface{}{
+			"/openconfig-network-instance:config/description":                                          "VRF RED",
+			"/openconfig-network-instance:config/enabled":                                              true,
+			"/openconfig-network-instance:config/enabled-address-families":                             []interface{}{"openconfig-types:IPV4", "openconfig-types:IPV6"},
+			"/openconfig-network-instance:config/name":                                                 "RED",
+			"/openconfig-network-instance:config/protocols/protocol[id=1][name=STATIC]/config/enabled": true,
+			"/openconfig-network-instance:config/protocols/protocol[id=1][name=STATIC]/config/id":      float64(1),
+			"/openconfig-network-instance:config/protocols/protocol[id=1][name=STATIC]/config/name":    "STATIC",
+			"/openconfig-network-instance:config/protocols/protocol[id=1][name=STATIC]/id":             float64(1),
+			"/openconfig-network-instance:config/protocols/protocol[id=1][name=STATIC]/name":           "STATIC",
+			"/openconfig-network-instance:config/protocols/protocol[id=2][name=IS-IS]/config/enabled":  false,
+			"/openconfig-network-instance:config/protocols/protocol[id=2][name=IS-IS]/config/id":       float64(2),
+			"/openconfig-network-instance:config/protocols/protocol[id=2][name=IS-IS]/config/name":     "IS-IS",
+			"/openconfig-network-instance:config/protocols/protocol[id=2][name=IS-IS]/id":              float64(2),
+			"/openconfig-network-instance:config/protocols/protocol[id=2][name=IS-IS]/name":            "IS-IS",
+			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/config/enabled":    false,
+			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/config/id":         float64(3),
+			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/config/name":       "BGP",
+			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/id":                float64(3),
+			"/openconfig-network-instance:config/protocols/protocol[id=3][name=BGP]/name":              "BGP",
+			"/openconfig-network-instance:config/type":                                                 "openconfig-network-instance-types:L3VRF",
+			"/openconfig-network-instance:name":                                                        "RED",
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := flattenOCJSON([]byte(tt.inJSON))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("flattenOCJSON: (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is useful for comparing between two SetRequests whose contents are in JSON_IETF format.

It only intends to support OpenConfig-compliant JSON because it is otherwise impossible to infer the list keys from RFC7951 JSON.

@marcushines