### PR TITLE
Preserve some backward-compatibilities with certain render functions.

### DIFF
--- a/util/reflect_exported_test.go
+++ b/util/reflect_exported_test.go
@@ -15,16 +15,42 @@
 package util_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/kylelemons/godebug/pretty"
 	"github.com/openconfig/gnmi/errdiff"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/integration_tests/schemaops/ctestschema"
 	"github.com/openconfig/ygot/integration_tests/schemaops/utestschema"
 	"github.com/openconfig/ygot/internal/ytestutil"
 	"github.com/openconfig/ygot/util"
+)
+
+var (
+	PrintMapKeysSchemaAnnotationFunc = func(ni *util.NodeInfo, in, out interface{}) (errs util.Errors) {
+		if util.IsNilOrInvalidValue(ni.FieldKey) {
+			return
+		}
+		outs := out.(*string)
+		s := "nil"
+		if !util.IsNilOrInvalidValue(ni.FieldValue) {
+			s = pretty.Sprint(ni.FieldValue.Interface())
+		}
+
+		fn, err := util.SchemaPaths(ni.StructField)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if l := len(fn); l != 1 {
+			errs = append(errs, fmt.Errorf("invalid schema path length %d for %v", l, ni.StructField.Name))
+		}
+
+		*outs += fmt.Sprintf("%s/%s : \n%s\n, ", util.ValueStr(ni.FieldKey.Interface()), fn[0][0], util.ValueStr(s))
+		return
+	}
 )
 
 // to ptr conversion utility functions
@@ -324,7 +350,7 @@ func TestForEachDataFieldOrderedMap(t *testing.T) {
 			OrderedList: ctestschema.GetOrderedMap(t),
 		},
 		in:         nil,
