### PR TITLE
Return deprecation error message when unmarshalling using SetNode/JSON

### DIFF
--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -223,6 +223,8 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 						if err := json.Unmarshal(args.val.(*gpb.TypedValue).GetJsonIetfVal(), &val); err != nil {
 							return nil, status.Errorf(codes.Unknown, "failed to update struct field %s in %T with value %v; %v", ft.Name, root, args.val, err)
 						}
+					case args.val.(*gpb.TypedValue).GetJsonVal() != nil:
+						return nil, status.Errorf(codes.InvalidArgument, "json_val format is deprecated, please use json_ietf_val")
 					case args.tolerateJSONInconsistenciesForVal:
 						encoding = gNMIEncodingWithJSONTolerance
 						val = args.val

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -2175,6 +2175,39 @@ func TestSetNode(t *testing.T) {
 			},
 		},
 		{
+			inDesc:   "fail setting with Json (non-ietf) value",
+			inSchema: containerWithStringKey(),
+			inParentFn: func() interface{} {
+				return &ContainerStruct1{
+					StructKeyList: map[string]*ListElemStruct1{
+						"forty-two": {
+							Key1: ygot.String("forty-two"),
+							Outer: &OuterContainerType1{
+								Inner: &InnerContainerType1{
+									Int32LeafName: ygot.Int32(42),
+								},
+							},
+						},
+					},
+				}
+			},
+			inPath:           mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/int32-leaf-field"),
+			inValJSON:        &gpb.TypedValue{Value: &gpb.TypedValue_JsonVal{JsonVal: []byte("43")}},
+			wantErrSubstring: "json_val format is deprecated, please use json_ietf_val",
+			wantParent: &ContainerStruct1{
+				StructKeyList: map[string]*ListElemStruct1{
+					"forty-two": {
+						Key1: ygot.String("forty-two"),
+						Outer: &OuterContainerType1{
+							Inner: &InnerContainerType1{
+								Int32LeafName: ygot.Int32(42),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			inDesc:   "success setting already-set non-shadow leaf",
 			inSchema: containerWithStringKey(),
 			inParentFn: func() interface{} {


### PR DESCRIPTION
Should use JSON_IETF instead.

This is backwards-compatible because it was never handling JSON correctly, this change merely gives a better error message than before.