### PR TITLE
Support unmarshalling an atomic `Notification` for ordered lists.

### DIFF
--- a/util/gnmi.go
+++ b/util/gnmi.go
@@ -42,6 +42,29 @@ func PathMatchesPrefix(path *gpb.Path, prefix []string) bool {
 	return true
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// PathPartiallyMatchesPrefix reports whether the path partially or wholly
+// matches the prefix.
+//
+// e.g. a/b partially matches a/b/c or a/b, but doesn't match a/c.
+func PathPartiallyMatchesPrefix(path *gpb.Path, prefix []string) bool {
+	for len(prefix) != 0 && prefix[len(prefix)-1] == "" {
+		prefix = prefix[:len(prefix)-1]
+	}
+	for i := 0; i != min(len(prefix), len(path.GetElem())); i++ {
+		if prefix[i] != path.GetElem()[i].GetName() {
+			return false
+		}
+	}
+	return true
+}
+
 // PathElemsEqual replaces the proto.Equal() check for PathElems.
 // If a.Key["foo"] == "*" and b.Key["foo"] == "bar" func returns false.
 // This significantly improves comparison speed.

--- a/util/gnmi.go
+++ b/util/gnmi.go
@@ -50,7 +50,7 @@ func min(a, b int) int {
 }
 
 // PathPartiallyMatchesPrefix reports whether the path partially or wholly
-// matches the prefix.
+// matches the prefix. No keys from the path are compared.
 //
 // e.g. a/b partially matches a/b/c or a/b, but doesn't match a/c.
 func PathPartiallyMatchesPrefix(path *gpb.Path, prefix []string) bool {

--- a/util/gnmi_test.go
+++ b/util/gnmi_test.go
@@ -132,6 +132,90 @@ func TestPathMatchesPrefix(t *testing.T) {
 	}
 }
 
+func TestPathPartiallyMatchesPrefix(t *testing.T) {
+	tests := []struct {
+		desc   string
+		path   string
+		prefix string
+		want   bool
+	}{
+		{
+			desc:   "empty",
+			path:   "",
+			prefix: "",
+			want:   true,
+		},
+		{
+			desc:   "root",
+			path:   "/",
+			prefix: "/",
+			want:   true,
+		},
+		{
+			desc:   "absolute",
+			path:   "/a/b/c",
+			prefix: "/a/b",
+			want:   true,
+		},
+		{
+			desc:   "relative",
+			path:   "a/b/c/",
+			prefix: "a/b/",
+			want:   true,
+		},
+		{
+			desc:   "relative, different trailing slash 1",
+			path:   "a/b/c/",
+			prefix: "a/b",
+			want:   true,
+		},
+		{
+			desc:   "relative, different trailing slash 2",
+			path:   "a/b/c",
+			prefix: "a/b/",
+			want:   true,
+		},
+		{
+			desc:   "relative vs absolute 1",
+			path:   "/a/b/c/",
+			prefix: "a/b/",
+			want:   false,
+		},
+		{
+			desc:   "relative vs absolute 2",
+			path:   "a/b/c/",
+			prefix: "/a/b/",
+			want:   false,
+		},
+		{
+			desc:   "prefix longer",
+			path:   "a/b",
+			prefix: "a/b/c",
+			want:   true,
+		},
+		{
+			desc:   "prefix longer 2",
+			path:   "/a",
+			prefix: "/a/b/c",
+			want:   true,
+		},
+		{
+			desc:   "not equal",
+			path:   "a/b/c",
+			prefix: "a/d",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := util.PathPartiallyMatchesPrefix(pathNoKeysToGNMIPath(tt.path), strings.Split(tt.prefix, "/")), tt.want; got != want {
+				t.Errorf("%s: got: %v want: %v", tt.desc, got, want)
+			}
+		})
+	}
+}
+
 func TestTrimGNMIPathPrefix(t *testing.T) {
 	tests := []struct {
 		desc   string

--- a/ytypes/gnmi.go
+++ b/ytypes/gnmi.go
@@ -20,6 +20,8 @@ import (
 //
 // If an error occurs during unmarshalling, schema.Root may already be
 // modified. A rollback is not performed.
+//
+// TODO(wenbli): Handle atomic notifications by deleting prior to unmarshalling.
 func UnmarshalNotifications(schema *Schema, ns []*gpb.Notification, opts ...UnmarshalOpt) error {
 	for _, n := range ns {
 		err := UnmarshalSetRequest(schema, &gpb.SetRequest{

--- a/ytypes/gnmi.go
+++ b/ytypes/gnmi.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ytypes
 
 import (
@@ -5,6 +19,7 @@ import (
 	"reflect"
 
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/util"
 	"github.com/openconfig/ygot/ygot"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -20,13 +35,15 @@ import (
 //
 // If an error occurs during unmarshalling, schema.Root may already be
 // modified. A rollback is not performed.
-//
-// TODO(wenbli): Handle atomic notifications by deleting prior to unmarshalling.
 func UnmarshalNotifications(schema *Schema, ns []*gpb.Notification, opts ...UnmarshalOpt) error {
 	for _, n := range ns {
+		deletePaths := n.Delete
+		if n.Atomic {
+			deletePaths = append(deletePaths, &gpb.Path{})
+		}
 		err := UnmarshalSetRequest(schema, &gpb.SetRequest{
 			Prefix: n.Prefix,
-			Delete: n.Delete,
+			Delete: deletePaths,
 			Update: n.Update,
 		}, opts...)
 		if err != nil {
@@ -52,19 +69,28 @@ func UnmarshalSetRequest(schema *Schema, req *gpb.SetRequest, opts ...UnmarshalO
 		return nil
 	}
 	root := schema.Root
+	var prefix *gpb.Path
 	node, nodeName, err := getOrCreateNode(schema.RootSchema(), root, req.Prefix, preferShadowPath)
 	if err != nil {
-		return err
+		// Fallback to prepending the prefix if getOrCreateNode failed.
+		// This can happen if the prefix points to a compressed-out
+		// node in compressed generated code. In particular this will
+		// always happen for `telemetry-atomic` where the extension
+		// marks such compressed out elements (i.e. surrounding
+		// containers for lists and config/state containers).
+		node = root
+		nodeName = reflect.TypeOf(root).Elem().Name()
+		prefix = req.Prefix
 	}
 
 	// Process deletes, then replace, then updates.
-	if err := deletePaths(schema.SchemaTree[nodeName], node, req.Delete, preferShadowPath); err != nil {
+	if err := deletePaths(schema.SchemaTree[nodeName], node, prefix, req.Delete, preferShadowPath); err != nil {
 		return err
 	}
-	if err := replacePaths(schema.SchemaTree[nodeName], node, req.Replace, preferShadowPath, ignoreExtraFields); err != nil {
+	if err := replacePaths(schema.SchemaTree[nodeName], node, prefix, req.Replace, preferShadowPath, ignoreExtraFields); err != nil {
 		return err
 	}
-	if err := updatePaths(schema.SchemaTree[nodeName], node, req.Update, preferShadowPath, ignoreExtraFields); err != nil {
+	if err := updatePaths(schema.SchemaTree[nodeName], node, prefix, req.Update, preferShadowPath, ignoreExtraFields); err != nil {
 		return err
 	}
 
@@ -92,13 +118,19 @@ func getOrCreateNode(schema *yang.Entry, goStruct ygot.GoStruct, path *gpb.Path,
 }
 
 // deletePaths deletes a slice of paths from the given GoStruct.
-func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, paths []*gpb.Path, preferShadowPath bool) error {
+func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, prefix *gpb.Path, paths []*gpb.Path, preferShadowPath bool) error {
 	var dopts []DelNodeOpt
 	if preferShadowPath {
 		dopts = append(dopts, &PreferShadowPath{})
 	}
 
 	for _, path := range paths {
+		if prefix != nil {
+			var err error
+			if path, err = util.JoinPaths(prefix, path); err != nil {
+				return fmt.Errorf("cannot join prefix with deletion path: %v", err)
+			}
+		}
 		if err := DeleteNode(schema, goStruct, path, dopts...); err != nil {
 			return err
 		}
@@ -106,16 +138,41 @@ func deletePaths(schema *yang.Entry, goStruct ygot.GoStruct, paths []*gpb.Path, 
 	return nil
 }
 
+// joinPrefixToUpdate returns a new update that has the prefix joined to the path.
+//
+// It guarantees to not change the original update, and preserves the .Val and
+// .Path values.
+func joinPrefixToUpdate(prefix *gpb.Path, update *gpb.Update) (*gpb.Update, error) {
+	if prefix == nil {
+		return update, nil
+	}
+	// Here we avoid doing a deep copy for performance.
+	// Currently protobuf is missing a library function for a safe
+	// shallow copy: https://github.com/golang/protobuf/issues/1155
+	joinedUpdate := &gpb.Update{
+		Val: update.Val,
+	}
+	var err error
+	if joinedUpdate.Path, err = util.JoinPaths(prefix, update.Path); err != nil {
+		return nil, fmt.Errorf("cannot join prefix with gpb.Update path: %v", err)
+	}
+	return joinedUpdate, nil
+}
+
 // replacePaths unmarshals a slice of updates into the given GoStruct. It
 // deletes the values at these paths before unmarshalling them. These updates
 // can either by JSON-encoded or gNMI-encoded values (scalars).
-func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
+func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, prefix *gpb.Path, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
 	var dopts []DelNodeOpt
 	if preferShadowPath {
 		dopts = append(dopts, &PreferShadowPath{})
 	}
 
 	for _, update := range updates {
+		var err error
+		if update, err = joinPrefixToUpdate(prefix, update); err != nil {
+			return err
+		}
 		if err := DeleteNode(schema, goStruct, update.Path, dopts...); err != nil {
 			return err
 		}
@@ -128,8 +185,12 @@ func replacePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Upd
 
 // updatePaths unmarshals a slice of updates into the given GoStruct. These
 // updates can either by JSON-encoded or gNMI-encoded values (scalars).
-func updatePaths(schema *yang.Entry, goStruct ygot.GoStruct, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
+func updatePaths(schema *yang.Entry, goStruct ygot.GoStruct, prefix *gpb.Path, updates []*gpb.Update, preferShadowPath, ignoreExtraFields bool) error {
 	for _, update := range updates {
+		var err error
+		if update, err = joinPrefixToUpdate(prefix, update); err != nil {
+			return err
+		}
 		if err := setNode(schema, goStruct, update, preferShadowPath, ignoreExtraFields); err != nil {
 			return err
 		}
@@ -148,5 +209,8 @@ func setNode(schema *yang.Entry, goStruct ygot.GoStruct, update *gpb.Update, pre
 		sopts = append(sopts, &IgnoreExtraFields{})
 	}
 
-	return SetNode(schema, goStruct, update.Path, update.Val, sopts...)
+	if err := SetNode(schema, goStruct, update.Path, update.Val, sopts...); err != nil {
+		return fmt.Errorf("setNode: %v", err)
+	}
+	return nil
 }

--- a/ytypes/gnmi_exported_test.go
+++ b/ytypes/gnmi_exported_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ytypes_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/integration_tests/schemaops/ctestschema"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+func TestUnmarshalNotificationsOrderedMap(t *testing.T) {
+	tests := []struct {
+		desc            string
+		inSchema        *ytypes.Schema
+		inNotifications []*gpb.Notification
+		inUnmarshalOpts []ytypes.UnmarshalOpt
+		want            ygot.GoStruct
+		wantErr         bool
+	}{{
+		desc: "atomic update to a non-empty struct",
+		inSchema: &ytypes.Schema{
+			Root: &ctestschema.Device{
+				OrderedList: ctestschema.GetOrderedMap(t),
+			},
+			SchemaTree: ctestschema.SchemaTree,
+		},
+		inNotifications: []*gpb.Notification{{
+			Timestamp: 42,
+			Atomic:    true,
+			Prefix:    mustPath("/ordered-lists"),
+			Update: []*gpb.Update{{
+				Path: mustPath(`ordered-list[key=boo]/config/key`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "boo"}},
+			}, {
+				Path: mustPath(`ordered-list[key=boo]/key`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "boo"}},
+			}, {
+				Path: mustPath(`ordered-list[key=boo]/config/value`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "boo-val"}},
+			}, {
+				Path: mustPath(`ordered-list[key=coo]/config/key`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "coo"}},
+			}, {
+				Path: mustPath(`ordered-list[key=coo]/key`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "coo"}},
+			}, {
+				Path: mustPath(`ordered-list[key=coo]/config/value`),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "coo-val"}},
+			}},
+		}},
+		want: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := &ctestschema.OrderedList_OrderedMap{}
+				v, err := orderedMap.AppendNew("boo")
+				if err != nil {
+					t.Error(err)
+				}
+				v.Value = ygot.String("boo-val")
+
+				v, err = orderedMap.AppendNew("coo")
+				if err != nil {
+					t.Error(err)
+				}
+				v.Value = ygot.String("coo-val")
+				return orderedMap
+			}(),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := ytypes.UnmarshalNotifications(tt.inSchema, tt.inNotifications, tt.inUnmarshalOpts...)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Fatalf("got error: %v, want: %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if diff := cmp.Diff(tt.inSchema.Root, tt.want, orderedMapCmpOptions...); diff != "" {
+					t.Errorf("(-got, +want):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/ytypes/gnmi_test.go
+++ b/ytypes/gnmi_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ytypes
 
 import (

--- a/ytypes/list_exported_test.go
+++ b/ytypes/list_exported_test.go
@@ -226,6 +226,13 @@ func TestUnmarshalKeyedList(t *testing.T) {
 			},
 		},
 		{
+			desc:   "success at ordered map level",
+			json:   `[ { "key" : "foo", "config": { "value" : "foo-val" } }, { "key" : "bar", "config": { "value" : "bar-val" } } ]`,
+			schema: ctestschema.SchemaTree["OrderedList"],
+			parent: &ctestschema.OrderedList_OrderedMap{},
+			want:   ctestschema.GetOrderedMap(t),
+		},
+		{
 			desc:   "success with nested ordered map",
 			json:   `{ "ordered-lists": { "ordered-list" : [ { "key" : "foo", "config": { "value" : "foo-val" }, "ordered-lists": { "ordered-list" : [ { "key" : "foo", "config": { "value" : "foo-val" } }, { "key" : "bar", "config": { "value" : "bar-val" } } ] } }, { "key" : "bar", "config": { "value" : "bar-val" } } ] } }`,
 			schema: ctestschema.SchemaTree["Device"],

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -297,6 +297,14 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 			for _, p := range schPaths {
 				if util.PathMatchesPrefix(path, p) {
 					return checkPath(p, args, false)
+				} else if util.PathPartiallyMatchesPrefix(path, p) {
+					// Handle ordered map deletion at the container level in compressed GoStructs.
+					if _, isOrderedMap := fv.Interface().(ygot.GoOrderedList); isOrderedMap {
+						if args.delete {
+							fv.Set(reflect.Zero(ft.Type))
+							return nil, nil
+						}
+					}
 				}
 			}
 
@@ -313,6 +321,14 @@ func retrieveNodeContainer(schema *yang.Entry, root interface{}, path *gpb.Path,
 		for _, p := range schPaths {
 			if util.PathMatchesPrefix(path, p) {
 				return checkPath(p, args, shadowLeaf)
+			} else if !shadowLeaf && util.PathPartiallyMatchesPrefix(path, p) {
+				// Handle ordered map deletion at the container level in compressed GoStructs.
+				if _, isOrderedMap := fv.Interface().(ygot.GoOrderedList); isOrderedMap {
+					if args.delete {
+						fv.Set(reflect.Zero(ft.Type))
+						return nil, nil
+					}
+				}
 			}
 		}
 		if !args.preferShadowPath {

--- a/ytypes/node.go
+++ b/ytypes/node.go
@@ -438,7 +438,7 @@ func retrieveNodeOrderedList(schema *yang.Entry, root ygot.GoOrderedList, path, 
 		if match {
 			remainingPath := util.PopGNMIPath(path)
 			if args.delete && len(remainingPath.GetElem()) == 0 {
-				deleteMethod, err := util.MethodByName(v, "Delete")
+				deleteMethod, err := util.MethodByName(reflect.ValueOf(root), "Delete")
 				if err != nil {
 					outerErr = err
 					return false
@@ -455,7 +455,7 @@ func retrieveNodeOrderedList(schema *yang.Entry, root ygot.GoOrderedList, path, 
 			// deletion operation is executed, then remove
 			// the map element from the map.
 			if args.delete && v.Elem().IsZero() {
-				deleteMethod, err := util.MethodByName(v, "Delete")
+				deleteMethod, err := util.MethodByName(reflect.ValueOf(root), "Delete")
 				if err != nil {
 					outerErr = err
 					return false

--- a/ytypes/node_exported_test.go
+++ b/ytypes/node_exported_test.go
@@ -1026,6 +1026,15 @@ func TestDeleteNodeOrderedMap(t *testing.T) {
 		inPath:     mustPath("/ordered-multikeyed-lists"),
 		wantParent: &ctestschema.Device{},
 	}, {
+		desc:     "success deleting entire multi-keyed ordered map at container level when shadowpath option is turned on",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inOpts:     []ytypes.DelNodeOpt{&ytypes.PreferShadowPath{}},
+		inPath:     mustPath("/ordered-multikeyed-lists"),
+		wantParent: &ctestschema.Device{},
+	}, {
 		desc:     "success deleting last key field in multi-keyed ordered map which triggers deletion of element",
 		inSchema: ctestschema.SchemaTree["Device"],
 		inParent: &ctestschema.Device{

--- a/ytypes/node_exported_test.go
+++ b/ytypes/node_exported_test.go
@@ -904,6 +904,14 @@ func TestDeleteNodeOrderedMap(t *testing.T) {
 			}(),
 		},
 	}, {
+		desc:     "success deleting entire single-keyed ordered map at container level",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath:     mustPath("/ordered-lists"),
+		wantParent: &ctestschema.Device{},
+	}, {
 		desc:     "success deleting an ordered map element's key field",
 		inSchema: ctestschema.SchemaTree["Device"],
 		inParent: &ctestschema.Device{
@@ -1009,6 +1017,14 @@ func TestDeleteNodeOrderedMap(t *testing.T) {
 				return orderedMap
 			}(),
 		},
+	}, {
+		desc:     "success deleting entire multi-keyed ordered map at container level",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath:     mustPath("/ordered-multikeyed-lists"),
+		wantParent: &ctestschema.Device{},
 	}, {
 		desc:     "success deleting last key field in multi-keyed ordered map which triggers deletion of element",
 		inSchema: ctestschema.SchemaTree["Device"],

--- a/ytypes/node_exported_test.go
+++ b/ytypes/node_exported_test.go
@@ -591,7 +591,7 @@ func hasSetNodePreferShadowPath(opts []ytypes.SetNodeOpt) bool {
 	return false
 }
 
-func TestSetNode(t *testing.T) {
+func TestSetNodeOrderedMap(t *testing.T) {
 	tests := []struct {
 		desc     string
 		inSchema *yang.Entry
@@ -850,7 +850,7 @@ func TestSetNode(t *testing.T) {
 	}
 }
 
-func TestDeleteNode(t *testing.T) {
+func TestDeleteNodeOrderedMap(t *testing.T) {
 	tests := []struct {
 		desc             string
 		inSchema         *yang.Entry

--- a/ytypes/node_exported_test.go
+++ b/ytypes/node_exported_test.go
@@ -637,6 +637,37 @@ func TestSetNode(t *testing.T) {
 			}(),
 		},
 	}, {
+		desc:     "success not setting shadow string field in ordered map",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParentFn: func() any {
+			return &ctestschema.Device{
+				OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+					orderedMap := &ctestschema.OrderedList_OrderedMap{}
+					v, err := orderedMap.AppendNew("foo")
+					if err != nil {
+						t.Error(err)
+					}
+					v.Value = ygot.String("foo-value")
+					return orderedMap
+				}(),
+			}
+		},
+		inPath:    mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		inVal:     &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: "hello"}},
+		inValJSON: &gpb.TypedValue{Value: &gpb.TypedValue_JsonIetfVal{JsonIetfVal: []byte(`"hello"`)}},
+		want:      nil,
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := &ctestschema.OrderedList_OrderedMap{}
+				v, err := orderedMap.AppendNew("foo")
+				if err != nil {
+					t.Error(err)
+				}
+				v.Value = ygot.String("foo-value")
+				return orderedMap
+			}(),
+		},
+	}, {
 		desc:     "success setting string field in ordered map and initializing new list element",
 		inSchema: ctestschema.SchemaTree["Device"],
 		inParentFn: func() any {
@@ -816,5 +847,232 @@ func TestSetNode(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestDeleteNode(t *testing.T) {
+	tests := []struct {
+		desc             string
+		inSchema         *yang.Entry
+		inParent         any
+		inPath           *gpb.Path
+		inOpts           []ytypes.DelNodeOpt
+		wantParent       any
+		wantErrSubstring string
+	}{{
+		desc:     "success deleting string field in ordered map",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				v := orderedMap.Get("foo")
+				if v == nil {
+					t.Fatalf("key foo doesn't exist in ordered map")
+				}
+				v.Value = nil
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success not deleting shadow string field in ordered map",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/state/value"),
+		wantParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+	}, {
+		desc:     "success deleting an ordered map element",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]"),
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				if deleted := orderedMap.Delete("foo"); !deleted {
+					t.Fatalf("key foo was not deleted")
+				}
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success deleting an ordered map element's key field",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/key"),
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				v := orderedMap.Get("foo")
+				if v == nil {
+					t.Fatalf("key foo doesn't exist in ordered map")
+				}
+				v.Key = nil
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "deleting an ordered map element non-key field when the key field has been deleted -- this should trigger the entire list entry to be deleted since it's now empty",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				v := orderedMap.Get("foo")
+				if v == nil {
+					t.Fatalf("key foo doesn't exist in ordered map")
+				}
+				v.Key = nil
+				return orderedMap
+			}(),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/value"),
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				if deleted := orderedMap.Delete("foo"); !deleted {
+					t.Fatalf("key foo was not deleted")
+				}
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "deleting an ordered map element key field when the non-key field has been deleted -- this should trigger the entire list entry to be deleted since it's now empty",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				v := orderedMap.Get("foo")
+				if v == nil {
+					t.Fatalf("key foo doesn't exist in ordered map")
+				}
+				v.Value = nil
+				return orderedMap
+			}(),
+		},
+		inPath: mustPath("/ordered-lists/ordered-list[key=foo]/config/key"),
+		wantParent: &ctestschema.Device{
+			OrderedList: func() *ctestschema.OrderedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMap(t)
+				if deleted := orderedMap.Delete("foo"); !deleted {
+					t.Fatalf("key foo was not deleted")
+				}
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success deleting string field in multi-keyed ordered map",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]/config/value"),
+		wantParent: &ctestschema.Device{
+			OrderedMultikeyedList: func() *ctestschema.OrderedMultikeyedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMapMultikeyed(t)
+				v := orderedMap.Get(ctestschema.OrderedMultikeyedList_Key{
+					Key1: "foo",
+					Key2: 42,
+				})
+				if v == nil {
+					t.Fatalf("key doesn't exist in ordered map")
+				}
+				v.Value = nil
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success deleting multi-keyed ordered map element",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]"),
+		wantParent: &ctestschema.Device{
+			OrderedMultikeyedList: func() *ctestschema.OrderedMultikeyedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMapMultikeyed(t)
+				if deleted := orderedMap.Delete(ctestschema.OrderedMultikeyedList_Key{
+					Key1: "foo",
+					Key2: 42,
+				}); !deleted {
+					t.Fatalf("key was not deleted")
+				}
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success deleting last key field in multi-keyed ordered map which triggers deletion of element",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: func() *ctestschema.OrderedMultikeyedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMapMultikeyed(t)
+				v := orderedMap.Get(ctestschema.OrderedMultikeyedList_Key{
+					Key1: "foo",
+					Key2: 42,
+				})
+				if v == nil {
+					t.Fatalf("key doesn't exist in ordered map")
+				}
+				v.Key1 = nil
+				v.Value = nil
+				return orderedMap
+			}(),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]/key2"),
+		wantParent: &ctestschema.Device{
+			OrderedMultikeyedList: func() *ctestschema.OrderedMultikeyedList_OrderedMap {
+				orderedMap := ctestschema.GetOrderedMapMultikeyed(t)
+				if deleted := orderedMap.Delete(ctestschema.OrderedMultikeyedList_Key{
+					Key1: "foo",
+					Key2: 42,
+				}); !deleted {
+					t.Fatalf("key was not deleted")
+				}
+				return orderedMap
+			}(),
+		},
+	}, {
+		desc:     "success deleting non-existent multi-keyed ordered map element",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath: mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=dne][key2=999]"),
+		wantParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+	}, {
+		desc:     "error deleting multi-keyed ordered map element path that doesn't exist",
+		inSchema: ctestschema.SchemaTree["Device"],
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		inPath:           mustPath("/ordered-multikeyed-lists/ordered-multikeyed-list[key1=foo][key2=42]/config/dne"),
+		wantErrSubstring: "no match found",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := ytypes.DeleteNode(tt.inSchema, tt.inParent, tt.inPath, tt.inOpts...)
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Fatalf("got error %v\nwant error substr: %s", err, tt.wantErrSubstring)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantParent, tt.inParent, orderedMapCmpOptions...); diff != "" {
+				t.Errorf("TestDeleteNode (-want, +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Involves supporting `DeleteNode` at the container above the list for ordered maps.