### PR TITLE
perf(node): caching implementation for node operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/derekparker/trie v0.0.0-20221221181808-1424fce0c981
+	github.com/goccy/go-json v0.10.0
 	github.com/golang/glog v1.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
+github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=

--- a/testcmp/cmp_test.go
+++ b/testcmp/cmp_test.go
@@ -40,7 +40,7 @@ func mustPath(s string) *gnmipb.Path {
 func jsonIETF(s string) *gnmipb.TypedValue {
 	return &gnmipb.TypedValue{
 		Value: &gnmipb.TypedValue_JsonIetfVal{
-			[]byte(s),
+			JsonIetfVal: []byte(s),
 		},
 	}
 }
@@ -86,7 +86,7 @@ func TestGNMIUpdateComparer(t *testing.T) {
 		wantDiff: &gnmipb.Notification{
 			Update: []*gnmipb.Update{{
 				Path: mustPath("/system/config/hostname"),
-				Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"bus"}},
+				Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "bus"}},
 			}},
 		},
 	}, {
@@ -157,11 +157,11 @@ func TestGNMIUpdateComparer(t *testing.T) {
 		desc: "equal: not IETF JSON",
 		inA: &gnmipb.Update{
 			Path: mustPath("/system/config/hostname"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inB: &gnmipb.Update{
 			Path: mustPath("/system/config/hostname"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inSpec:    commonSpec,
 		wantEqual: true,
@@ -169,11 +169,11 @@ func TestGNMIUpdateComparer(t *testing.T) {
 		desc: "not equal: different paths",
 		inA: &gnmipb.Update{
 			Path: mustPath("/system/config/domain-name"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inB: &gnmipb.Update{
 			Path: mustPath("/system/config/hostname"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inSpec:    commonSpec,
 		wantEqual: false,
@@ -191,7 +191,7 @@ func TestGNMIUpdateComparer(t *testing.T) {
 		desc: "not equal: one value nil",
 		inA: &gnmipb.Update{
 			Path: mustPath("/system/config/domain-name"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inB: &gnmipb.Update{
 			Path: mustPath("/system/config/domain-name"),
@@ -202,11 +202,11 @@ func TestGNMIUpdateComparer(t *testing.T) {
 		desc: "not equal: different types",
 		inA: &gnmipb.Update{
 			Path: mustPath("/system/config/hostname"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{"fish"}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_StringVal{StringVal: "fish"}},
 		},
 		inB: &gnmipb.Update{
 			Path: mustPath("/system/config/hostname"),
-			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_UintVal{42}},
+			Val:  &gnmipb.TypedValue{Value: &gnmipb.TypedValue_UintVal{UintVal: 42}},
 		},
 		inSpec:    commonSpec,
 		wantEqual: false,

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -256,6 +256,16 @@ func InsertIntoStruct(parentStruct interface{}, fieldName string, fieldValue int
 	// generated code. Here we cast the value to the type in the generated code.
 	if ft.Type.Kind() == reflect.Bool && t.Kind() == reflect.Bool {
 		nv := reflect.New(ft.Type).Elem()
+
+		// If the field is not nil, do not create a new pointer which modifies the
+		// field's memory address under its parent.
+		if pv.Elem().FieldByName(fieldName).Addr().UnsafePointer() != nil {
+			nv = reflect.NewAt(
+				ft.Type,
+				pv.Elem().FieldByName(fieldName).Addr().UnsafePointer(),
+			).Elem()
+		}
+
 		nv.SetBool(v.Bool())
 		v = nv
 	}
@@ -265,6 +275,16 @@ func InsertIntoStruct(parentStruct interface{}, fieldName string, fieldValue int
 	// This will also cast a []uint8 value since byte is an alias for uint8.
 	if ft.Type.Kind() == reflect.Slice && t.Kind() == reflect.Slice && ft.Type.Elem().Kind() == reflect.Uint8 && t.Elem().Kind() == reflect.Uint8 {
 		nv := reflect.New(ft.Type).Elem()
+
+		// If the field is not nil, do not create a new pointer which modifies the
+		// field's memory address under its parent.
+		if pv.Elem().FieldByName(fieldName).Addr().UnsafePointer() != nil {
+			nv = reflect.NewAt(
+				ft.Type,
+				pv.Elem().FieldByName(fieldName).Addr().UnsafePointer(),
+			).Elem()
+		}
+
 		nv.SetBytes(v.Bytes())
 		v = nv
 	}
@@ -272,6 +292,13 @@ func InsertIntoStruct(parentStruct interface{}, fieldName string, fieldValue int
 	n := v
 	if n.IsValid() && (ft.Type.Kind() == reflect.Ptr && t.Kind() != reflect.Ptr) {
 		n = reflect.New(t)
+
+		// If the field is not nil, do not create a new pointer which modifies the
+		// field's memory address under its parent.
+		if pv.Elem().FieldByName(fieldName).UnsafePointer() != nil {
+			n = reflect.NewAt(t, pv.Elem().FieldByName(fieldName).UnsafePointer())
+		}
+
 		n.Elem().Set(v)
 	}
 

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -290,14 +290,24 @@ func TestStructTagToLibPaths(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		got, err := structTagToLibPaths(tt.inField, tt.inParent, tt.inPreferShadowPath)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("%s: structTagToLibPaths(%v, %v, %v): did not get expected error status, got: %v, want err: %v", tt.name, tt.inField, tt.inParent, tt.inPreferShadowPath, err, tt.wantErr)
-		}
+		func() {
+			mapPaths := mapPathsPool.Get().([]*gnmiPath)
+			defer mapPathsPool.Put(mapPaths)
 
-		if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
-			t.Errorf("%s: structTagToLibPaths(%v, %v, %v): did not get expected set of map paths, diff(-want, +got):\n%s", tt.name, tt.inField, tt.inParent, tt.inPreferShadowPath, diff)
-		}
+			n, err := structTagToLibPaths(mapPaths, tt.inField, tt.inParent, tt.inPreferShadowPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("%s: structTagToLibPaths(%v, %v, %v): did not get expected error status, got: %v, want err: %v", tt.name, tt.inField, tt.inParent, tt.inPreferShadowPath, err, tt.wantErr)
+			}
+
+			var p []*gnmiPath = nil
+			if n > 0 {
+				p = mapPaths[:n]
+			}
+
+			if diff := cmp.Diff(tt.want, p, cmp.AllowUnexported(gnmiPath{}), cmp.Comparer(proto.Equal)); diff != "" {
+				t.Errorf("%s: structTagToLibPaths(%v, %v, %v): did not get expected set of map paths, diff(-want, +got):\n%s", tt.name, tt.inField, tt.inParent, tt.inPreferShadowPath, diff)
+			}
+		}()
 	}
 }
 

--- a/ytypes/gnmi.go
+++ b/ytypes/gnmi.go
@@ -44,25 +44,43 @@ func UnmarshalNotifications(schema *Schema, ns []*gpb.Notification, opts ...Unma
 // If an error occurs during unmarshalling, schema.Root may already be
 // modified. A rollback is not performed.
 func UnmarshalSetRequest(schema *Schema, req *gpb.SetRequest, opts ...UnmarshalOpt) error {
-	preferShadowPath := hasPreferShadowPath(opts)
-	ignoreExtraFields := hasIgnoreExtraFields(opts)
 	if req == nil {
 		return nil
 	}
+
+	// Use option slices instead of flags to pass options down to the function calls.
+	var getOrCreateOpts []GetOrCreateNodeOpt
+	var deleteOpts []DelNodeOpt
+	var updateOpts []SetNodeOpt
+
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case *PreferShadowPath:
+			getOrCreateOpts = append(getOrCreateOpts, &PreferShadowPath{})
+			deleteOpts = append(deleteOpts, &PreferShadowPath{})
+			updateOpts = append(updateOpts, &PreferShadowPath{})
+		case *IgnoreExtraFields:
+			updateOpts = append(updateOpts, &IgnoreExtraFields{})
+		case *NodeCacheOpt:
+			getOrCreateOpts = append(getOrCreateOpts, o)
+			updateOpts = append(updateOpts, o)
+		}
+	}
+
 	root := schema.Root
-	node, nodeName, err := getOrCreateNode(schema.RootSchema(), root, req.Prefix, preferShadowPath)
+	node, nodeName, err := getOrCreateNode(schema.RootSchema(), root, req.Prefix, getOrCreateOpts)
 	if err != nil {
 		return err
 	}
 
 	// Process deletes, then replace, then updates.
-	if err := deletePaths(schema.SchemaTree[nodeName], node, req.Delete, preferShadowPath); err != nil {
+	if err := deletePaths(schema.SchemaTree[nodeName], node, req.Delete, deleteOpts); err != nil {
 		return err
 	}
-	if err := replacePaths(schema.SchemaTree[nodeName], node, req.Replace, preferShadowPath, ignoreExtraFields); err != nil {
+	if err := replacePaths(schema.SchemaTree[nodeName], node, req.Replace, deleteOpts, updateOpts); err != nil {
 		return err
 	}
-	if err := updatePaths(schema.SchemaTree[nodeName], node, req.Update, preferShadowPath, ignoreExtraFields); err != nil {
+	if err := updatePaths(schema.SchemaTree[nodeName], node, req.Update, updateOpts); err != nil {
 		return err
 	}
 
@@ -71,11 +89,7 @@ func UnmarshalSetRequest(schema *Schema, req *gpb.SetRequest, opts ...UnmarshalO
 
 // getOrCreateNode instantiates the node at the given path, and returns that
 // node along with its name.
-func getOrCreateNode(schema *yang.Entry, goStruct ygot.GoStruct, path *gpb.Path, preferShadowPath bool) (ygot.GoStruct, string, error) {
-	var gcopts []GetOrCreateNodeOpt
-	if preferShadowPath {
-		gcopts = append(gcopts, &PreferShadowPath{})
-	}
+func getOrCreateNode(schema *yang.Entry, goStruct ygot.GoStruct, path *gpb.Path, gcopts []GetOrCreateNodeOpt) (ygot.GoStruct, string, error) {
 	// Operate at the prefix level.
 	nodeI, _, err := GetOrCreateNode(schema, goStruct, path, gcopts...)
 	if err != nil {
@@ -90,12 +104,7 @@ func getOrCreateNode(schema *yang.Entry, goStruct ygot.GoStruct, path *gpb.Path,
 }
 
 // deletePaths deletes a slice of paths from the given GoStruct.
-func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, paths []*gpb.Path, preferShadowPath bool) error {
-	var dopts []DelNodeOpt
-	if preferShadowPath {
-		dopts = append(dopts, &PreferShadowPath{})
-	}
-
+func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, paths []*gpb.Path, dopts []DelNodeOpt) error {
 	for _, path := range paths {
 		if err := DeleteNode(schema, goStruct, path, dopts...); err != nil {
 			return err
@@ -107,17 +116,12 @@ func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, paths []*gpb.Path, 
 // replacePaths unmarshals a slice of updates into the given GoStruct. It
 // deletes the values at these paths before unmarshalling them. These updates
 // can either by JSON-encoded or gNMI-encoded values (scalars).
-func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
-	var dopts []DelNodeOpt
-	if preferShadowPath {
-		dopts = append(dopts, &PreferShadowPath{})
-	}
-
+func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, dopts []DelNodeOpt, uopts []SetNodeOpt) error {
 	for _, update := range updates {
 		if err := DeleteNode(schema, goStruct, update.Path, dopts...); err != nil {
 			return err
 		}
-		if err := setNode(schema, goStruct, update, preferShadowPath, ignoreExtraFields); err != nil {
+		if err := setNode(schema, goStruct, update, uopts); err != nil {
 			return err
 		}
 	}
@@ -126,9 +130,9 @@ func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Upd
 
 // updatePaths unmarshals a slice of updates into the given GoStruct. These
 // updates can either by JSON-encoded or gNMI-encoded values (scalars).
-func updatePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
+func updatePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, uopts []SetNodeOpt) error {
 	for _, update := range updates {
-		if err := setNode(schema, goStruct, update, preferShadowPath, ignoreExtraFields); err != nil {
+		if err := setNode(schema, goStruct, update, uopts); err != nil {
 			return err
 		}
 	}
@@ -137,14 +141,6 @@ func updatePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Upda
 
 // setNode unmarshals either a JSON-encoded value or a gNMI-encoded (scalar)
 // value into the given GoStruct.
-func setNode(schema *yang.Entry, goStruct ygot.GoStruct, update *gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
-	sopts := []SetNodeOpt{&InitMissingElements{}}
-	if preferShadowPath {
-		sopts = append(sopts, &PreferShadowPath{})
-	}
-	if ignoreExtraFields {
-		sopts = append(sopts, &IgnoreExtraFields{})
-	}
-
-	return SetNode(schema, goStruct, update.Path, update.Val, sopts...)
+func setNode(schema *yang.Entry, goStruct ygot.GoStruct, update *gpb.Update, uopts []SetNodeOpt) error {
+	return SetNode(schema, goStruct, update.Path, update.Val, append(uopts, &InitMissingElements{})...)
 }

--- a/ytypes/gnmi_test.go
+++ b/ytypes/gnmi_test.go
@@ -18,6 +18,7 @@ func TestUnmarshalSetRequest(t *testing.T) {
 		inUnmarshalOpts []UnmarshalOpt
 		want            ygot.GoStruct
 		wantErr         bool
+		resetNodeCache  bool
 	}{{
 		desc: "nil input",
 		inSchema: &Schema{
@@ -102,6 +103,7 @@ func TestUnmarshalSetRequest(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}, {
 		desc: "updates of invalid paths to non-empty struct with IgnoreExtraFields",
 		inSchema: &Schema{
@@ -146,6 +148,7 @@ func TestUnmarshalSetRequest(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}, {
 		desc: "replaces and update to a non-empty struct",
 		inSchema: &Schema{
@@ -332,6 +335,7 @@ func TestUnmarshalSetRequest(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}, {
 		desc: "replaces to a non-empty struct with prefix",
 		inSchema: &Schema{
@@ -405,7 +409,13 @@ func TestUnmarshalSetRequest(t *testing.T) {
 		wantErr: true,
 	}}
 
+	nodeCache := NewNodeCache()
+
 	for _, tt := range tests {
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.desc, func(t *testing.T) {
 			err := UnmarshalSetRequest(tt.inSchema, tt.inReq, tt.inUnmarshalOpts...)
 			if gotErr := err != nil; gotErr != tt.wantErr {
@@ -428,6 +438,7 @@ func TestUnmarshalNotifications(t *testing.T) {
 		inUnmarshalOpts []UnmarshalOpt
 		want            ygot.GoStruct
 		wantErr         bool
+		resetNodeCache  bool
 	}{{
 		desc: "updates to an empty struct",
 		inSchema: &Schema{
@@ -460,6 +471,7 @@ func TestUnmarshalNotifications(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}, {
 		desc: "updates to non-empty struct",
 		inSchema: &Schema{
@@ -503,6 +515,7 @@ func TestUnmarshalNotifications(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}, {
 		desc: "fail: update to invalid field",
 		inSchema: &Schema{
@@ -681,9 +694,16 @@ func TestUnmarshalNotifications(t *testing.T) {
 				},
 			},
 		},
+		resetNodeCache: true,
 	}}
 
+	nodeCache := NewNodeCache()
+
 	for _, tt := range tests {
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.desc, func(t *testing.T) {
 			err := UnmarshalNotifications(tt.inSchema, tt.inNotifications, tt.inUnmarshalOpts...)
 			if gotErr := err != nil; gotErr != tt.wantErr {

--- a/ytypes/node_cache.go
+++ b/ytypes/node_cache.go
@@ -1,0 +1,274 @@
+package ytypes
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	json "github.com/goccy/go-json"
+	"github.com/openconfig/ygot/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// NodeCacheOpt is an option that can be usd with calls such as `SetNode` and `GetNode`.
+//
+// The `node cache` potentially provides fast-paths for config tree traversals and offers
+// noticeable performance boosts on a busy server that calls functions such as `SetNode`
+// and `GetNode` frequently.
+//
+// Passing in the reference of the `node cache` could prevent making the `ytypes` package
+// stateful. The applications that use the `ytypes` package maintain the `node cache`.
+type NodeCacheOpt struct {
+	NodeCache *NodeCache
+}
+
+// IsGetNodeOpt implements the GetNodeOpt interface.
+func (*NodeCacheOpt) IsGetNodeOpt() {}
+
+// IsSetNodeOpt implements the SetNodeOpt interface.
+func (*NodeCacheOpt) IsSetNodeOpt() {}
+
+// IsUnmarshalOpt marks IgnoreExtraFields as a valid UnmarshalOpt.
+func (*NodeCacheOpt) IsUnmarshalOpt() {}
+
+// IsGetOrCreateNodeOpt implements the GetOrCreateNodeOpt interface.
+func (*NodeCacheOpt) IsGetOrCreateNodeOpt() {}
+
+// cachedNodeInfo is used to provide shortcuts to making operations
+// to the nodes without having to traverse the config tree for every operation.
+type cachedNodeInfo struct {
+	parent interface{}
+	root   interface{}
+	nodes  []*TreeNode
+}
+
+// NodeCache is a thread-safe struct that's used for providing fast-paths for config tree traversals.
+type NodeCache struct {
+	store map[string]*cachedNodeInfo
+	mu    *sync.RWMutex
+}
+
+// NewNodeCache returns the pointer of a new `NodeCache` instance.
+func NewNodeCache() *NodeCache {
+	return &NodeCache{
+		store: map[string]*cachedNodeInfo{},
+		mu:    &sync.RWMutex{},
+	}
+}
+
+// Reset resets the cache. The cache will be repopulated after the reset.
+func (c *NodeCache) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.store = map[string]*cachedNodeInfo{}
+}
+
+// setNodeCache uses the cached information to set the node instead of traversalling the config tree.
+// This improves runtime performance of the library.
+func (c *NodeCache) set(path *gpb.Path, val interface{}, opts ...SetNodeOpt) (setComplete bool, err error) {
+	switch val.(type) {
+	case *gpb.TypedValue:
+	default:
+		// Only TypedValue is supported by the node cache for now.
+		return
+	}
+
+	// Get the unique path representation as the key of the cache store.
+	pathRep, err := uniquePathRepresentation(path)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+
+	// If the path was cached, use the shortcut for setting the node value.
+	nodeInfo, ok := c.store[pathRep]
+	if !ok || len(nodeInfo.nodes) == 0 {
+		c.mu.Unlock()
+		return
+	}
+
+	schema := &nodeInfo.nodes[0].Schema
+	parent := &nodeInfo.parent
+	root := &nodeInfo.root
+
+	// Set value in the config tree.
+	switch {
+	case val.(*gpb.TypedValue).GetJsonIetfVal() != nil:
+	default:
+		var encoding Encoding
+		var options []UnmarshalOpt
+		if hasSetNodePreferShadowPath(opts) {
+			options = append(options, &PreferShadowPath{})
+		}
+
+		if hasIgnoreExtraFieldsSetNode(opts) {
+			options = append(options, &IgnoreExtraFields{})
+		}
+
+		if hasTolerateJSONInconsistencies(opts) {
+			encoding = gNMIEncodingWithJSONTolerance
+		} else {
+			encoding = GNMIEncoding
+		}
+
+		// This call updates the node's value in the config tree.
+		if e := unmarshalGeneric(*schema, *parent, val, encoding, options...); e != nil {
+			// When the node doesn't exist the unmarshal call will fail. Within the setNodeCache function this
+			// should not return an error. Instead, this should return setComplete == false to let the ygot library
+			// continue to go through the node creation process.
+			fmt.Printf("node cache - unmarshalling error: %s\n", e)
+			c.mu.Unlock()
+			return
+		}
+	}
+
+	c.mu.Unlock()
+
+	// Retrieve the node and update the cache.
+	var nodes []*TreeNode
+	nodes, err = retrieveNode(*schema, *parent, *root, nil, path, retrieveNodeArgs{
+		modifyRoot:                        hasInitMissingElements(opts),
+		val:                               val,
+		tolerateJSONInconsistenciesForVal: hasTolerateJSONInconsistencies(opts),
+		preferShadowPath:                  hasSetNodePreferShadowPath(opts),
+		ignoreExtraFields:                 hasIgnoreExtraFieldsSetNode(opts),
+		uniquePathRepresentation:          &pathRep,
+		nodeCache:                         c,
+	})
+	if err != nil {
+		// Here it's assumed that the set was successful. Therefore, if an error is
+		// returned from retrieveNode the error should be escalated.
+		return
+	}
+
+	if len(nodes) != 0 {
+		setComplete = true
+		return
+	}
+
+	err = status.Errorf(
+		codes.Unknown,
+		"failed to retrieve node, value %v",
+		val,
+	)
+
+	return
+}
+
+// update performs `NodeCache` update based on the input arguments.
+func (c *NodeCache) update(nodes []*TreeNode, tp, np *gpb.Path, parent, root interface{}, pathStr *string) {
+	var pathRep string
+	if pathStr != nil {
+		pathRep = *pathStr
+	} else {
+		if tp != nil && len(tp.GetElem()) > 0 {
+			var err error
+
+			pathRep, err = uniquePathRepresentation(appendElem(np, tp.GetElem()[0]))
+			if err != nil {
+				return
+			}
+		} else {
+			var err error
+
+			pathRep, err = uniquePathRepresentation(np)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.store[pathRep]; !ok {
+		c.store[pathRep] = &cachedNodeInfo{}
+	}
+
+	if c.store[pathRep].nodes == nil || len(c.store[pathRep].nodes) == 0 {
+		c.store[pathRep].nodes = nodes
+	} else {
+		// Only update the data.
+		c.store[pathRep].nodes[0].Data = nodes[0].Data
+	}
+
+	c.store[pathRep].parent = parent
+	c.store[pathRep].root = root
+}
+
+// delete removes the path entry from the node cache.
+func (c *NodeCache) delete(path *gpb.Path) {
+	// Delete in the nodeCache.
+	nodePath, err := uniquePathRepresentation(path)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	keysToDelete := []string{}
+	for k := range c.store {
+		if strings.Contains(k, nodePath) {
+			keysToDelete = append(keysToDelete, k)
+		}
+	}
+
+	for _, k := range keysToDelete {
+		delete(c.store, k)
+	}
+}
+
+// get tries to retrieve the cached `TreeNode` slice. If the cache doesn't contain the
+// target `TreeNode` slice or the cached data is `nil`, an error is returned.
+func (c *NodeCache) get(path *gpb.Path) ([]*TreeNode, error) {
+	pathRep, err := uniquePathRepresentation(path)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if nodeInfo, ok := c.store[pathRep]; ok {
+		ret := nodeInfo.nodes
+		if ret == nil || len(ret) == 0 {
+			return nil, status.Error(codes.NotFound, "cache: no node was found.")
+		} else if util.IsValueNil(ret[0].Data) {
+			return nil, status.Error(codes.NotFound, "cache: nil value node was found.")
+		}
+
+		return ret, nil
+	}
+
+	return nil, nil
+}
+
+// uniquePathRepresentation returns the unique path representation. The current
+// implementation uses json marshal for both simplicity and performance.
+//
+// https://pkg.go.dev/encoding/json#Marshal
+//
+// Map values encode as JSON objects. The map's key type must either be a string,
+// an integer type, or implement encoding.TextMarshaler. The map keys are sorted
+// and used as JSON object keys by applying the following rules, subject to the
+// UTF-8 coercion described for string values above:
+//
+//   - keys of any string type are used directly
+//
+//   - encoding.TextMarshalers are marshaled
+//
+//   - integer keys are converted to strings
+func uniquePathRepresentation(path *gpb.Path) (string, error) {
+	b, err := json.Marshal(path.GetElem())
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(strings.TrimLeft(string(b), "["), "]"), nil
+}

--- a/ytypes/node_test.go
+++ b/ytypes/node_test.go
@@ -381,6 +381,7 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 		inOpts           []GetOrCreateNodeOpt
 		want             interface{}
 		wantErrSubstring string
+		resetNodeCache   bool
 	}{
 		{
 			inDesc: "success get int32 leaf with an existing key",
@@ -401,11 +402,12 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 			want:     ygot.Int32(42),
 		},
 		{
-			inDesc:   "success get int32 leaf with a new key",
-			inParent: &ContainerStruct1{},
-			inSchema: containerWithStringKey(),
-			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/int32-leaf-field"),
-			want:     ygot.Int32(0),
+			inDesc:         "success get int32 leaf with a new key",
+			inParent:       &ContainerStruct1{},
+			inSchema:       containerWithStringKey(),
+			inPath:         mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/int32-leaf-field"),
+			want:           ygot.Int32(0),
+			resetNodeCache: true,
 		},
 		{
 			inDesc: "success get string leaf with an existing key",
@@ -426,11 +428,12 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 			want:     ygot.String("forty_two"),
 		},
 		{
-			inDesc:   "success get string leaf with a new key",
-			inParent: &ContainerStruct1{},
-			inSchema: containerWithStringKey(),
-			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/string-leaf-field"),
-			want:     ygot.String(""),
+			inDesc:         "success get string leaf with a new key",
+			inParent:       &ContainerStruct1{},
+			inSchema:       containerWithStringKey(),
+			inPath:         mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/string-leaf-field"),
+			want:           ygot.String(""),
+			resetNodeCache: true,
 		},
 		{
 			inDesc: "success get enum leaf with an existing key",
@@ -451,11 +454,12 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 			want:     EnumType(43),
 		},
 		{
-			inDesc:   "success get enum leaf with a new key",
-			inParent: &ContainerStruct1{},
-			inSchema: containerWithStringKey(),
-			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/enum-leaf-field"),
-			want:     EnumType(0),
+			inDesc:         "success get enum leaf with a new key",
+			inParent:       &ContainerStruct1{},
+			inSchema:       containerWithStringKey(),
+			inPath:         mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/enum-leaf-field"),
+			want:           EnumType(0),
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "fail get enum leaf incorrect container schema",
@@ -499,9 +503,10 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					},
 				},
 			},
-			inSchema: containerWithStringKey(),
-			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/state/int32-leaf-field"),
-			want:     nil,
+			inSchema:       containerWithStringKey(),
+			inPath:         mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/state/int32-leaf-field"),
+			want:           nil,
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "fail getting a shadow value whose container doesn't exist",
@@ -540,10 +545,11 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					},
 				},
 			},
-			inSchema: containerWithStringKey(),
-			inPath:   mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/state/int32-leaf-field"),
-			inOpts:   []GetOrCreateNodeOpt{&PreferShadowPath{}},
-			want:     ygot.Int32(42),
+			inSchema:       containerWithStringKey(),
+			inPath:         mustPath("/config/simple-key-list[key1=forty-two]/outer/inner/state/int32-leaf-field"),
+			inOpts:         []GetOrCreateNodeOpt{&PreferShadowPath{}},
+			want:           ygot.Int32(42),
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "fail getting a shadow value whose container doesn't exist with preferShadowPath=true",
@@ -607,9 +613,10 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					},
 				},
 			},
-			inSchema: containerWithUInt32Key,
-			inPath:   mustPath("/config/simple-key-list[key1=42]/outer/inner"),
-			want:     &InnerContainerType1{Int32LeafName: ygot.Int32(42)},
+			inSchema:       containerWithUInt32Key,
+			inPath:         mustPath("/config/simple-key-list[key1=42]/outer/inner"),
+			want:           &InnerContainerType1{Int32LeafName: ygot.Int32(42)},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "fail finding with incorrect enum key",
@@ -633,8 +640,9 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 					42: {Key1: 42, Int32LeafName: ygot.Int32(99)},
 				},
 			},
-			inPath: mustPath("/config/simple-key-list[key1=E_VALUE_FORTY_TWO]"),
-			want:   &ListElemEnumKey{Key1: 42, Int32LeafName: ygot.Int32(99)},
+			inPath:         mustPath("/config/simple-key-list[key1=E_VALUE_FORTY_TWO]"),
+			want:           &ListElemEnumKey{Key1: 42, Int32LeafName: ygot.Int32(99)},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "success finding bool key",
@@ -645,7 +653,15 @@ func TestGetOrCreateNodeSimpleKey(t *testing.T) {
 		},
 	}
 
+	nodeCache := NewNodeCache()
+
 	for i, tt := range tests {
+		// If there are root (inParent) changes. The node cache should be reset before
+		// running the test.
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.inDesc, func(t *testing.T) {
 			got, _, err := GetOrCreateNode(tt.inSchema, tt.inParent, tt.inPath, tt.inOpts...)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
@@ -977,6 +993,7 @@ func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
 		inPath           *gpb.Path
 		wantErrSubstring string
 		want             interface{}
+		resetNodeCache   bool
 	}{
 		{
 			inDesc:   "success retrieving container with direct descendant schema",
@@ -1023,8 +1040,9 @@ func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
 					},
 				},
 			},
-			inPath: mustPath("/outer/inner/enum-leaf-field"),
-			want:   EnumType(42),
+			inPath:         mustPath("/outer/inner/enum-leaf-field"),
+			want:           EnumType(42),
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "success retrieving container from existing container",
@@ -1042,7 +1060,14 @@ func TestGetOrCreateNodeWithSimpleSchema(t *testing.T) {
 			},
 		},
 	}
+
+	nodeCache := NewNodeCache()
+
 	for i, tt := range tests {
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.inDesc, func(t *testing.T) {
 			got, _, err := GetOrCreateNode(tt.inSchema, tt.inParent, tt.inPath)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
@@ -1329,6 +1354,7 @@ func TestGetNode(t *testing.T) {
 		inArgs           []GetNodeOpt
 		wantTreeNodes    []*TreeNode
 		wantErrSubstring string
+		resetNodeCache   bool
 	}{{
 		desc:     "simple get leaf",
 		inSchema: rootSchema,
@@ -1364,6 +1390,7 @@ func TestGetNode(t *testing.T) {
 			Data:   (*string)(nil),
 			Path:   mustPath("/leaf"),
 		}},
+		resetNodeCache: true,
 	}, {
 		desc:     "simple get container with no results",
 		inSchema: rootSchema,
@@ -1398,6 +1425,7 @@ func TestGetNode(t *testing.T) {
 			Schema: childContainerSchema,
 			Path:   mustPath("/container"),
 		}},
+		resetNodeCache: true,
 	}, {
 		desc:     "simple get nested container",
 		inSchema: rootSchema,
@@ -1703,6 +1731,7 @@ func TestGetNode(t *testing.T) {
 		inPath:           mustPath("/container/grandchild/val"),
 		inArgs:           []GetNodeOpt{&PreferShadowPath{}},
 		wantErrSubstring: "shadow path traverses a non-leaf node, this is not allowed",
+		resetNodeCache:   true,
 	}, {
 		desc:     "deeper list dual shadow/non-shadow leaf path",
 		inSchema: rootSchema,
@@ -1847,7 +1876,13 @@ func TestGetNode(t *testing.T) {
 		wantErrSubstring: "no match found in *ytypes.listChildContainer",
 	}}
 
+	nodeCache := NewNodeCache()
+
 	for _, tt := range tests {
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.desc, func(t *testing.T) {
 			got, err := GetNode(tt.inSchema, tt.inData, tt.inPath, tt.inArgs...)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
@@ -1891,6 +1926,7 @@ func TestSetNode(t *testing.T) {
 		wantErrSubstring string
 		wantLeaf         interface{}
 		wantParent       interface{}
+		resetNodeCache   bool
 	}{
 		{
 			inDesc:     "success setting string field in top node",
@@ -1902,14 +1938,15 @@ func TestSetNode(t *testing.T) {
 			wantParent: &ListElemStruct1{Key1: ygot.String("hello")},
 		},
 		{
-			inDesc:     "success setting string field in top node with preferShadowPath=true where shadow-path doesn't exist",
-			inSchema:   simpleSchema(),
-			inParentFn: func() interface{} { return &ListElemStruct1{} },
-			inPath:     mustPath("/key1"),
-			inVal:      &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
-			inOpts:     []SetNodeOpt{&PreferShadowPath{}},
-			wantLeaf:   ygot.String("hello"),
-			wantParent: &ListElemStruct1{Key1: ygot.String("hello")},
+			inDesc:         "success setting string field in top node with preferShadowPath=true where shadow-path doesn't exist",
+			inSchema:       simpleSchema(),
+			inParentFn:     func() interface{} { return &ListElemStruct1{} },
+			inPath:         mustPath("/key1"),
+			inVal:          &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+			inOpts:         []SetNodeOpt{&PreferShadowPath{}},
+			wantLeaf:       ygot.String("hello"),
+			wantParent:     &ListElemStruct1{Key1: ygot.String("hello")},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "failure setting uint field in top node with int value",
@@ -1931,24 +1968,26 @@ func TestSetNode(t *testing.T) {
 			wantParent:       &ListElemStruct4{},
 		},
 		{
-			inDesc:     "success setting uint field in uint node with positive int value with JSON tolerance is set",
-			inSchema:   listElemStruct4Schema,
-			inParentFn: func() interface{} { return &ListElemStruct4{} },
-			inPath:     mustPath("/key1"),
-			inVal:      &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 42}},
-			inOpts:     []SetNodeOpt{&TolerateJSONInconsistencies{}},
-			wantLeaf:   ygot.Uint32(42),
-			wantParent: &ListElemStruct4{Key1: ygot.Uint32(42)},
+			inDesc:         "success setting uint field in uint node with positive int value with JSON tolerance is set",
+			inSchema:       listElemStruct4Schema,
+			inParentFn:     func() interface{} { return &ListElemStruct4{} },
+			inPath:         mustPath("/key1"),
+			inVal:          &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 42}},
+			inOpts:         []SetNodeOpt{&TolerateJSONInconsistencies{}},
+			wantLeaf:       ygot.Uint32(42),
+			wantParent:     &ListElemStruct4{Key1: ygot.Uint32(42)},
+			resetNodeCache: true,
 		},
 		{
-			inDesc:     "success setting uint field in uint node with 0 int value with JSON tolerance is set",
-			inSchema:   listElemStruct4Schema,
-			inParentFn: func() interface{} { return &ListElemStruct4{} },
-			inPath:     mustPath("/key1"),
-			inVal:      &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 0}},
-			inOpts:     []SetNodeOpt{&TolerateJSONInconsistencies{}},
-			wantLeaf:   ygot.Uint32(0),
-			wantParent: &ListElemStruct4{Key1: ygot.Uint32(0)},
+			inDesc:         "success setting uint field in uint node with 0 int value with JSON tolerance is set",
+			inSchema:       listElemStruct4Schema,
+			inParentFn:     func() interface{} { return &ListElemStruct4{} },
+			inPath:         mustPath("/key1"),
+			inVal:          &gpb.TypedValue{Value: &gpb.TypedValue_IntVal{IntVal: 0}},
+			inOpts:         []SetNodeOpt{&TolerateJSONInconsistencies{}},
+			wantLeaf:       ygot.Uint32(0),
+			wantParent:     &ListElemStruct4{Key1: ygot.Uint32(0)},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:           "failure setting uint field in uint node with negative int value with JSON tolerance is set",
@@ -2061,6 +2100,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "success setting annotation in list element",
@@ -2173,6 +2213,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "fail setting with Json (non-ietf) value",
@@ -2240,6 +2281,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "success ignoring already-set shadow leaf",
@@ -2305,6 +2347,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:     "success ignore setting shadow leaf",
@@ -2360,6 +2403,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:     "success ignoring non-shadow leaf when preferShadowPath=true",
@@ -2380,6 +2424,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:     "success writing shadow leaf when preferShadowPath=true",
@@ -2402,6 +2447,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "fail setting leaf that doesn't exist when preferShadowPath=true",
@@ -2497,6 +2543,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "OK setting JSON struct with unknown field with IgnoreExtraFields",
@@ -2531,6 +2578,7 @@ func TestSetNode(t *testing.T) {
 					},
 				},
 			},
+			resetNodeCache: true,
 		},
 		{
 			inDesc:   "success setting list element",
@@ -2653,11 +2701,18 @@ func TestSetNode(t *testing.T) {
 		},
 	}
 
+	nodeCache := NewNodeCache()
+
 	for _, tt := range tests {
 		for typeDesc, inVal := range map[string]interface{}{"scalar": tt.inVal, "JSON": tt.inValJSON} {
 			if inVal == nil {
 				continue
 			}
+
+			if tt.resetNodeCache {
+				nodeCache.Reset()
+			}
+
 			t.Run(tt.inDesc+" "+typeDesc, func(t *testing.T) {
 				parent := tt.inParentFn()
 				err := SetNode(tt.inSchema, parent, tt.inPath, inVal, tt.inOpts...)
@@ -3265,7 +3320,7 @@ func TestRetrieveNodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, err := retrieveNode(tt.inSchema, tt.inRoot, tt.inPath, nil, tt.inArgs)
+			_, err := retrieveNode(tt.inSchema, nil, tt.inRoot, tt.inPath, nil, tt.inArgs)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
 				t.Fatalf("did not get expected error, %s", diff)
 			}

--- a/ytypes/schema_tests/get_test.go
+++ b/ytypes/schema_tests/get_test.go
@@ -182,7 +182,7 @@ func TestGetNodeFull(t *testing.T) {
 			return d
 		}(),
 		inSchema:         rootSchema,
-		inPath:           mustPath("/interfaces/interface[name=eth0]"),
+		inPath:           mustPath("/interfaces/interface[name=eth3]"),
 		wantErrSubstring: "NotFound",
 	}}
 

--- a/ytypes/schema_tests/set_test.go
+++ b/ytypes/schema_tests/set_test.go
@@ -52,6 +52,7 @@ func TestSet(t *testing.T) {
 		inOpts           []ytypes.SetNodeOpt
 		wantErrSubstring string
 		wantNode         *ytypes.TreeNode
+		resetNodeCache   bool // Reset the node cache to clear the cache state.
 	}{{
 		desc:     "set leafref with mismatched name - compressed schema",
 		inSchema: mustSchema(exampleoc.Schema),
@@ -72,7 +73,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_StringVal{"XCVR-1-2"},
+			Value: &gpb.TypedValue_StringVal{StringVal: "XCVR-1-2"},
 		},
 		inOpts: []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantNode: &ytypes.TreeNode{
@@ -114,7 +115,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_StringVal{"XCVR-1-2"},
+			Value: &gpb.TypedValue_StringVal{StringVal: "XCVR-1-2"},
 		},
 		inOpts: []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantNode: &ytypes.TreeNode{
@@ -163,7 +164,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_UintVal{5},
+			Value: &gpb.TypedValue_UintVal{UintVal: 5},
 		},
 		inOpts: []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantNode: &ytypes.TreeNode{
@@ -212,7 +213,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_StringVal{"XCVR-1-2"},
+			Value: &gpb.TypedValue_StringVal{StringVal: "XCVR-1-2"},
 		},
 		inOpts: []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantNode: &ytypes.TreeNode{
@@ -254,7 +255,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_StringVal{"XCVR-1-2"},
+			Value: &gpb.TypedValue_StringVal{StringVal: "XCVR-1-2"},
 		},
 		inOpts: []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantNode: &ytypes.TreeNode{
@@ -277,6 +278,7 @@ func TestSet(t *testing.T) {
 			// No error, but leaf is not set when shadow-path is provided.
 			Data: nil,
 		},
+		resetNodeCache: true,
 	}, {
 		desc:     "set state (shadowed schema) key list - compressed schema - schema doesn't contain shadow-path",
 		inSchema: mustSchema(exampleoc.Schema),
@@ -297,7 +299,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_StringVal{"XCVR-1-2"},
+			Value: &gpb.TypedValue_StringVal{StringVal: "XCVR-1-2"},
 		},
 		inOpts:           []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantErrSubstring: "no match found",
@@ -310,7 +312,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_IntVal{42},
+			Value: &gpb.TypedValue_IntVal{IntVal: 42},
 		},
 		wantErrSubstring: "no match found",
 	}, {
@@ -326,7 +328,7 @@ func TestSet(t *testing.T) {
 			}},
 		},
 		inValue: &gpb.TypedValue{
-			Value: &gpb.TypedValue_UintVal{42},
+			Value: &gpb.TypedValue_UintVal{UintVal: 42},
 		},
 		inOpts:           []ytypes.SetNodeOpt{&ytypes.InitMissingElements{}},
 		wantErrSubstring: "failed to unmarshal",
@@ -379,7 +381,13 @@ func TestSet(t *testing.T) {
 		},
 	}}
 
+	nodeCache := ytypes.NewNodeCache()
+
 	for _, tt := range tests {
+		if tt.resetNodeCache {
+			nodeCache.Reset()
+		}
+
 		t.Run(tt.desc, func(t *testing.T) {
 			err := ytypes.SetNode(tt.inSchema.RootSchema(), tt.inSchema.Root, tt.inPath, tt.inValue, tt.inOpts...)
 			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {


### PR DESCRIPTION
## What
The squashed changes are ported from our local fork after making performance improvement changes for our use case.

## Why
In one of our use cases of the `ygot` library, we found that there are significant performance benefits if we add a caching layer to the `node` calls. Most of the time spent on calling these methods, especially when the config tree is very large, is to perform tree traversal and find the nodes to operate on. This involves using relatively expensive calls to `reflect` methods and is mostly repetitive computation, if the configuration tree's structure and paths are relatively static but the values may change.

## How (high-level)
The idea to implement the caching layer is to be able to use the unique node paths to locate a node immediately once its address is cached. This provides a shortcut to the tree-traversal method and brings in performance gains. In our use case, this feature addition along with other performance patches we made in other PRs brought the computation time down to <= 10ms from multiple seconds, under pressure tests.

This does come with a cost of higher complexity where the cache operations have to be managed properly. It also resulted in changes we had to make in `reflect.go` to make sure that the node's address doesn't change when its value is modified.

In addition, we hope to make sure that the `ygot` library is stateless, and there's no breaking change to the *exported* APIs after adding the caching mechanism. As a result, the applications that use the `ytypes` library maintain the cache(s) on their own, and they can optionally pass in a pointer of the `node cache` to the call option struct and get a performance boost.

## Other Changes
### JSON Marshaling Performance
When trying to squeeze the last bit of performance out, we decided to use `go-json` at a few places instead of `encoding/json`. There was a bit of hesitation to do so, but the performance boost was significant, especially on the hot paths.

### Procedure Shortcuts and `reflect` Calls
At the very last bit, but not least, we try to optimize the use of `reflect` as much as possible, and early return from continuing unnecessary heap allocations (GC pressure at scale) and computations. Both of which could be considered refactoring with performance gains so no breaking change was introduced. Such code changes can be found, for example, in `ygot/render.go/prependmodsJSON`.


## Summary of Change
- Add caching for high performance Sets/Gets. The CPU usage and performance of GetNode/SetNode calls are significantly reduced after this change.

- Improve JSON marshaling performance using go-json. This helps squeeze out the last bit of performance particularly for embedded devices.

- Shortcut expensive heap allocations. The repetitive heap allocations may increase GC pressure and increase CPU usage when being called frequently.

**Note**: tests need to be added and completed for `caching enabled` method calls.