### PR TITLE
Support `ForEachDataField`, `DeepCopy`, `Merge` for ordered maps.

### DIFF
--- a/integration_tests/schemaops/schemaops_compressed_test.go
+++ b/integration_tests/schemaops/schemaops_compressed_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schemaops
+package schemaops_test
 
 import (
 	"testing"

--- a/integration_tests/schemaops/schemaops_test.go
+++ b/integration_tests/schemaops/schemaops_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schemaops
+package schemaops_test
 
 import (
 	"testing"

--- a/internal/yreflect/reflect_orderedmap.go
+++ b/internal/yreflect/reflect_orderedmap.go
@@ -42,7 +42,7 @@ func MethodByName(v reflect.Value, name string) (reflect.Value, error) {
 // AppendIntoOrderedMap appends a populated value into the ordered map.
 //
 // There must not exist an existing element with the same key.
-func AppendIntoOrderedMap(orderedMap goOrderedList, value interface{}) error {
+func AppendIntoOrderedMap(orderedMap goOrderedList, value any) error {
 	appendMethod, err := MethodByName(reflect.ValueOf(orderedMap), "Append")
 	if err != nil {
 		return err

--- a/util/reflect_exported_test.go
+++ b/util/reflect_exported_test.go
@@ -292,3 +292,87 @@ func TestForEachFieldOrderedMap(t *testing.T) {
 		}
 	}
 }
+
+func TestForEachDataField(t *testing.T) {
+	tests := []struct {
+		desc       string
+		inParent   any
+		in         any
+		out        any
+		inIterFunc util.FieldIteratorFunc
+		wantOut    string
+		wantErr    string
+	}{{
+		desc: "single-keyed list",
+		inParent: &ctestschema.Device{
+			OrderedList: ctestschema.GetOrderedMap(t),
+		},
+		in:         nil,
+		inIterFunc: util.PrintMapKeysSchemaAnnotationFunc,
+		wantOut: `foo (string)/ordered-lists : 
+{ΛMetadata:    [],
+ Key:           "foo",
+ ΛKey:         [],
+ OrderedList:   nil,
+ ΛOrderedList: [],
+ ParentKey:     nil,
+ ΛParentKey:   [],
+ RoVa...
+, bar (string)/ordered-lists : 
+{ΛMetadata:    [],
+ Key:           "bar",
+ ΛKey:         [],
+ OrderedList:   nil,
+ ΛOrderedList: [],
+ ParentKey:     nil,
+ ΛParentKey:   [],
+ RoVa...
+, `,
+	}, {
+		desc: "multi-keyed list",
+		inParent: &ctestschema.Device{
+			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
+		},
+		in:         nil,
+		inIterFunc: util.PrintMapKeysSchemaAnnotationFunc,
+		wantOut: `{ foo (string), 42 (uint64) }/ordered-multikeyed-lists : 
+{ΛMetadata: [],
+ Key1:       "foo",
+ ΛKey1:     [],
+ Key2:       42,
+ ΛKey2:     [],
+ Value:      "foo-val",
+ ΛValue:    []} (string)
+, { bar (string), 42 (uint64) }/ordered-multikeyed-lists : 
+{ΛMetadata: [],
+ Key1:       "bar",
+ ΛKey1:     [],
+ Key2:       42,
+ ΛKey2:     [],
+ Value:      "bar-val",
+ ΛValue:    []} (string)
+, { baz (string), 84 (uint64) }/ordered-multikeyed-lists : 
+{ΛMetadata: [],
+ Key1:       "baz",
+ ΛKey1:     [],
+ Key2:       84,
+ ΛKey2:     [],
+ Value:      "baz-val",
+ ΛValue:    []} (string)
+, `,
+	}}
+
+	for _, tt := range tests {
+		outStr := ""
+		var errs util.Errors = util.ForEachDataField(tt.inParent, tt.in, &outStr, tt.inIterFunc)
+		if diff := cmp.Diff(errs.String(), tt.wantErr); diff != "" {
+			t.Errorf("error (-got, +want):\n%s", diff)
+		}
+		if len(errs) > 0 {
+			continue
+		}
+		if diff := cmp.Diff(outStr, tt.wantOut); diff != "" {
+			t.Errorf("%s (-got, +want):\n%s", tt.desc, diff)
+		}
+	}
+}

--- a/util/reflect_test.go
+++ b/util/reflect_test.go
@@ -938,7 +938,7 @@ var (
 		return
 	}
 
-	printMapKeysSchemaAnnotationFunc = func(ni *NodeInfo, in, out interface{}) (errs Errors) {
+	PrintMapKeysSchemaAnnotationFunc = func(ni *NodeInfo, in, out interface{}) (errs Errors) {
 		if IsNilOrInvalidValue(ni.FieldKey) {
 			return
 		}
@@ -1255,7 +1255,7 @@ func TestForEachDataField(t *testing.T) {
 			desc:         "map keys with no struct schema",
 			in:           nil,
 			parentStruct: &StructOfMapOfStructs{BasicStructMapField: map[string]BasicStruct{"basicStruct1": basicStruct1}, BasicStructPtrMapField: map[string]*BasicStruct{"basicStruct2": &basicStruct2}},
-			iterFunc:     printMapKeysSchemaAnnotationFunc,
+			iterFunc:     PrintMapKeysSchemaAnnotationFunc,
 			wantOut: `basicStruct1 (string)/basic-struct : 
 {Int32Field:     42,
  StringField:    "forty two",

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -950,7 +950,7 @@ func copyOrderedMap(dstField reflect.Value, srcOrderedMap GoOrderedList, accessP
 		return err
 	}
 	for _, k := range keys {
-		if _, ok := srcKeys[k]; ok {
+		if _, ok := srcKeys[k.Interface()]; ok {
 			return fmt.Errorf("ordered map keys overlap at %v -- merge behaviour is not well defined", k)
 		}
 	}

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -913,10 +913,10 @@ func validateMap(srcField, dstField reflect.Value) (*mapType, error) {
 }
 
 // copyOrderedMap copies srcField into dstField. Both srcField and dstField are
-// reflect.Value structs which contain a map value. If both srcField and dstField
-// are populated, and have non-overlapping keys, they are merged. If the same
-// key is populated in srcField and dstField, their contents are merged if they
-// do not overlap, otherwise an error is returned.
+// ordered list values. If both srcField and dstField are populated, and have
+// non-overlapping keys, then the keys in the src are appended to the dst. If
+// there are overlapping values, then an ereror is returned since the behaviour
+// is not well-defined.
 func copyOrderedMap(dstField reflect.Value, srcOrderedMap GoOrderedList, accessPath string, opts ...MergeOpt) error {
 	dstOrderedMap, dstIsOrderedMap := dstField.Interface().(GoOrderedList)
 	srcField := reflect.ValueOf(srcOrderedMap)

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/openconfig/gnmi/errlist"
+	"github.com/openconfig/ygot/internal/yreflect"
 	"github.com/openconfig/ygot/util"
 )
 
@@ -680,9 +681,14 @@ func copyStruct(dstVal, srcVal reflect.Value, accessPath string, opts ...MergeOp
 		dstField := dstVal.Field(i)
 		accessPath := accessPath + "." + srcVal.Type().Field(i).Name
 
+		orderedMap, isOrderedMap := srcField.Interface().(GoOrderedList)
 		switch srcField.Kind() {
 		case reflect.Ptr:
-			errs.Add(copyPtrField(dstField, srcField, accessPath, opts...))
+			if isOrderedMap {
+				errs.Add(copyOrderedMap(dstField, orderedMap, accessPath, opts...))
+			} else {
+				errs.Add(copyPtrField(dstField, srcField, accessPath, opts...))
+			}
 		case reflect.Interface:
 			errs.Add(copyInterfaceField(dstField, srcField, accessPath, opts...))
 		case reflect.Map:
@@ -904,6 +910,73 @@ func validateMap(srcField, dstField reflect.Value) (*mapType, error) {
 	}
 
 	return &mapType{key: st.Key(), value: st.Elem()}, nil
+}
+
+// copyOrderedMap copies srcField into dstField. Both srcField and dstField are
+// reflect.Value structs which contain a map value. If both srcField and dstField
+// are populated, and have non-overlapping keys, they are merged. If the same
+// key is populated in srcField and dstField, their contents are merged if they
+// do not overlap, otherwise an error is returned.
+func copyOrderedMap(dstField reflect.Value, srcOrderedMap GoOrderedList, accessPath string, opts ...MergeOpt) error {
+	dstOrderedMap, dstIsOrderedMap := dstField.Interface().(GoOrderedList)
+	srcField := reflect.ValueOf(srcOrderedMap)
+	if dstType, srcType := srcField.Type(), dstField.Type(); dstType != srcType || !dstIsOrderedMap {
+		return fmt.Errorf("source and destination ordered map types not matching: src: %s, dst: %s", dstType.Name(), srcType.Name())
+	}
+
+	// Skip cases where there are empty maps in both src and dst.
+	// Exception: user wants an empty map to be merged as well.
+	if srcOrderedMap.Len() == 0 && dstOrderedMap.Len() == 0 {
+		if !mergeEmptyMapsEnabled(opts) || srcField.IsNil() {
+			return nil
+		}
+	}
+
+	if dstOrderedMap.Len() == 0 {
+		dstField.Set(reflect.New(dstField.Type().Elem()))
+		dstOrderedMap = dstField.Interface().(GoOrderedList)
+	}
+
+	srcKeys := map[any]struct{}{}
+	keys, err := yreflect.OrderedMapKeys(srcOrderedMap)
+	if err != nil {
+		return err
+	}
+	for _, k := range keys {
+		srcKeys[k.Interface()] = struct{}{}
+	}
+	keys, err = yreflect.OrderedMapKeys(dstOrderedMap)
+	if err != nil {
+		return err
+	}
+	for _, k := range keys {
+		if _, ok := srcKeys[k]; ok {
+			return fmt.Errorf("ordered map keys overlap at %v -- merge behaviour is not well defined", k)
+		}
+	}
+
+	elemType, err := yreflect.OrderedMapElementType(dstOrderedMap)
+	if err != nil {
+		return err
+	}
+
+	errs := &errlist.Error{}
+	errs.Separator = "\n"
+	if err := yreflect.RangeOrderedMap(srcOrderedMap, func(k, v reflect.Value) bool {
+		d := reflect.New(elemType.Elem())
+		if err := copyStruct(d.Elem(), v.Elem(), fmt.Sprintf("%s[%#v]", accessPath, k.Interface()), opts...); err != nil {
+			errs.Add(err)
+			return true
+		}
+		if err := yreflect.AppendIntoOrderedMap(dstOrderedMap, d.Interface()); err != nil {
+			errs.Add(err)
+		}
+		return true
+	}); err != nil {
+		errs.Add(err)
+	}
+
+	return errs.Err()
 }
 
 // copySliceField copies srcField into dstField. Both srcField and dstField

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -912,11 +912,12 @@ func validateMap(srcField, dstField reflect.Value) (*mapType, error) {
 	return &mapType{key: st.Key(), value: st.Elem()}, nil
 }
 
-// copyOrderedMap copies srcField into dstField. Both srcField and dstField are
-// ordered list values. If both srcField and dstField are populated, and have
-// non-overlapping keys, then the keys in the src are appended to the dst. If
-// there are overlapping values, then an ereror is returned since the behaviour
-// is not well-defined.
+// copyOrderedMap copies srcOrderedMap into dstField. Both srcOrderedMap and
+// dstField (this is a reflect.Value for convenience) are ordered list values.
+// If both srcOrderedMap and dstField are populated, and have non-overlapping
+// keys, then the keys in the src are appended to the dst. If there are
+// overlapping values, then an ereror is returned since the behaviour is not
+// well-defined.
 func copyOrderedMap(dstField reflect.Value, srcOrderedMap GoOrderedList, accessPath string, opts ...MergeOpt) error {
 	dstOrderedMap, dstIsOrderedMap := dstField.Interface().(GoOrderedList)
 	srcField := reflect.ValueOf(srcOrderedMap)

--- a/ygot/struct_validation_map_exported_test.go
+++ b/ygot/struct_validation_map_exported_test.go
@@ -22,8 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/ygot/integration_tests/schemaops/ctestschema"
+	"github.com/openconfig/ygot/internal/ytestutil"
 	"github.com/openconfig/ygot/testutil"
 	"github.com/openconfig/ygot/ygot"
 )
@@ -301,5 +304,108 @@ func TestEmitJSON(t *testing.T) {
 				t.Errorf("%s: EmitJSON(%v, nil): got invalid JSON, diff(-want, +got):\n%s", tt.name, tt.inStruct, diff)
 			}
 		})
+	}
+}
+
+func TestDeepCopyOrderedMap(t *testing.T) {
+	tests := []struct {
+		name             string
+		in               func() *ctestschema.Device
+		inKey            string
+		wantErrSubstring string
+	}{{
+		name: "single-keyed",
+		in:   func() *ctestschema.Device { return &ctestschema.Device{OrderedList: ctestschema.GetOrderedMap(t)} },
+	}, {
+		name: "multi-keyed",
+		in: func() *ctestschema.Device {
+			return &ctestschema.Device{OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t)}
+		},
+	}, {
+		name: "nested",
+		in: func() *ctestschema.Device {
+			return &ctestschema.Device{OrderedList: ctestschema.GetNestedOrderedMap(t)}
+		},
+	}}
+
+	for _, tt := range tests {
+		got, err := ygot.DeepCopy(tt.in())
+		gotRoot, ok := got.(*ctestschema.Device)
+		if !ok {
+			t.Fatalf("Got object that's not root device: %T", got)
+		}
+
+		in := tt.in()
+		if err != nil {
+			if diff := errdiff.Substring(err, tt.wantErrSubstring); diff != "" {
+				t.Errorf("%s: DeepCopy(%#v): did not get expected error, %s", tt.name, in, diff)
+			}
+			continue
+		}
+
+		if diff := cmp.Diff(got, in, ytestutil.OrderedMapCmpOptions...); diff != "" {
+			t.Errorf("did not get identical copy, diff(-got,+want):\n%s", diff)
+		}
+
+		gotValues := gotRoot.OrderedList.Values()
+		for i, inV := range in.OrderedList.Values() {
+			gotV := gotValues[i]
+			if inV == gotV {
+				t.Errorf("%s: DeepCopy: after copy, input and copy have same memory address: %v", tt.name, inV)
+			}
+			if gotV == nil {
+				continue
+			}
+			if inV.Key != nil && inV.Key == gotV.Key {
+				t.Errorf("%s: DeepCopy: key have same address", tt.name)
+			}
+			if inV.ParentKey != nil && inV.ParentKey == gotV.ParentKey {
+				t.Errorf("%s: DeepCopy: ParentKey have same address", tt.name)
+			}
+			if inV.RoValue != nil && inV.RoValue == gotV.RoValue {
+				t.Errorf("%s: DeepCopy: RoValue have same address", tt.name)
+			}
+			if inV.Value != nil && inV.Value == gotV.Value {
+				t.Errorf("%s: DeepCopy: Value have same address", tt.name)
+			}
+			for j, inV := range inV.OrderedList.Values() {
+				gotV := gotValues[i].OrderedList.Values()[j]
+				if inV == gotV {
+					t.Errorf("%s: DeepCopy: after copy, input and copy have same memory address: %v", tt.name, inV)
+				}
+				if gotV == nil {
+					continue
+				}
+				if inV.Key != nil && inV.Key == gotV.Key {
+					t.Errorf("%s: DeepCopy: key have same address", tt.name)
+				}
+				if inV.ParentKey != nil && inV.ParentKey == gotV.ParentKey {
+					t.Errorf("%s: DeepCopy: ParentKey have same address", tt.name)
+				}
+				if inV.Value != nil && inV.Value == gotV.Value {
+					t.Errorf("%s: DeepCopy: Value have same address", tt.name)
+				}
+			}
+		}
+
+		gotMultikeyedValues := gotRoot.OrderedMultikeyedList.Values()
+		for i, inV := range in.OrderedMultikeyedList.Values() {
+			gotV := gotMultikeyedValues[i]
+			if inV == gotV {
+				t.Errorf("%s: DeepCopy: after copy, input and copy have same memory address: %v", tt.name, inV)
+			}
+			if gotV == nil {
+				continue
+			}
+			if inV.Key1 != nil && inV.Key1 == gotV.Key1 {
+				t.Errorf("%s: DeepCopy: key have same address", tt.name)
+			}
+			if inV.Key2 != nil && inV.Key2 == gotV.Key2 {
+				t.Errorf("%s: DeepCopy: RoValue have same address", tt.name)
+			}
+			if inV.Value != nil && inV.Value == gotV.Value {
+				t.Errorf("%s: DeepCopy: Value have same address", tt.name)
+			}
+		}
 	}
 }

--- a/ygot/struct_validation_map_exported_test.go
+++ b/ygot/struct_validation_map_exported_test.go
@@ -454,6 +454,9 @@ func TestMergeStructsOrderedMap(t *testing.T) {
 			OrderedList: ctestschema.GetOrderedMap2(t),
 		},
 	}, {
+		// NOTE: For overlaps where the second ordered list is a subset
+		// of the first, then this may be a valid merge and we may want
+		// to implement this if there is a use case.
 		name: "overlapping ordered lists",
 		inA: &ctestschema.Device{
 			OrderedList: ctestschema.GetOrderedMap(t),


### PR DESCRIPTION
For merge if there is any overlap it simply errors out -- I don't think there is a clear way of merging them if there is a partial overlap.

For overlaps where the second ordered list is a subset of the first, then I can see it as a valid merge -- however I'm opting for simplicity for now since this seems like a more advanced use case.