### PR TITLE
populateUpdate marshals JSON instead of TypedValue scalars

### DIFF
--- a/gnmidiff/intent_test.go
+++ b/gnmidiff/intent_test.go
@@ -1,0 +1,81 @@
+package gnmidiff
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+func TestProtoLeafToJSON(t *testing.T) {
+	tests := []struct {
+		desc         string
+		inTypedValue *gpb.TypedValue
+		wantJSON     interface{}
+		wantErr      bool
+	}{{
+		desc: "int",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_IntVal{IntVal: 42},
+		},
+		wantJSON: float64(42),
+	}, {
+		desc: "uint",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_UintVal{UintVal: 42},
+		},
+		wantJSON: float64(42),
+	}, {
+		desc: "string",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_StringVal{StringVal: "42"},
+		},
+		wantJSON: "42",
+	}, {
+		desc: "double",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_DoubleVal{DoubleVal: 42.42},
+		},
+		wantJSON: "42.42",
+	}, {
+		desc: "bool",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+		},
+		wantJSON: true,
+	}, {
+		desc: "leaf-list",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_LeaflistVal{LeaflistVal: &gpb.ScalarArray{Element: []*gpb.TypedValue{
+				{
+					Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+				},
+			}}},
+		},
+		wantJSON: []interface{}{true},
+	}, {
+		desc: "bool",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_BytesVal{BytesVal: []byte("aabbcc")},
+		},
+		wantJSON: binaryBase64([]byte("aabbcc")),
+	}, {
+		desc: "JSON_IETF",
+		inTypedValue: &gpb.TypedValue{
+			Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte("aabbcc")},
+		},
+		wantErr: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := protoLeafToJSON(tt.inTypedValue)
+			if gotErr := (err != nil); gotErr != tt.wantErr {
+				t.Fatalf("gotErr: %v, wantErr: %v", gotErr, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.wantJSON, got); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/gnmidiff/setrequest_test.go
+++ b/gnmidiff/setrequest_test.go
@@ -189,7 +189,10 @@ func TestDiffSetRequest(t *testing.T) {
 		inA                *gpb.SetRequest
 		inB                *gpb.SetRequest
 		wantSetRequestDiff SetRequestIntentDiff
-		wantErr            bool
+		// If nil, then wantSetRequestDiff will be used.
+		wantSetRequestDiffWithSchema *SetRequestIntentDiff
+		wantErrNoSchema              bool
+		wantErrWithSchema            bool
 	}{{
 		desc: "exactly the same",
 		inA: &gpb.SetRequest{
@@ -364,7 +367,8 @@ func TestDiffSetRequest(t *testing.T) {
 				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "TDM"}},
 			}},
 		},
-		wantErr: true,
+		wantErrNoSchema:   true,
+		wantErrWithSchema: true,
 	}, {
 		desc: "only A",
 		inA: &gpb.SetRequest{
@@ -620,22 +624,116 @@ func TestDiffSetRequest(t *testing.T) {
 		},
 	}}
 
