### PR TITLE
Remove CI support for Go 1.13, 1.14, 1.15, 1.16, 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.x']
+        go: ['1.18', '1.19', '1.20', '1.x']
 
     steps:
       - name: Install protobuf
@@ -29,14 +29,7 @@ jobs:
           go-version: ${{ matrix.go }}
         id: go
 
-      - if: ${{ matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15' }}
-        name: Install protoc-gen-go, goimports, Staticcheck
-        run: |
-          GO111MODULE=on go get google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          GO111MODULE=on go get golang.org/x/tools/cmd/goimports@latest
-
-      - if: ${{ !(matrix.go == '1.13' || matrix.go == '1.14' || matrix.go == '1.15') }}
-        name: Install protoc-gen-go, goimports, Staticcheck
+      - name: Install protoc-gen-go, goimports, Staticcheck
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
The pre-1.17 versions are introducing problems for PRs such as https://github.com/openconfig/ygot/actions/runs/4207239816/jobs/7301781404 in https://github.com/openconfig/ygot/pull/784

Furthermore, I wanted to remove support for 1.17 since 1.18 is the first version of generics, and it allows us to introduce generics into ygot.

I believe this change is reasonable since 1.20 has just been released, so officially only 1.18 is no longer released, and ygot supports an extra version (1.18) as stated in the README.