### PR TITLE
Support ytypes.GetNode for ordered maps.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -151,9 +151,10 @@ jobs:
           # and testutil's code.
           go test -covermode count -coverprofile profile.coverprofile -outputdir gogen -coverpkg github.com/openconfig/ygot/gogen,github.com/openconfig/ygot/ygen,github.com/openconfig/ygot/testutil github.com/openconfig/ygot/gogen
           go test -covermode count -coverprofile profile.coverprofile -outputdir protogen -coverpkg github.com/openconfig/ygot/protogen,github.com/openconfig/ygot/ygen,github.com/openconfig/ygot/testutil github.com/openconfig/ygot/protogen
-          # Also cover testutil from ytypes and ygot packages
-          go test -covermode count -coverprofile profile.coverprofile -outputdir ygot -coverpkg github.com/openconfig/ygot/ygot,github.com/openconfig/ygot/testutil github.com/openconfig/ygot/ygot
-          go test -covermode count -coverprofile profile.coverprofile -outputdir ytypes -coverpkg github.com/openconfig/ygot/ytypes,github.com/openconfig/ygot/testutil github.com/openconfig/ygot/ytypes
+          # Also cover testutil,yreflect from util, ytypes and ygot packages
+          go test -covermode count -coverprofile profile.coverprofile -outputdir util -coverpkg github.com/openconfig/ygot/util,github.com/openconfig/ygot/testutil,github.com/openconfig/ygot/internal/yreflect github.com/openconfig/ygot/util
+          go test -covermode count -coverprofile profile.coverprofile -outputdir ygot -coverpkg github.com/openconfig/ygot/ygot,github.com/openconfig/ygot/testutil,github.com/openconfig/ygot/internal/yreflect github.com/openconfig/ygot/ygot
+          go test -covermode count -coverprofile profile.coverprofile -outputdir ytypes -coverpkg github.com/openconfig/ygot/ytypes,github.com/openconfig/ygot/testutil,github.com/openconfig/ygot/internal/yreflect github.com/openconfig/ygot/ytypes
 
           echo 'mode: count' > concatenated.coverprofile
           for p in $pkgs; do