-	for _, tt := range tests {
+	jsonScalarTests := []struct {
+		desc               string
+		inA                *gpb.SetRequest
+		inB                *gpb.SetRequest
+		wantSetRequestDiff SetRequestIntentDiff
+		// If nil, then wantSetRequestDiff will be used.
+		wantSetRequestDiffWithSchema *SetRequestIntentDiff
+		wantErrNoSchema              bool
+		wantErrWithSchema            bool
+	}{{
+		desc: "int64 and string mismatch due to non-one-to-one mapping between TypedValue and JSON",
+		inA: &gpb.SetRequest{
+			Update: []*gpb.Update{{
+				Path: ygot.MustStringToPath("/interfaces/interface[name=eth0]/state/counters/in-pkts"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_UintVal{UintVal: 42}},
+			}},
+		},
+		inB: &gpb.SetRequest{
+			Update: []*gpb.Update{{
+				Path: ygot.MustStringToPath("/interfaces/interface[name=eth0]/state/counters/in-pkts"),
+				Val:  must7951(ygot.Uint64(42)),
+			}},
+		},
+		wantSetRequestDiff: SetRequestIntentDiff{
+			DeleteDiff: DeleteDiff{
+				MissingDeletes: map[string]struct{}{},
+				ExtraDeletes:   map[string]struct{}{},
+				CommonDeletes:  map[string]struct{}{},
+			},
+			UpdateDiff: UpdateDiff{
+				MissingUpdates: map[string]interface{}{},
+				ExtraUpdates:   map[string]interface{}{},
+				CommonUpdates:  map[string]interface{}{},
+				MismatchedUpdates: map[string]MismatchedUpdate{
+					"/interfaces/interface[name=eth0]/state/counters/in-pkts": {A: float64(42), B: string("42")},
+				},
+			},
+		},
+		wantSetRequestDiffWithSchema: &SetRequestIntentDiff{
+			DeleteDiff: DeleteDiff{
+				MissingDeletes: map[string]struct{}{},
+				ExtraDeletes:   map[string]struct{}{},
+				CommonDeletes:  map[string]struct{}{},
+			},
+			UpdateDiff: UpdateDiff{
+				MissingUpdates: map[string]interface{}{},
+				ExtraUpdates:   map[string]interface{}{},
+				CommonUpdates: map[string]interface{}{
+					"/interfaces/interface[name=eth0]/state/counters/in-pkts": "42",
+				},
+				MismatchedUpdates: map[string]MismatchedUpdate{},
+			},
+		},
+	}, {
+		desc: "int64 and string mismatch when both are TypedValue",
+		inA: &gpb.SetRequest{
+			Update: []*gpb.Update{{
+				Path: ygot.MustStringToPath("/interfaces/interface[name=eth0]/state/counters/in-pkts"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_UintVal{UintVal: 42}},
+			}},
+		},
+		inB: &gpb.SetRequest{
+			Update: []*gpb.Update{{
+				Path: ygot.MustStringToPath("/interfaces/interface[name=eth0]/state/counters/in-pkts"),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "42"}},
+			}},
+		},
+		wantSetRequestDiff: SetRequestIntentDiff{
+			DeleteDiff: DeleteDiff{
+				MissingDeletes: map[string]struct{}{},
+				ExtraDeletes:   map[string]struct{}{},
+				CommonDeletes:  map[string]struct{}{},
+			},
+			UpdateDiff: UpdateDiff{
+				MissingUpdates: map[string]interface{}{},
+				ExtraUpdates:   map[string]interface{}{},
+				CommonUpdates:  map[string]interface{}{},
+				MismatchedUpdates: map[string]MismatchedUpdate{
+					"/interfaces/interface[name=eth0]/state/counters/in-pkts": {A: float64(42), B: string("42")},
+				},
+			},
+		},
+		wantErrWithSchema: true,
+	}}
+
+	for _, tt := range append(tests, jsonScalarTests...) {
 		t.Run(tt.desc, func(t *testing.T) {
 			for _, withSchema := range []bool{false, true} {
 				var inSchema *ytypes.Schema
+				wantSetRequestDiff := tt.wantSetRequestDiff
+				wantErr := tt.wantErrNoSchema
 				if withSchema {
 					var err error
 					if inSchema, err = exampleoc.Schema(); err != nil {
 						t.Fatalf("schema has error: %v", err)
 					}
+					if tt.wantSetRequestDiffWithSchema != nil {
+						wantSetRequestDiff = *tt.wantSetRequestDiffWithSchema
+					}
+					wantErr = tt.wantErrWithSchema
 				}
 				t.Run(fmt.Sprintf("withSchema-%v", withSchema), func(t *testing.T) {
 					got, err := DiffSetRequest(tt.inA, tt.inB, inSchema)
-					if (err != nil) != tt.wantErr {
-						t.Fatalf("got error: %v, want error: %v", err, tt.wantErr)
+					if (err != nil) != wantErr {
+						t.Fatalf("got error: %v, want error: %v", err, wantErr)
 					}
-					if diff := cmp.Diff(tt.wantSetRequestDiff, got); diff != "" {
+					if wantErr {
+						return
+					}
+					if diff := cmp.Diff(wantSetRequestDiff, got); diff != "" {
 						t.Errorf("DiffSetRequest (-want, +got):\n%s", diff)
 					}
 				})

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -4210,6 +4210,14 @@ func TestMarshal7951(t *testing.T) {
 		in:   &renderExample{Empty: true},
 		want: `{"empty":[null]}`,
 	}, {
+		desc: "int type",
+		in:   &renderExample{Int64Val: Int64(42)},
+		want: `{"int64-val":42}`,
+	}, {
+		desc: "float type",
+		in:   &renderExample{FloatVal: Float64(42.42)},
+		want: `{"floatval":"42.42"}`,
+	}, {
 		desc: "indentation requested",
 		in: &renderExample{
 			Str: String("test-string"),

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -4212,7 +4212,7 @@ func TestMarshal7951(t *testing.T) {
 	}, {
 		desc: "int type",
 		in:   &renderExample{Int64Val: Int64(42)},
-		want: `{"int64-val":42}`,
+		want: `{"int64-val":"42"}`,
 	}, {
 		desc: "float type",
 		in:   &renderExample{FloatVal: Float64(42.42)},


### PR DESCRIPTION
In gnmidiff for simplicity we want to have a uniform way of encoding values due to the chance that both JSON and TypedValue scalars can both be inputs at the same time. This means when diffing programmatically and visually (via CLI) the values can be compared apples-to-apples and it relieves the user of having to deal with type differences.

Previously `TogNMINotifications` was called which outputs scalars, but for uniformity `Marshal7951` is now used. There is actually no strict advantage to using TypedValue scalars due to the fact that YANG -> TypedValue conversion is lossy (namely all int/uint values get squished to int64/uint64), and so there is no way to accurately convert TypedValue scalar to  JSON since int64/int32 are treated differently.

Also double-val conversion is now done correctly (to string instead of float64)