### PR TITLE
Add test coverage for SetNode

### DIFF
--- a/ytypes/gnmi.go
+++ b/ytypes/gnmi.go
@@ -20,6 +20,8 @@ import (
 //
 // If an error occurs during unmarshalling, schema.Root may already be
 // modified. A rollback is not performed.
+//
+// TODO(wenbli): Handle atomic notifications by deleting prior to unmarshalling.
 func UnmarshalNotifications(schema *Schema, ns []*gpb.Notification, opts ...UnmarshalOpt) error {
 	for _, n := range ns {
 		err := UnmarshalSetRequest(schema, &gpb.SetRequest{


### PR DESCRIPTION
The behaviour when a key is already present is to append.

The other option is to treat `telemetry-atomic` nodes as leaves and therefore erase it prior to unmarshalling. However I don't think `SetNode` is the right layer to implement this because the `atomic` flag is at the `Notification` proto and not the `TypedValue` proto. Append helps with higher level handling (e.g. `UnmarshalNotifications`) since it allows piecewise unmarshalling to happen.