### PR TITLE
Enable `gofmt` CI against new directories by default.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Gofmt
         run: |
-          for i in util ygot ygen ytypes ygot/pathtranslate testutil testcmp ypathgen; do
+          for i in `find . -type d | egrep -v "exampleoc|demo|proto|uexampleoc"`; do 
             diff -u <(echo -n) <(gofmt -d -s ./$i)
           done
 

--- a/gnmidiff/json.go
+++ b/gnmidiff/json.go
@@ -33,29 +33,31 @@ import (
 // Output path format is per gNMI's path conventions.
 //
 // e.g.
-// {
-//   "openconfig-network-instance:config": {
-//     "description": "VRF RED",
-//     "enabled": true,
-//     "enabled-address-families": [
-//       "openconfig-types:IPV4",
-//       "openconfig-types:IPV6"
-//     ],
-//     "name": "RED",
-//     "type": "openconfig-network-instance-types:L3VRF"
-//     },
-//   "openconfig-network-instance:name": "RED"
-// }
+//
+//	{
+//	  "openconfig-network-instance:config": {
+//	    "description": "VRF RED",
+//	    "enabled": true,
+//	    "enabled-address-families": [
+//	      "openconfig-types:IPV4",
+//	      "openconfig-types:IPV6"
+//	    ],
+//	    "name": "RED",
+//	    "type": "openconfig-network-instance-types:L3VRF"
+//	    },
+//	  "openconfig-network-instance:name": "RED"
+//	}
 //
 // returns
-// {
-//   "openconfig-network-instance:config/description": "VRF RED",
-//   "openconfig-network-instance:config/enabled": true,
-//   "openconfig-network-instance:config/enabled-address-families": ["openconfig-types:IPV4", "openconfig-types:IPV6"],
-//   "openconfig-network-instance:config/name": "RED",
-//   "openconfig-network-instance:config/type": "openconfig-network-instance-types:L3VRF",
-//   "openconfig-network-instance:name": "RED",
-// }
+//
+//	{
+//	  "openconfig-network-instance:config/description": "VRF RED",
+//	  "openconfig-network-instance:config/enabled": true,
+//	  "openconfig-network-instance:config/enabled-address-families": ["openconfig-types:IPV4", "openconfig-types:IPV6"],
+//	  "openconfig-network-instance:config/name": "RED",
+//	  "openconfig-network-instance:config/type": "openconfig-network-instance-types:L3VRF",
+//	  "openconfig-network-instance:name": "RED",
+//	}
 //
 // When keepNamespace=false, then any namespace is removed from the flattened
 // *paths*, but still kept in any identity values.


### PR DESCRIPTION
The `gofmt` check required explicit opt in of directories - meaning that
`gofmt` issues could slip through the net.  This check makes it such that new
directories need to opt out.