--- a/integration_tests/schemaops/ctestschema/ctestschema.go
+++ b/integration_tests/schemaops/ctestschema/ctestschema.go
@@ -632,11 +632,11 @@ func (*Device) ΛBelongingModule() string {
 // OrderedList represents the /ctestschema/ordered-lists/ordered-list YANG schema element.
 type OrderedList struct {
 	ΛMetadata    []ygot.Annotation                   `path:"@" ygotAnnotation:"true"`
-	Key          *string                             `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema"`
+	Key          *string                             `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema" shadow-path:"state/key|key" shadow-module:"ctestschema/ctestschema|ctestschema"`
 	ΛKey         []ygot.Annotation                   `path:"config/@key|@key" ygotAnnotation:"true"`
 	OrderedList  *OrderedList_OrderedList_OrderedMap `path:"ordered-lists/ordered-list" module:"ctestschema/ctestschema"`
 	ΛOrderedList []ygot.Annotation                   `path:"ordered-lists/@ordered-list" ygotAnnotation:"true"`
-	Value        *string                             `path:"config/value" module:"ctestschema/ctestschema"`
+	Value        *string                             `path:"config/value" module:"ctestschema/ctestschema" shadow-path:"state/value" shadow-module:"ctestschema/ctestschema"`
 	ΛValue       []ygot.Annotation                   `path:"config/@value" ygotAnnotation:"true"`
 }
 
@@ -873,9 +873,9 @@ func (*OrderedList) ΛBelongingModule() string {
 // OrderedList_OrderedList represents the /ctestschema/ordered-lists/ordered-list/ordered-lists/ordered-list YANG schema element.
 type OrderedList_OrderedList struct {
 	ΛMetadata []ygot.Annotation `path:"@" ygotAnnotation:"true"`
-	Key       *string           `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema"`
+	Key       *string           `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema" shadow-path:"state/key|key" shadow-module:"ctestschema/ctestschema|ctestschema"`
 	ΛKey      []ygot.Annotation `path:"config/@key|@key" ygotAnnotation:"true"`
-	Value     *string           `path:"config/value" module:"ctestschema/ctestschema"`
+	Value     *string           `path:"config/value" module:"ctestschema/ctestschema" shadow-path:"state/value" shadow-module:"ctestschema/ctestschema"`
 	ΛValue    []ygot.Annotation `path:"config/@value" ygotAnnotation:"true"`
 }
 
@@ -953,11 +953,11 @@ func (*OrderedList_OrderedList) ΛBelongingModule() string {
 // OrderedMultikeyedList represents the /ctestschema/ordered-multikeyed-lists/ordered-multikeyed-list YANG schema element.
 type OrderedMultikeyedList struct {
 	ΛMetadata []ygot.Annotation `path:"@" ygotAnnotation:"true"`
-	Key1      *string           `path:"config/key1|key1" module:"ctestschema/ctestschema|ctestschema"`
+	Key1      *string           `path:"config/key1|key1" module:"ctestschema/ctestschema|ctestschema" shadow-path:"state/key1|key1" shadow-module:"ctestschema/ctestschema|ctestschema"`
 	ΛKey1     []ygot.Annotation `path:"config/@key1|@key1" ygotAnnotation:"true"`
-	Key2      *uint64           `path:"config/key2|key2" module:"ctestschema/ctestschema|ctestschema"`
+	Key2      *uint64           `path:"config/key2|key2" module:"ctestschema/ctestschema|ctestschema" shadow-path:"state/key2|key2" shadow-module:"ctestschema/ctestschema|ctestschema"`
 	ΛKey2     []ygot.Annotation `path:"config/@key2|@key2" ygotAnnotation:"true"`
-	Value     *string           `path:"config/value" module:"ctestschema/ctestschema"`
+	Value     *string           `path:"config/value" module:"ctestschema/ctestschema" shadow-path:"state/value" shadow-module:"ctestschema/ctestschema"`
 	ΛValue    []ygot.Annotation `path:"config/@value" ygotAnnotation:"true"`
 }
 
@@ -1056,9 +1056,9 @@ func (*OrderedMultikeyedList) ΛBelongingModule() string {
 // UnorderedList represents the /ctestschema/unordered-lists/unordered-list YANG schema element.
 type UnorderedList struct {
 	ΛMetadata []ygot.Annotation `path:"@" ygotAnnotation:"true"`
-	Key       *string           `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema"`
+	Key       *string           `path:"config/key|key" module:"ctestschema/ctestschema|ctestschema" shadow-path:"state/key|key" shadow-module:"ctestschema/ctestschema|ctestschema"`
 	ΛKey      []ygot.Annotation `path:"config/@key|@key" ygotAnnotation:"true"`
-	Value     *string           `path:"config/value" module:"ctestschema/ctestschema"`
+	Value     *string           `path:"config/value" module:"ctestschema/ctestschema" shadow-path:"state/value" shadow-module:"ctestschema/ctestschema"`
 	ΛValue    []ygot.Annotation `path:"config/@value" ygotAnnotation:"true"`
 }
 

--- a/integration_tests/schemaops/ctestschema/helpers.go
+++ b/integration_tests/schemaops/ctestschema/helpers.go
@@ -126,3 +126,23 @@ func GetNestedOrderedMap(t *testing.T) *OrderedList_OrderedMap {
 	om.Get("foo").OrderedList = nestedOrderedMap
 	return om
 }
+
+func GetOrderedMapMultikeyed(t *testing.T) *OrderedMultikeyedList_OrderedMap {
+	orderedMap := &OrderedMultikeyedList_OrderedMap{}
+	v, err := orderedMap.AppendNew("foo", 42)
+	if err != nil {
+		t.Error(err)
+	}
+	v.Value = ygot.String("foo-val")
+	v, err = orderedMap.AppendNew("bar", 42)
+	if err != nil {
+		t.Error(err)
+	}
+	v.Value = ygot.String("bar-val")
+	v, err = orderedMap.AppendNew("baz", 84)
+	if err != nil {
+		t.Error(err)
+	}
+	v.Value = ygot.String("baz-val")
+	return orderedMap
+}

--- a/integration_tests/schemaops/ctestschema/update.sh
+++ b/integration_tests/schemaops/ctestschema/update.sh
@@ -15,6 +15,7 @@ go run ../../../generator/generator.go -path="." -output_file=ctestschema.go \
   -compress_paths \
   -shorten_enum_leaf_names \
   -typedef_enum_with_defmod \
+  -ignore_shadow_schema_paths \
   -enum_suffix_for_simple_union_enums \
   -generate_rename \
   -generate_append \

--- a/internal/yreflect/reflect_orderedmap.go
+++ b/internal/yreflect/reflect_orderedmap.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yreflect
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/openconfig/ygot/util"
+)
+
+// goOrderedList is a convenience interface for ygot.GoOrderedList. It is here
+// to avoid a circular dependency.
+type goOrderedList interface {
+	// IsYANGOrderedList is a marker method that indicates that the struct
+	// implements the goOrderedList interface.
+	IsYANGOrderedList()
+}
+
+// AppendIntoOrderedMap append value with key into parent which must be a
+// GoOrderedList interface.
+//
+// If the type is a GoOrderedList, then there must not exist an existing
+// element.
+func AppendIntoOrderedMap(orderedMap goOrderedList, value interface{}) error {
+	appendMethod, err := util.MethodByName(reflect.ValueOf(orderedMap), "Append")
+	if err != nil {
+		return err
+	}
+	ret := appendMethod.Call([]reflect.Value{reflect.ValueOf(value)})
+	if got, wantReturnN := len(ret), 1; got != wantReturnN {
+		return fmt.Errorf("method Append() doesn't have expected number of return values, got %v, want %v", got, wantReturnN)
+	}
+	if err := ret[0].Interface(); err != nil {
+		return fmt.Errorf("unable to append new ordered map element (it is expected that YANG `ordered-by user` lists are always unmarshalled as a whole instead of individually): %v", err)
+	}
+
+	return nil
+}
+
+// RangeOrderedMap calls a visitor function over each key-value pair in order.
+//
+// If the visit function returns false, the for loop breaks.
+// An erorr is returned if the ordered map is not well-formed.
+func RangeOrderedMap(orderedMap goOrderedList, visit func(k reflect.Value, v reflect.Value) bool) error {
+	omv := reflect.ValueOf(orderedMap)
+	// First get the ordered keys, and then index into each of the values associated with it.
+	keysMethod, err := util.MethodByName(omv, "Keys")
+	if err != nil {
+		return err
+	}
+	ret := keysMethod.Call(nil)
+	if got, wantReturnN := len(ret), 1; got != wantReturnN {
+		return fmt.Errorf("method Keys() doesn't have expected number of return values, got %v, want %v", got, wantReturnN)
+	}
+	keys := ret[0]
+	if gotKind := keys.Type().Kind(); gotKind != reflect.Slice {
+		return fmt.Errorf("method Keys() did not return a slice value, got %v", gotKind)
+	}
+
+	getMethod, err := util.MethodByName(omv, "Get")
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i != keys.Len(); i++ {
+		k := keys.Index(i)
+		ret := getMethod.Call([]reflect.Value{k})
+		if got, wantReturnN := len(ret), 1; got != wantReturnN {
+			return fmt.Errorf("method Get() doesn't have expected number of return values, got %v, want %v", got, wantReturnN)
+		}
+		v := ret[0]
+		if gotKind := v.Type().Kind(); gotKind != reflect.Ptr {
+			return fmt.Errorf("method Keys() did not return a ptr value, got %v", gotKind)
+		}
+
+		if !visit(k, v) {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// UnaryMethodArgType returns the argument type of the input type's specified
+// unary method.
+func UnaryMethodArgType(t reflect.Type, methodName string) (reflect.Type, error) {
+	appendMethod, ok := t.MethodByName(methodName)
+	if !ok {
+		return nil, fmt.Errorf("did not find %s() method on type: %s", methodName, t.Name())
+	}
+	methodSpec := appendMethod.Func.Type()
+	// The receiver is the first arg.
+	if gotIn, wantIn := methodSpec.NumIn(), 2; gotIn != wantIn {
+		return nil, fmt.Errorf("method %s() doesn't have expected number of input parameters, got %v, want %v", methodName, gotIn, wantIn)
+	}
+	return methodSpec.In(1), nil
+}

--- a/internal/yreflect/reflect_orderedmap.go
+++ b/internal/yreflect/reflect_orderedmap.go
@@ -29,11 +29,9 @@ type goOrderedList interface {
 	IsYANGOrderedList()
 }
 
-// AppendIntoOrderedMap append value with key into parent which must be a
-// GoOrderedList interface.
+// AppendIntoOrderedMap appends a populated value into the ordered map.
 //
-// If the type is a GoOrderedList, then there must not exist an existing
-// element.
+// There must not exist an existing element with the same key.
 func AppendIntoOrderedMap(orderedMap goOrderedList, value interface{}) error {
 	appendMethod, err := util.MethodByName(reflect.ValueOf(orderedMap), "Append")
 	if err != nil {

--- a/internal/yreflect/reflect_orderedmap_test.go
+++ b/internal/yreflect/reflect_orderedmap_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yreflect_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gnmi/errdiff"
+	"github.com/openconfig/ygot/integration_tests/schemaops/ctestschema"
+	"github.com/openconfig/ygot/internal/yreflect"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestAppendIntoOrderedMap(t *testing.T) {
+	om := ctestschema.GetOrderedMap(t)
+	newKey := "new"
+	for om.Get(newKey) != nil {
+		newKey += "-repeat"
+	}
+	om2 := ctestschema.GetOrderedMap(t)
+	newOrderedListElement, err := om2.AppendNew(newKey)
+	if err != nil {
+		t.Fatalf("om2.AppendNew(newKey) failed, this is unexpected for testing: %v", err)
+	}
+	var stringval = "val"
+	newOrderedListElement.Value = &stringval
+
+	tests := []struct {
+		desc          string
+		inMap         ygot.GoOrderedList
+		inValue       interface{}
+		wantMap       ygot.GoOrderedList
+		wantErrSubstr string
+	}{{
+		desc:    "ordered map",
+		inMap:   om,
+		inValue: newOrderedListElement,
+		wantMap: om2,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := yreflect.AppendIntoOrderedMap(tt.inMap, tt.inValue)
+			if diff := errdiff.Substring(err, tt.wantErrSubstr); diff != "" {
+				t.Fatalf("InsertIntoMap: %s", diff)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantMap, tt.inMap, cmp.AllowUnexported(ctestschema.OrderedList_OrderedMap{})); diff != "" {
+				t.Errorf("(-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -217,27 +217,6 @@ func MethodByName(v reflect.Value, name string) (reflect.Value, error) {
 	return method, nil
 }
 
-// AppendIntoOrderedMap append value with key into parent which must be a
-// GoOrderedList interface.
-//
-// If the type is a GoOrderedList, then there must not exist an existing
-// element.
-func AppendIntoOrderedMap(orderedMap goOrderedList, value interface{}) error {
-	appendMethod, err := MethodByName(reflect.ValueOf(orderedMap), "Append")
-	if err != nil {
-		return err
-	}
-	ret := appendMethod.Call([]reflect.Value{reflect.ValueOf(value)})
-	if got, wantReturnN := len(ret), 1; got != wantReturnN {
-		return fmt.Errorf("method Append() doesn't have expected number of return values, got %v, want %v", got, wantReturnN)
-	}
-	if err := ret[0].Interface(); err != nil {
-		return fmt.Errorf("unable to append new ordered map element (it is expected that YANG `ordered-by user` lists are always unmarshalled as a whole instead of individually: %v", err)
-	}
-
-	return nil
-}
-
 // UpdateField updates a field called fieldName (which must exist, but may be
 // nil) in parentStruct, with value fieldValue. If the field is a slice,
 // fieldValue is appended.

--- a/util/reflect_exported_test.go
+++ b/util/reflect_exported_test.go
@@ -144,58 +144,6 @@ func TestInsertIntoMap(t *testing.T) {
 	}
 }
 
-// goOrderedList is a convenience interface for ygot.GoOrderedList. It is here
-// to avoid a circular dependency.
-type goOrderedList interface {
-	// IsYANGOrderedList is a marker method that indicates that the struct
-	// implements the goOrderedList interface.
-	IsYANGOrderedList()
-}
-
-func TestAppendIntoOrderedMap(t *testing.T) {
-	om := ctestschema.GetOrderedMap(t)
-	newKey := "new"
-	for om.Get(newKey) != nil {
-		newKey += "-repeat"
-	}
-	om2 := ctestschema.GetOrderedMap(t)
-	newOrderedListElement, err := om2.AppendNew(newKey)
-	if err != nil {
-		t.Fatalf("om2.AppendNew(newKey) failed, this is unexpected for testing: %v", err)
-	}
-	var stringval = "val"
-	newOrderedListElement.Value = &stringval
-
-	tests := []struct {
-		desc          string
-		inMap         goOrderedList
-		inValue       interface{}
-		wantMap       goOrderedList
-		wantErrSubstr string
-	}{{
-		desc:    "ordered map",
-		inMap:   om,
-		inValue: newOrderedListElement,
-		wantMap: om2,
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			err := util.AppendIntoOrderedMap(tt.inMap, tt.inValue)
-			if diff := errdiff.Substring(err, tt.wantErrSubstr); diff != "" {
-				t.Fatalf("InsertIntoMap: %s", diff)
-			}
-			if err != nil {
-				return
-			}
-
-			if diff := cmp.Diff(tt.wantMap, tt.inMap, cmp.AllowUnexported(ctestschema.OrderedList_OrderedMap{})); diff != "" {
-				t.Errorf("(-want, +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestInitializeStructField(t *testing.T) {
 	type testStruct struct {
 		// Following two fields exist to exercise

--- a/util/types.go
+++ b/util/types.go
@@ -35,11 +35,3 @@ func YangIntTypeBits(t yang.TypeKind) (int, error) {
 	}
 	return 0, fmt.Errorf("type is not an int")
 }
-
-// goOrderedList is a convenience interface for ygot.GoOrderedList. It is here
-// to avoid a circular dependency.
-type goOrderedList interface {
-	// IsYANGOrderedList is a marker method that indicates that the struct
-	// implements the goOrderedList interface.
-	IsYANGOrderedList()
-}

--- a/ytypes/node_exported_test.go
+++ b/ytypes/node_exported_test.go
@@ -1,0 +1,361 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ytypes_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gnmi/errdiff"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/integration_tests/schemaops/ctestschema"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+func treeNodesEqual(got, want []*ytypes.TreeNode) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("mismatched lengths of nodes, got: %d, want: %d", len(got), len(want))
+	}
+
+	for _, w := range want {
+		match := false
+		for _, g := range got {
+			// Use reflect.DeepEqual on schema comparison to avoid stack overflow (maybe due to circular references).
+			if cmp.Equal(g.Data, w.Data) && reflect.DeepEqual(g.Schema, w.Schema) && proto.Equal(g.Path, w.Path) {
+				match = true
+				break
+			}
+		}
+		if !match {
+			paths := []string{}
+			for _, g := range got {
+				paths = append(paths, fmt.Sprintf("< %s | %#v >", prototext.MarshalOptions{Multiline: false}.Format(g.Path), g))
+			}
+			return fmt.Errorf("no match for %#v (path: %s) in %v", w, prototext.MarshalOptions{Multiline: false}.Format(w.Path), paths)
+		}
+	}
+	return nil
+}
+
+func mustPath(s string) *gpb.Path {
+	p, err := ygot.StringToStructuredPath(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestGetNodeOrderedMap(t *testing.T) {
+	tests := []struct {
+		desc             string
+		inSchema         *yang.Entry
+		inData           any
+		inPath           *gpb.Path
+		inArgs           []ytypes.GetNodeOpt
+		wantTreeNodes    []*ytypes.TreeNode
+		wantErrSubstring string
+	}{{
+		desc:     "single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("foo"),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]"),
+		}},
+	}, {
+		desc:     "single-keyed ordered list match on second",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=bar]"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("bar"),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=bar]"),
+		}},
+	}, {
+		desc:     "multi-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("foo"),
+				Key2:  ygot.Uint64(42),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]"),
+		}},
+	}, {
+		desc:     "multi-keyed ordered list match on third",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=baz][key2=84]"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("baz"),
+				Key2:  ygot.Uint64(84),
+				Value: ygot.String("baz-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=baz][key2=84]"),
+		}},
+	}, {
+		desc:     "nested ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetNestedOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/ordered-lists/ordered-list[key=foo]"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList_OrderedList{
+				Key:   ygot.String("foo"),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList_OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/ordered-lists/ordered-list[key=foo]"),
+		}},
+	}, {
+		desc:     "wildcard match on single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=*]"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.GetHandleWildcards{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("foo"),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]"),
+		}, {
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("bar"),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=bar]"),
+		}},
+	}, {
+		desc:     "partial match on single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.GetPartialKeyMatch{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("foo"),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]"),
+		}, {
+			Data: &ctestschema.OrderedList{
+				Key:   ygot.String("bar"),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=bar]"),
+		}},
+	}, {
+		desc:     "wildcard match on multi-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=*][key2=42]"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.GetHandleWildcards{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("foo"),
+				Key2:  ygot.Uint64(42),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]"),
+		}, {
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("bar"),
+				Key2:  ygot.Uint64(42),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=bar][key2=42]"),
+		}},
+	}, {
+		desc:     "partial match on multi-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key2=42]"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.GetPartialKeyMatch{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("foo"),
+				Key2:  ygot.Uint64(42),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]"),
+		}, {
+			Data: &ctestschema.OrderedMultikeyedList{
+				Key1:  ygot.String("bar"),
+				Key2:  ygot.Uint64(42),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=bar][key2=42]"),
+		}},
+	}, {
+		desc:     "wildcard match on nested ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetNestedOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/ordered-lists/ordered-list[key=*]"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.GetHandleWildcards{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data: &ctestschema.OrderedList_OrderedList{
+				Key:   ygot.String("foo"),
+				Value: ygot.String("foo-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList_OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/ordered-lists/ordered-list[key=foo]"),
+		}, {
+			Data: &ctestschema.OrderedList_OrderedList{
+				Key:   ygot.String("bar"),
+				Value: ygot.String("bar-val"),
+			},
+			Schema: ctestschema.SchemaTree["OrderedList_OrderedList"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/ordered-lists/ordered-list[key=bar]"),
+		}},
+	}, {
+		desc:     "value not found through single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath:           mustPath("/ordered-lists/ordered-list[key=foo]/config/does-not-exist"),
+		wantErrSubstring: "no match found",
+	}, {
+		desc:     "value through single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data:   ygot.String("foo-val"),
+			Schema: ctestschema.SchemaTree["OrderedList"].Dir["config"].Dir["value"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		}},
+	}, {
+		desc:     "value not preferred through single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.PreferShadowPath{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data:   nil,
+			Schema: nil,
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		}},
+	}, {
+		desc:     "shadow-path value through single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data:   nil,
+			Schema: nil,
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		}},
+	}, {
+		desc:     "shadow-path value preferred through single-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		inArgs: []ytypes.GetNodeOpt{&ytypes.PreferShadowPath{}},
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data:   ygot.String("foo-val"),
+			Schema: ctestschema.SchemaTree["OrderedList"].Dir["state"].Dir["value"],
+			Path:   mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		}},
+	}, {
+		desc:     "value through multi-keyed ordered list",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inData: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]/config/value"),
+		wantTreeNodes: []*ytypes.TreeNode{{
+			Data:   ygot.String("foo-val"),
+			Schema: ctestschema.SchemaTree["OrderedMultikeyedList"].Dir["config"].Dir["value"],
+			Path:   mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]/config/value"),
+		}},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ytypes.GetNode(tt.inSchema, tt.inData, tt.inPath, tt.inArgs...)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("did not get expected error, %s", diff)
+			}
+
+			if err := treeNodesEqual(got, tt.wantTreeNodes); err != nil {
+				if len(got) > 0 {
+					fmt.Println("------------")
+					fmt.Printf("%T: %v\n", got[0].Data, got[0].Data)
+					fmt.Println(got[0].Schema.Path())
+					fmt.Println(tt.wantTreeNodes[0].Schema.Path())
+				}
+				t.Fatalf("did not get expected result, %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* A new function was created for ordered maps. It resembles the existing one for unordered lists but refactored a bit and I intend to re-use the logic in the next PR.
* Generated test code was updated to output shadow paths for testing.
* Refactored util code a little and created internal yreflect util lib.