-		inIterFunc: util.PrintMapKeysSchemaAnnotationFunc,
+		inIterFunc: PrintMapKeysSchemaAnnotationFunc,
 		wantOut: `foo (string)/ordered-lists : 
 {ΛMetadata:    [],
  Key:           "foo",
@@ -348,7 +374,7 @@ func TestForEachDataFieldOrderedMap(t *testing.T) {
 		desc:       "single-keyed uncompressed list",
 		inParent:   utestschema.GetDeviceWithOrderedMap(t),
 		in:         nil,
-		inIterFunc: util.PrintMapKeysSchemaAnnotationFunc,
+		inIterFunc: PrintMapKeysSchemaAnnotationFunc,
 		wantOut: `foo (string)/ordered-list : 
 {ΛMetadata:     [],
  Config:         {ΛMetadata: [],
@@ -370,7 +396,7 @@ func TestForEachDataFieldOrderedMap(t *testing.T) {
 			OrderedMultikeyedList: ctestschema.GetOrderedMapMultikeyed(t),
 		},
 		in:         nil,
-		inIterFunc: util.PrintMapKeysSchemaAnnotationFunc,
+		inIterFunc: PrintMapKeysSchemaAnnotationFunc,
 		wantOut: `{ foo (string), 42 (uint64) }/ordered-multikeyed-lists : 
 {ΛMetadata: [],
  Key1:       "foo",

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -814,11 +814,14 @@ func leavesToNotifications(leaves map[*path]any, ts int64, pfx *gnmiPath) ([]*gn
 			return nil, err
 		}
 	}
-	if len(n.Update) > 0 {
-		notifs = append([]*gnmipb.Notification{n}, notifs...)
+	switch {
+	case len(n.Update) == 0 && len(notifs) == 0:
+		return []*gnmipb.Notification{n}, nil
+	case len(n.Update) == 0:
+		return notifs, nil
+	default:
+		return append([]*gnmipb.Notification{n}, notifs...), nil
 	}
-
-	return notifs, nil
 }
 
 // EncodeTypedValueOpt is an interface implemented by arguments to
@@ -1379,7 +1382,9 @@ func structJSON(s GoStruct, parentMod string, args jsonOutputConfig) (map[string
 			if prependmods != nil && prependmods[i][j] != "" {
 				k = fmt.Sprintf("%s:%s", prependmods[i][j], k)
 			}
-			value, err = normalizeJSONValue(value)
+			if args.jType != Internal {
+				value, err = normalizeJSONValue(value)
+			}
 			if err != nil {
 				errs.Add(err)
 				continue

--- a/ygot/render_exported_test.go
+++ b/ygot/render_exported_test.go
@@ -366,10 +366,10 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 				"ordered-multikeyed-list": []any{
 					map[string]any{
 						"key1": "foo",
-						"key2": float64(42),
+						"key2": uint64(42),
 						"config": map[string]any{
 							"key1":  "foo",
-							"key2":  float64(42),
+							"key2":  uint64(42),
 							"value": "foo-val",
 						},
 						"state": map[string]any{
@@ -378,10 +378,10 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 					},
 					map[string]any{
 						"key1": "bar",
-						"key2": float64(42),
+						"key2": uint64(42),
 						"config": map[string]any{
 							"key1":  "bar",
-							"key2":  float64(42),
+							"key2":  uint64(42),
 							"value": "bar-val",
 						},
 						"state": map[string]any{
@@ -390,10 +390,10 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 					},
 					map[string]any{
 						"key1": "baz",
-						"key2": float64(84),
+						"key2": uint64(84),
 						"config": map[string]any{
 							"key1":  "baz",
-							"key2":  float64(84),
+							"key2":  uint64(84),
 							"value": "baz-val",
 						},
 						"state": map[string]any{
@@ -457,7 +457,7 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 				"ordered-multikeyed-list": []any{
 					map[string]any{
 						"key1": "foo",
-						"key2": float64(42),
+						"key2": uint64(42),
 						"config": map[string]any{
 							"value": "foo-val",
 						},
@@ -467,7 +467,7 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 					},
 					map[string]any{
 						"key1": "bar",
-						"key2": float64(42),
+						"key2": uint64(42),
 						"state": map[string]any{
 							"value":    "bar-val",
 							"ro-value": "bar-state-val",
@@ -475,7 +475,7 @@ func TestConstructJSONOrderedMap(t *testing.T) {
 					},
 					map[string]any{
 						"key1": "baz",
-						"key2": float64(84),
+						"key2": uint64(84),
 						"config": map[string]any{
 							"value": "baz-val",
 						},

--- a/ygot/render_test.go
+++ b/ygot/render_test.go
@@ -1026,6 +1026,13 @@ func TestTogNMINotifications(t *testing.T) {
 		want           []*gnmipb.Notification
 		wantErr        bool
 	}{{
+		name:        "empty",
+		inTimestamp: 42,
+		inStruct:    &renderExample{},
+		want: []*gnmipb.Notification{{
+			Timestamp: 42,
+		}},
+	}, {
 		name:        "simple single leaf example",
 		inTimestamp: 42,
 		inStruct:    &renderExample{Str: String("hello")},
@@ -2408,9 +2415,9 @@ func TestConstructJSON(t *testing.T) {
 		wantInternal: map[string]any{
 			"str":        "hello",
 			"leaf-list":  []any{"hello", "world"},
-			"int-val":    float64(42),
+			"int-val":    int32(42),
 			"enum":       "VAL_TWO",
-			"mixed-list": []any{float64(42)},
+			"mixed-list": []any{uint64(42)},
 			"keyless-list": []any{
 				map[string]any{
 					"val": "21st Amendment",
@@ -2440,7 +2447,7 @@ func TestConstructJSON(t *testing.T) {
 			"list": []any{},
 		},
 		wantInternal: map[string]any{
-			"ch": map[string]any{"val": float64(42)},
+			"ch": map[string]any{"val": uint64(42)},
 		},
 	}, {
 		name: "empty map nil",
@@ -2454,7 +2461,7 @@ func TestConstructJSON(t *testing.T) {
 			"ch": map[string]any{"val": "42"},
 		},
 		wantInternal: map[string]any{
-			"ch": map[string]any{"val": float64(42)},
+			"ch": map[string]any{"val": uint64(42)},
 		},
 	}, {
 		name:     "empty child",
@@ -2511,7 +2518,7 @@ func TestConstructJSON(t *testing.T) {
 			"mixed-list": []any{"foo:VAL_ONE", "test", float64(42)},
 		},
 		wantInternal: map[string]any{
-			"ch": map[string]any{"val": float64(42)},
+			"ch": map[string]any{"val": uint64(42)},
 			"enum-list": map[string]any{
 				"VAL_ONE": map[string]any{
 					"config": map[string]any{
@@ -2534,7 +2541,7 @@ func TestConstructJSON(t *testing.T) {
 					"val": "eighty four",
 				},
 			},
-			"mixed-list": []any{"VAL_ONE", "test", float64(42)},
+			"mixed-list": []any{"VAL_ONE", "test", 42},
 		},
 	}, {
 		name: "json test with complex children with PrependModuleNameIdentityref=true",
@@ -2579,7 +2586,7 @@ func TestConstructJSON(t *testing.T) {
 			"mixed-list": []any{"foo:VAL_ONE", "test", float64(42)},
 		},
 		wantInternal: map[string]any{
-			"ch": map[string]any{"val": float64(42)},
+			"ch": map[string]any{"val": uint64(42)},
 			"enum-list": map[string]any{
 				"VAL_ONE": map[string]any{
 					"config": map[string]any{
@@ -2602,7 +2609,7 @@ func TestConstructJSON(t *testing.T) {
 					"val": "eighty four",
 				},
 			},
-			"mixed-list": []any{"VAL_ONE", "test", float64(42)},
+			"mixed-list": []any{"VAL_ONE", "test", 42},
 		},
 	}, {
 		name: "device example #1",
@@ -2624,7 +2631,16 @@ func TestConstructJSON(t *testing.T) {
 				},
 			},
 		},
-		wantSame: true,
+		wantInternal: map[string]any{
+			"bgp": map[string]any{
+				"global": map[string]any{
+					"config": map[string]any{
+						"as":        uint32(15169),
+						"router-id": "192.0.2.1",
+					},
+				},
+			},
+		},
 	}, {
 		name: "device example #2",
 		in: &exampleDevice{
@@ -2680,7 +2696,7 @@ func TestConstructJSON(t *testing.T) {
 								"description":      "a neighbor",
 								"enabled":          true,
 								"neighbor-address": "192.0.2.1",
-								"peer-as":          float64(29636),
+								"peer-as":          uint32(29636),
 							},
 							"neighbor-address": "192.0.2.1",
 						},
@@ -2689,7 +2705,7 @@ func TestConstructJSON(t *testing.T) {
 								"description":      "a second neighbor",
 								"enabled":          false,
 								"neighbor-address": "100.64.32.96",
-								"peer-as":          float64(5413),
+								"peer-as":          uint32(5413),
 							},
 							"neighbor-address": "100.64.32.96",
 						},
@@ -2714,7 +2730,7 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantInternal: map[string]any{
 			"state": map[string]any{
-				"enabled-address-families-simple": []any{float64(3.14), float64(42), base64testStringEncoded, "VAL_ONE"},
+				"enabled-address-families-simple": []any{3.14, int64(42), base64testStringEncoded, "VAL_ONE"},
 			},
 		},
 	}, {
@@ -2727,7 +2743,11 @@ func TestConstructJSON(t *testing.T) {
 				"transport-address-simple": "42.42.42.42",
 			},
 		},
-		wantSame: true,
+		wantInternal: map[string]any{
+			"state": map[string]any{
+				"transport-address-simple": testutil.UnionString("42.42.42.42"),
+			},
+		},
 	}, {
 		name: "union example - enum",
 		in: &exampleBgpNeighbor{
@@ -2762,7 +2782,7 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantInternal: map[string]any{
 			"state": map[string]any{
-				"transport-address-simple": float64(3.14),
+				"transport-address-simple": testutil.UnionFloat64(3.14),
 			},
 		},
 	}, {
@@ -2824,7 +2844,7 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantInternal: map[string]any{
 			"state": map[string]any{
-				"transport-address": float64(42),
+				"transport-address": uint64(42),
 			},
 		},
 	}, {
@@ -2842,7 +2862,7 @@ func TestConstructJSON(t *testing.T) {
 		},
 		wantInternal: map[string]any{
 			"state": map[string]any{
-				"enabled-address-families": []any{"IPV6", float64(42)},
+				"enabled-address-families": []any{"IPV6", uint64(42)},
 			},
 		},
 	}, {
@@ -3106,13 +3126,13 @@ func TestConstructJSON(t *testing.T) {
 						"description":      "a neighbor",
 						"enabled":          true,
 						"neighbor-address": "192.0.2.1",
-						"peer-as":          float64(29636),
+						"peer-as":          uint32(29636),
 					},
 					"100.64.32.96": map[string]any{
 						"description":      "a second neighbor",
 						"enabled":          false,
 						"neighbor-address": "100.64.32.96",
-						"peer-as":          float64(5413),
+						"peer-as":          uint32(5413),
 					},
 				},
 			},


### PR DESCRIPTION
Unfortunately Hyrum's law applies to ygot. I am reverting the normalizing behaviour for internal JSON generation.