### PR TITLE
Fix generated protobuf for derived enum value being used as list key.

### DIFF
--- a/protogen/protogen.go
+++ b/protogen/protogen.go
@@ -1117,10 +1117,7 @@ func genListKeyProto(listPackage string, listName string, args *protoDefinitionA
 			enum = args.ir.Enums[scalarType.EnumeratedYANGTypeKey]
 		}
 		switch {
-		case scalarType.IsEnumeratedValue && enum.Kind == ygen.IdentityType:
-			km.Imports = append(km.Imports, importPath(args.cfg.baseImportPath, args.cfg.basePackageName, args.cfg.enumPackageName))
-			fd.Type = scalarType.NativeType
-		case scalarType.IsEnumeratedValue:
+		case scalarType.IsEnumeratedValue && enum.Kind == ygen.SimpleEnumerationType:
 			// list keys must be leafs and not leaf-lists.
 			e, err := genProtoEnum(enum, args.cfg.annotateEnumNames, true)
 			if err != nil {
@@ -1129,6 +1126,9 @@ func genListKeyProto(listPackage string, listName string, args *protoDefinitionA
 			tn := genutil.MakeNameUnique(scalarType.NativeType, definedFieldNames)
 			fd.Type = tn
 			km.Enums[tn] = e
+		case scalarType.IsEnumeratedValue:
+			km.Imports = append(km.Imports, importPath(args.cfg.baseImportPath, args.cfg.basePackageName, args.cfg.enumPackageName))
+			fd.Type = scalarType.NativeType
 		case scalarType.UnionTypes != nil:
 			fd.IsOneOf = true
 			path := kf.YANGDetails.LeafrefTargetPath

--- a/protogen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
+++ b/protogen/testdata/proto/proto-test-c.proto-test-c.elists.elist.formatted-txt
@@ -8,6 +8,7 @@ syntax = "proto3";
 package openconfig.proto_test_c.elists.elist;
 
 import "github.com/openconfig/ygot/proto/ywrapper/ywrapper.proto";
+import "openconfig/enums/enums.proto";
 
 option go_package = "github.com/foo/baz/openconfig/proto_test_c/elists/elist";
 
@@ -21,6 +22,7 @@ message Config {
   }
   ywrapper.StringValue non_key = 460983769;
   One one = 441760514;
+  openconfig.enums.ProtoTestCEnumWithDefault three = 174447098;
   ywrapper.StringValue two = 294851988;
 }
 
@@ -34,5 +36,6 @@ message State {
   }
   ywrapper.StringValue non_key = 139458606;
   One one = 199644645;
+  openconfig.enums.ProtoTestCEnumWithDefault three = 20703553;
   ywrapper.StringValue two = 346656131;
 }

--- a/protogen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
+++ b/protogen/testdata/proto/proto-test-c.proto-test-c.formatted-txt
@@ -7,6 +7,7 @@ syntax = "proto3";
 
 package openconfig.proto_test_c;
 
+import "openconfig/enums/enums.proto";
 import "openconfig/proto_test_c/elists/elists.proto";
 import "openconfig/proto_test_c/entity/entity.proto";
 
@@ -21,8 +22,9 @@ message ElistKey {
     ONE_E42 = 43;
   }
   One one = 1;
-  string two = 2;
-  elists.Elist elist = 3;
+  openconfig.enums.ProtoTestCEnumWithDefault three = 2;
+  string two = 3;
+  elists.Elist elist = 4;
 }
 
 // Elists represents the /proto-test-c/elists YANG schema element.

--- a/protogen/testdata/proto/proto-test-c.yang
+++ b/protogen/testdata/proto/proto-test-c.yang
@@ -74,6 +74,10 @@ module proto-test-c {
       type string;
     }
 
+    leaf three {
+      type enum-with-default;
+    }
+
     leaf non-key {
       type string;
     }
@@ -81,7 +85,7 @@ module proto-test-c {
 
   container elists {
     list elist {
-      key "one two";
+      key "one two three";
 
       leaf one {
         type leafref {
@@ -92,6 +96,12 @@ module proto-test-c {
       leaf two {
         type leafref {
           path "../config/two";
+        }
+      }
+
+      leaf three {
+        type leafref {
+          path "../config/three";
         }
       }
 


### PR DESCRIPTION
Currently the enum is being generated again inline but it should just use the global name that's already generated.

Added coverage.

Fixes #833 