### PR TITLE
Add generation flag for ordered maps

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -99,6 +99,7 @@ var (
 	includeModelData        = flag.Bool("include_model_data", false, "If set to true, a slice of gNMI ModelData messages are included in the generated Go code containing the details of the input schemas from which the code was generated.")
 	generatePopulateDefault = flag.Bool("generate_populate_defaults", false, "If set to true, a PopulateDefault method will be generated for all GoStructs which recursively populates default values.")
 	generateValidateFnName  = flag.String("validate_fn_name", "Validate", "The Name of the proxy function for the Validate functionality.")
+	generateOrderedMaps     = flag.Bool("generate_ordered_maps", true, "If set to true, ordered map structures satisfying the interface ygot.GoOrderedMap will be generated for `ordered-by user` lists instead of Go built-in maps.")
 
 	// Flags used for PathStruct generation only.
 	schemaStructPath        = flag.String("schema_struct_path", "", "The Go import path for the schema structs package. This should be specified if and only if schema structs are not being generated at the same time as path structs.")
@@ -374,6 +375,7 @@ func main() {
 				IncludeModelData:                    *includeModelData,
 				AppendEnumSuffixForSimpleUnionEnums: *appendEnumSuffixForSimpleUnionEnums,
 				IgnoreShadowSchemaPaths:             *ignoreShadowSchemaPaths,
+				GenerateOrderedListsAsUnorderedMaps: !*generateOrderedMaps,
 			},
 		)
 

--- a/gogen/codegen.go
+++ b/gogen/codegen.go
@@ -120,6 +120,10 @@ type GoOpts struct {
 	// compression is enabled, that the shadowed paths are to be ignored
 	// while while unmarshalling.
 	IgnoreShadowSchemaPaths bool
+	// GenerateOrderedListsAsUnorderedMaps indicates that lists that are
+	// marked `ordered-by user` will be represented using built-in Go maps
+	// instead of an ordered map Go structure.
+	GenerateOrderedListsAsUnorderedMaps bool
 }
 
 // GeneratedCode contains generated code snippets that can be processed by the calling

--- a/gogen/codegen_test.go
+++ b/gogen/codegen_test.go
@@ -3,8 +3,9 @@ package gogen
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +25,8 @@ const (
 	// should be performed to check for flakes.
 	deflakeRuns int = 10
 )
+
+var updateGolden = flag.Bool("update_golden", false, "Update golden files")
 
 // yangTestCase describs a test case for which code generation is performed
 // through Goyang's API, it provides the input set of parameters in a way that
@@ -307,6 +310,25 @@ func TestSimpleStructs(t *testing.T) {
 			},
 		},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata/structs/openconfig-withlist-opstate.formatted-txt"),
+	}, {
+		name:    "OpenConfig schema test - list and associated method (rename, new) - using unordered list",
+		inFiles: []string{filepath.Join(datapath, "openconfig-withlist.yang")},
+		inConfig: CodeGenerator{
+			IROptions: ygen.IROptions{
+				TransformationOptions: ygen.TransformationOpts{
+					CompressBehaviour:                    genutil.PreferIntendedConfig,
+					ShortenEnumLeafNames:                 true,
+					UseDefiningModuleForTypedefEnumNames: true,
+					EnumerationsUseUnderscores:           true,
+				},
+			},
+			GoOptions: GoOpts{
+				GenerateRenameMethod:                true,
+				GenerateSimpleUnions:                true,
+				GenerateOrderedListsAsUnorderedMaps: true,
+			},
+		},
+		wantStructsCodeFile: filepath.Join(TestRoot, "testdata/structs/openconfig-withlist-unordered.formatted-txt"),
 	}, {
 		name:    "OpenConfig schema test - multi-keyed list key struct name conflict and associated method (rename, new)",
 		inFiles: []string{filepath.Join(datapath, "openconfig-multikey-list-name-conflict.yang")},
@@ -1161,9 +1183,9 @@ func TestSimpleStructs(t *testing.T) {
 			}
 
 			if tt.wantSchemaFile != "" {
-				wantSchema, rferr := ioutil.ReadFile(tt.wantSchemaFile)
+				wantSchema, rferr := os.ReadFile(tt.wantSchemaFile)
 				if rferr != nil {
-					t.Fatalf("%s: ioutil.ReadFile(%q) error: %v", tt.name, tt.wantSchemaFile, rferr)
+					t.Fatalf("%s: os.ReadFile(%q) error: %v", tt.name, tt.wantSchemaFile, rferr)
 				}
 
 				var wantJSON map[string]interface{}
@@ -1177,14 +1199,19 @@ func TestSimpleStructs(t *testing.T) {
 				}
 			}
 
-			wantCodeBytes, rferr := ioutil.ReadFile(tt.wantStructsCodeFile)
+			wantCodeBytes, rferr := os.ReadFile(tt.wantStructsCodeFile)
 			if rferr != nil {
-				t.Fatalf("%s: ioutil.ReadFile(%q) error: %v", tt.name, tt.wantStructsCodeFile, rferr)
+				t.Fatalf("%s: os.ReadFile(%q) error: %v", tt.name, tt.wantStructsCodeFile, rferr)
 			}
 
 			wantCode := string(wantCodeBytes)
 
 			if gotCode != wantCode {
+				if *updateGolden {
+					if err := os.WriteFile(tt.wantStructsCodeFile, []byte(gotCode), 0644); err != nil {
+						t.Fatal(err)
+					}
+				}
 				// Use difflib to generate a unified diff between the
 				// two code snippets such that this is simpler to debug
 				// in the test output.

--- a/gogen/gogen.go
+++ b/gogen/gogen.go
@@ -1045,7 +1045,7 @@ func writeGoStruct(targetStruct *ygen.ParsedDirectory, goStructElements map[stri
 			// If the field within the struct is a list, then generate code for this list. This
 			// includes extracting any new types that are required to represent the key of a
 			// list that has multiple keys.
-			fieldType, multiKeyListKey, listMethods, orderedMapSpec, listErr := yangListFieldToGoType(field, fieldName, targetStruct, goStructElements)
+			fieldType, multiKeyListKey, listMethods, orderedMapSpec, listErr := yangListFieldToGoType(field, fieldName, targetStruct, goStructElements, !goOpts.GenerateOrderedListsAsUnorderedMaps)
 			if listErr != nil {
 				errs = append(errs, listErr)
 			}

--- a/gogen/internal/gotypes/ordered_map.go
+++ b/gogen/internal/gotypes/ordered_map.go
@@ -72,7 +72,7 @@ type RoutingPolicy_PolicyDefinition_Statement struct {
 type RoutingPolicy_PolicyDefinition_Statement_OrderedMap struct {
 	// TODO: Add a mutex here and add race tests after implementing
 	// ygot.Equal and evaluating the thread-safety of ygot.
-	//mu       sync.RWmutex
+	// mu       sync.RWmutex
 	// keys contain the key order of the map.
 	keys []string
 	// valueMap contains the mapping from the statement key to each of the

--- a/gogen/testdata/structs/openconfig-withlist-opstate.formatted-txt
+++ b/gogen/testdata/structs/openconfig-withlist-opstate.formatted-txt
@@ -73,6 +73,7 @@ type UnionUnsupported struct {
 type Model struct {
 	MultiKey	map[Model_MultiKey_Key]*Model_MultiKey	`path:"b/multi-key" module:"openconfig-withlist/openconfig-withlist"`
 	SingleKey	map[string]*Model_SingleKey	`path:"a/single-key" module:"openconfig-withlist/openconfig-withlist"`
+	SingleKeyOrdered	*Model_SingleKeyOrdered_OrderedMap	`path:"c/single-key-ordered" module:"openconfig-withlist/openconfig-withlist"`
 }
 
 // IsYANGGoStruct ensures that Model implements the yang.GoStruct
@@ -196,6 +197,165 @@ func (t *Model) RenameSingleKey(oldK, newK string) error {
 	return nil
 }
 
+// AppendNewSingleKeyOrdered creates a new entry in the SingleKeyOrdered
+// ordered map of the Model struct. The keys of the list are
+// populated from the input arguments.
+func (s *Model) AppendNewSingleKeyOrdered(Key string) (*Model_SingleKeyOrdered, error) {
+	if s.SingleKeyOrdered == nil {
+		s.SingleKeyOrdered = &Model_SingleKeyOrdered_OrderedMap{}
+	}
+	return s.SingleKeyOrdered.AppendNew(Key)
+}
+
+// AppendSingleKeyOrdered appends the supplied Model_SingleKeyOrdered struct
+// to the list SingleKeyOrdered of Model. If the key value(s)
+// specified in the supplied Model_SingleKeyOrdered already exist in the list, an
+// error is returned.
+func (s *Model) AppendSingleKeyOrdered(v *Model_SingleKeyOrdered) error {
+	if s.SingleKeyOrdered == nil {
+		s.SingleKeyOrdered = &Model_SingleKeyOrdered_OrderedMap{}
+	}
+	return s.SingleKeyOrdered.Append(v)
+}
+
+// GetSingleKeyOrdered retrieves the value with the specified key from the
+// SingleKeyOrdered map field of Model. If the receiver
+// is nil, or the specified key is not present in the list, nil is returned
+// such that Get* methods may be safely chained.
+func (s *Model) GetSingleKeyOrdered(Key string) *Model_SingleKeyOrdered {
+	key := Key
+	return s.SingleKeyOrdered.Get(key)
+}
+
+// DeleteSingleKeyOrdered deletes the value with the specified keys from
+// the receiver Model. If there is no such element, the
+// function is a no-op.
+func (s *Model) DeleteSingleKeyOrdered(Key string) bool {
+	key := Key
+	return s.SingleKeyOrdered.Delete(key)
+}
+
+// Model_SingleKeyOrdered_OrderedMap is an ordered map that represents the "ordered-by user"
+// list elements at /openconfig-withlist/model/c/single-key-ordered.
+type Model_SingleKeyOrdered_OrderedMap struct {
+	keys []string
+	valueMap map[string]*Model_SingleKeyOrdered
+}
+
+// IsYANGOrderedList ensures that Model_SingleKeyOrdered_OrderedMap implements the
+// ygot.GoOrderedMap interface.
+func (*Model_SingleKeyOrdered_OrderedMap) IsYANGOrderedList() {}
+
+// init initializes any uninitialized values.
+func (o *Model_SingleKeyOrdered_OrderedMap) init() {
+	if o == nil {
+		return
+	}
+	if o.valueMap == nil {
+		o.valueMap = map[string]*Model_SingleKeyOrdered{}
+	}
+}
+
+// Keys returns a copy of the list's keys.
+func (o *Model_SingleKeyOrdered_OrderedMap) Keys() []string {
+	if o == nil {
+		return nil
+	}
+	return append([]string{}, o.keys...)
+}
+
+// Values returns the current set of the list's values in order.
+func (o *Model_SingleKeyOrdered_OrderedMap) Values() []*Model_SingleKeyOrdered {
+	if o == nil {
+		return nil
+	}
+	var values []*Model_SingleKeyOrdered
+	for _, key := range o.keys {
+		values = append(values, o.valueMap[key])
+	}
+	return values
+}
+
+// Len returns a size of Model_SingleKeyOrdered_OrderedMap
+func (o *Model_SingleKeyOrdered_OrderedMap) Len() int {
+	if o == nil {
+		return 0
+	}
+	return len(o.keys)
+}
+
+// Get returns the value corresponding to the key. If the key is not found, nil
+// is returned.
+func (o *Model_SingleKeyOrdered_OrderedMap) Get(key string) *Model_SingleKeyOrdered {
+	if o == nil {
+		return nil
+	}
+	val, _ := o.valueMap[key]
+	return val
+}
+
+// Delete deletes an element.
+func (o *Model_SingleKeyOrdered_OrderedMap) Delete(key string) bool {
+	if o == nil {
+		return false
+	}
+	if _, ok := o.valueMap[key]; !ok {
+		return false
+	}
+	for i, k := range o.keys {
+		if k == key {
+			o.keys = append(o.keys[:i], o.keys[i+1:]...)
+			delete(o.valueMap, key)
+			return true
+		}
+	}
+	return false
+}
+
+// Append appends a Model_SingleKeyOrdered, returning an error if the key
+// already exists in the ordered list or if the key is unspecified.
+func (o *Model_SingleKeyOrdered_OrderedMap) Append(v *Model_SingleKeyOrdered) error {
+	if o == nil {
+		return fmt.Errorf("nil ordered map, cannot append Model_SingleKeyOrdered")
+	}
+	if v == nil {
+		return fmt.Errorf("nil Model_SingleKeyOrdered")
+	}
+	if v.Key == nil {
+		return fmt.Errorf("invalid nil key received for Key")
+	}
+
+	key := *v.Key
+
+	if _, ok := o.valueMap[key]; ok {
+		return fmt.Errorf("duplicate key for list Statement %v", key)
+	}
+	o.keys = append(o.keys, key)
+	o.init()
+	o.valueMap[key] = v
+	return nil
+}
+
+// AppendNew creates and appends a new Model_SingleKeyOrdered, returning the
+// newly-initialized v. It returns an error if the v already exists.
+func (o *Model_SingleKeyOrdered_OrderedMap) AppendNew(Key string) (*Model_SingleKeyOrdered, error) {
+	if o == nil {
+		return nil, fmt.Errorf("nil ordered map, cannot append Model_SingleKeyOrdered")
+	}
+	key := Key
+
+	if _, ok := o.valueMap[key]; ok {
+		return nil, fmt.Errorf("duplicate key for list Statement %v", key)
+	}
+	o.keys = append(o.keys, key)
+	newElement := &Model_SingleKeyOrdered{
+		Key: &Key,
+	}
+	o.init()
+	o.valueMap[key] = newElement
+	return newElement, nil
+}
+
 // ΛBelongingModule returns the name of the module that defines the namespace
 // of Model.
 func (*Model) ΛBelongingModule() string {
@@ -259,5 +419,32 @@ func (t *Model_SingleKey) ΛListKeyMap() (map[string]interface{}, error) {
 // ΛBelongingModule returns the name of the module that defines the namespace
 // of Model_SingleKey.
 func (*Model_SingleKey) ΛBelongingModule() string {
+	return "openconfig-withlist"
+}
+
+// Model_SingleKeyOrdered represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrdered struct {
+	Key	*string	`path:"state/key|key" module:"openconfig-withlist/openconfig-withlist|openconfig-withlist"`
+}
+
+// IsYANGGoStruct ensures that Model_SingleKeyOrdered implements the yang.GoStruct
+// interface. This allows functions that need to handle this struct to
+// identify it as being generated by ygen.
+func (*Model_SingleKeyOrdered) IsYANGGoStruct() {}
+
+// ΛListKeyMap returns the keys of the Model_SingleKeyOrdered struct, which is a YANG list entry.
+func (t *Model_SingleKeyOrdered) ΛListKeyMap() (map[string]interface{}, error) {
+	if t.Key == nil {
+		return nil, fmt.Errorf("nil value for key Key")
+	}
+
+	return map[string]interface{}{
+		"key": *t.Key,
+	}, nil
+}
+
+// ΛBelongingModule returns the name of the module that defines the namespace
+// of Model_SingleKeyOrdered.
+func (*Model_SingleKeyOrdered) ΛBelongingModule() string {
 	return "openconfig-withlist"
 }

--- a/gogen/testdata/structs/openconfig-withlist-unordered.formatted-txt
+++ b/gogen/testdata/structs/openconfig-withlist-unordered.formatted-txt
@@ -73,7 +73,7 @@ type UnionUnsupported struct {
 type Model struct {
 	MultiKey	map[Model_MultiKey_Key]*Model_MultiKey	`path:"b/multi-key" module:"openconfig-withlist/openconfig-withlist"`
 	SingleKey	map[string]*Model_SingleKey	`path:"a/single-key" module:"openconfig-withlist/openconfig-withlist"`
-	SingleKeyOrdered	*Model_SingleKeyOrdered_OrderedMap	`path:"c/single-key-ordered" module:"openconfig-withlist/openconfig-withlist"`
+	SingleKeyOrdered	map[string]*Model_SingleKeyOrdered	`path:"c/single-key-ordered" module:"openconfig-withlist/openconfig-withlist"`
 }
 
 // IsYANGGoStruct ensures that Model implements the yang.GoStruct
@@ -197,163 +197,50 @@ func (t *Model) RenameSingleKey(oldK, newK string) error {
 	return nil
 }
 
-// AppendNewSingleKeyOrdered creates a new entry in the SingleKeyOrdered
-// ordered map of the Model struct. The keys of the list are
-// populated from the input arguments.
-func (s *Model) AppendNewSingleKeyOrdered(Key string) (*Model_SingleKeyOrdered, error) {
-	if s.SingleKeyOrdered == nil {
-		s.SingleKeyOrdered = &Model_SingleKeyOrdered_OrderedMap{}
-	}
-	return s.SingleKeyOrdered.AppendNew(Key)
-}
+// NewSingleKeyOrdered creates a new entry in the SingleKeyOrdered list of the
+// Model struct. The keys of the list are populated from the input
+// arguments.
+func (t *Model) NewSingleKeyOrdered(Key string) (*Model_SingleKeyOrdered, error){
 
-// AppendSingleKeyOrdered appends the supplied Model_SingleKeyOrdered struct
-// to the list SingleKeyOrdered of Model. If the key value(s)
-// specified in the supplied Model_SingleKeyOrdered already exist in the list, an
-// error is returned.
-func (s *Model) AppendSingleKeyOrdered(v *Model_SingleKeyOrdered) error {
-	if s.SingleKeyOrdered == nil {
-		s.SingleKeyOrdered = &Model_SingleKeyOrdered_OrderedMap{}
-	}
-	return s.SingleKeyOrdered.Append(v)
-}
-
-// GetSingleKeyOrdered retrieves the value with the specified key from the
-// SingleKeyOrdered map field of Model. If the receiver
-// is nil, or the specified key is not present in the list, nil is returned
-// such that Get* methods may be safely chained.
-func (s *Model) GetSingleKeyOrdered(Key string) *Model_SingleKeyOrdered {
-	key := Key
-	return s.SingleKeyOrdered.Get(key)
-}
-
-// DeleteSingleKeyOrdered deletes the value with the specified keys from
-// the receiver Model. If there is no such element, the
-// function is a no-op.
-func (s *Model) DeleteSingleKeyOrdered(Key string) bool {
-	key := Key
-	return s.SingleKeyOrdered.Delete(key)
-}
-
-// Model_SingleKeyOrdered_OrderedMap is an ordered map that represents the "ordered-by user"
-// list elements at /openconfig-withlist/model/c/single-key-ordered.
-type Model_SingleKeyOrdered_OrderedMap struct {
-	keys []string
-	valueMap map[string]*Model_SingleKeyOrdered
-}
-
-// IsYANGOrderedList ensures that Model_SingleKeyOrdered_OrderedMap implements the
-// ygot.GoOrderedMap interface.
-func (*Model_SingleKeyOrdered_OrderedMap) IsYANGOrderedList() {}
-
-// init initializes any uninitialized values.
-func (o *Model_SingleKeyOrdered_OrderedMap) init() {
-	if o == nil {
-		return
-	}
-	if o.valueMap == nil {
-		o.valueMap = map[string]*Model_SingleKeyOrdered{}
-	}
-}
-
-// Keys returns a copy of the list's keys.
-func (o *Model_SingleKeyOrdered_OrderedMap) Keys() []string {
-	if o == nil {
-		return nil
-	}
-	return append([]string{}, o.keys...)
-}
-
-// Values returns the current set of the list's values in order.
-func (o *Model_SingleKeyOrdered_OrderedMap) Values() []*Model_SingleKeyOrdered {
-	if o == nil {
-		return nil
-	}
-	var values []*Model_SingleKeyOrdered
-	for _, key := range o.keys {
-		values = append(values, o.valueMap[key])
-	}
-	return values
-}
-
-// Len returns a size of Model_SingleKeyOrdered_OrderedMap
-func (o *Model_SingleKeyOrdered_OrderedMap) Len() int {
-	if o == nil {
-		return 0
-	}
-	return len(o.keys)
-}
-
-// Get returns the value corresponding to the key. If the key is not found, nil
-// is returned.
-func (o *Model_SingleKeyOrdered_OrderedMap) Get(key string) *Model_SingleKeyOrdered {
-	if o == nil {
-		return nil
-	}
-	val, _ := o.valueMap[key]
-	return val
-}
-
-// Delete deletes an element.
-func (o *Model_SingleKeyOrdered_OrderedMap) Delete(key string) bool {
-	if o == nil {
-		return false
-	}
-	if _, ok := o.valueMap[key]; !ok {
-		return false
-	}
-	for i, k := range o.keys {
-		if k == key {
-			o.keys = append(o.keys[:i], o.keys[i+1:]...)
-			delete(o.valueMap, key)
-			return true
-		}
-	}
-	return false
-}
-
-// Append appends a Model_SingleKeyOrdered, returning an error if the key
-// already exists in the ordered list or if the key is unspecified.
-func (o *Model_SingleKeyOrdered_OrderedMap) Append(v *Model_SingleKeyOrdered) error {
-	if o == nil {
-		return fmt.Errorf("nil ordered map, cannot append Model_SingleKeyOrdered")
-	}
-	if v == nil {
-		return fmt.Errorf("nil Model_SingleKeyOrdered")
-	}
-	if v.Key == nil {
-		return fmt.Errorf("invalid nil key received for Key")
+	// Initialise the list within the receiver struct if it has not already been
+	// created.
+	if t.SingleKeyOrdered == nil {
+		t.SingleKeyOrdered = make(map[string]*Model_SingleKeyOrdered)
 	}
 
-	key := *v.Key
-
-	if _, ok := o.valueMap[key]; ok {
-		return fmt.Errorf("duplicate key for list Statement %v", key)
-	}
-	o.keys = append(o.keys, key)
-	o.init()
-	o.valueMap[key] = v
-	return nil
-}
-
-// AppendNew creates and appends a new Model_SingleKeyOrdered, returning the
-// newly-initialized v. It returns an error if the v already exists.
-func (o *Model_SingleKeyOrdered_OrderedMap) AppendNew(Key string) (*Model_SingleKeyOrdered, error) {
-	if o == nil {
-		return nil, fmt.Errorf("nil ordered map, cannot append Model_SingleKeyOrdered")
-	}
 	key := Key
 
-	if _, ok := o.valueMap[key]; ok {
-		return nil, fmt.Errorf("duplicate key for list Statement %v", key)
+	// Ensure that this key has not already been used in the
+	// list. Keyed YANG lists do not allow duplicate keys to
+	// be created.
+	if _, ok := t.SingleKeyOrdered[key]; ok {
+		return nil, fmt.Errorf("duplicate key %v for list SingleKeyOrdered", key)
 	}
-	o.keys = append(o.keys, key)
-	newElement := &Model_SingleKeyOrdered{
+
+	t.SingleKeyOrdered[key] = &Model_SingleKeyOrdered{
 		Key: &Key,
 	}
-	o.init()
-	o.valueMap[key] = newElement
-	return newElement, nil
+
+	return t.SingleKeyOrdered[key], nil
+}
+
+// RenameSingleKeyOrdered renames an entry in the list SingleKeyOrdered within
+// the Model struct. The entry with key oldK is renamed to newK updating
+// the key within the value.
+func (t *Model) RenameSingleKeyOrdered(oldK, newK string) error {
+	if _, ok := t.SingleKeyOrdered[newK]; ok {
+		return fmt.Errorf("key %v already exists in SingleKeyOrdered", newK)
+	}
+
+	e, ok := t.SingleKeyOrdered[oldK]
+	if !ok {
+		return fmt.Errorf("key %v not found in SingleKeyOrdered", oldK)
+	}
+	e.Key = &newK
+
+	t.SingleKeyOrdered[newK] = e
+	delete(t.SingleKeyOrdered, oldK)
+	return nil
 }
 
 // ΛBelongingModule returns the name of the module that defines the namespace

--- a/gogen/unordered_list.go
+++ b/gogen/unordered_list.go
@@ -594,7 +594,7 @@ func UnorderedMapTypeName(listYANGPath, listFieldName, parentName string, goStru
 //
 // In the case that the list has multiple keys, the type generated as the key of the list is returned.
 // If errors are encountered during the type generation for the list, the error is returned.
-func yangListFieldToGoType(listField *ygen.NodeDetails, listFieldName string, parent *ygen.ParsedDirectory, goStructElements map[string]*ygen.ParsedDirectory) (string, *generatedGoMultiKeyListStruct, *generatedGoListMethod, *generatedOrderedMapStruct, error) {
+func yangListFieldToGoType(listField *ygen.NodeDetails, listFieldName string, parent *ygen.ParsedDirectory, goStructElements map[string]*ygen.ParsedDirectory, generateOrderedMaps bool) (string, *generatedGoMultiKeyListStruct, *generatedGoListMethod, *generatedOrderedMapStruct, error) {
 	// The list itself, since it is a container, has a struct associated with it. Retrieve
 	// this from the set of Directory structs for which code (a Go struct) will be
 	//  generated such that additional details can be used in the code generation.
@@ -665,7 +665,7 @@ func yangListFieldToGoType(listField *ygen.NodeDetails, listFieldName string, pa
 	var listMethodSpec *generatedGoListMethod
 	var orderedMapSpec *generatedOrderedMapStruct
 
-	if listField.YANGDetails.OrderedByUser {
+	if listField.YANGDetails.OrderedByUser && generateOrderedMaps {
 		structName := OrderedMapTypeName(listElem.Name)
 		listType = fmt.Sprintf("*%s", structName)
 		// Create spec for generating ordered maps.

--- a/testdata/modules/openconfig-withlist.yang
+++ b/testdata/modules/openconfig-withlist.yang
@@ -66,6 +66,28 @@ module openconfig-withlist {
           }
         }
       }
+
+      container c {
+        list single-key-ordered {
+          key "key";
+          ordered-by user;
+
+          leaf key {
+            type leafref {
+              path "../config/key";
+            }
+          }
+
+          container config {
+            uses single-key-config;
+          }
+
+          container state {
+            config false;
+            uses single-key-config;
+          }
+        }
+      }
     }
   }
 

--- a/util/reflect.go
+++ b/util/reflect.go
@@ -610,7 +610,7 @@ func (node *PathQueryNodeMemo) GetRoot() *PathQueryNodeMemo {
 }
 
 // FieldIteratorFunc is an iteration function for arbitrary field traversals.
-// in, out are passed through from the caller to the iteration vistior function
+// in, out are passed through from the caller to the iteration visitor function
 // and can be used to pass state in and out. They are not otherwise touched.
 // It returns a slice of errors encountered while processing the field.
 type FieldIteratorFunc func(ni *NodeInfo, in, out interface{}) Errors
@@ -629,7 +629,7 @@ const (
 )
 
 // FieldIteratorFunc2 is an iteration function for arbitrary field traversals.
-// in, out are passed through from the caller to the iteration vistior function
+// in, out are passed through from the caller to the iteration visitor function
 // and can be used to pass state in and out. They are not otherwise touched.
 // It returns what next iteration action to take as well as an error.
 type FieldIteratorFunc2 func(ni *NodeInfo, in, out any) (IterationAction, Errors)

--- a/ygot/diff_exported_test.go
+++ b/ygot/diff_exported_test.go
@@ -42,7 +42,6 @@ func mustPath(s string) *gnmipb.Path {
 }
 
 func TestDiffOrderedMap(t *testing.T) {
-	// TODO: Test for uncompressed structs.
 	tests := []struct {
 		name          string
 		inOrig, inMod ygot.GoStruct
@@ -656,9 +655,6 @@ func TestDiffOrderedMap(t *testing.T) {
 				return
 			}
 
-			if err != nil {
-				return
-			}
 			// To re-use the NotificationSetEqual helper, we put the want and got into
 			// a slice.
 			if !testutil.NotificationSetEqual([]*gnmipb.Notification{got}, []*gnmipb.Notification{tt.want}) {

--- a/ygot/struct_validation_map_exported_test.go
+++ b/ygot/struct_validation_map_exported_test.go
@@ -118,7 +118,7 @@ func (*mapStructTestFourCOtherSet) ΛBelongingModule() string                { r
 // an enumeration in the YANG schema.
 type ECTest int64
 
-// IsYANGEnumeration ensures that the ECTest derived enum type implemnts
+// IsYANGEnumeration ensures that the ECTest derived enum type implements
 // the GoEnum interface.
 func (ECTest) IsYANGGoEnum() {}
 

--- a/ypathgen/testdata/modules/oc-list/list.txt
+++ b/ypathgen/testdata/modules/oc-list/list.txt
@@ -109,6 +109,45 @@ func (n *Model_SingleKeyPathAny) WithKey(Key string) *Model_SingleKeyPathAny {
 	return n
 }
 
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+func (n *ModelPath) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+func (n *ModelPathAny) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// WithKey sets Model_SingleKeyOrderedPathAny's key "key" to the specified value.
+// Key: string
+func (n *Model_SingleKeyOrderedPathAny) WithKey(Key string) *Model_SingleKeyOrderedPathAny {
+	ygot.ModifyKey(n.NodePath, "key", Key)
+	return n
+}
+
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
@@ -247,6 +286,58 @@ func (n *Model_SingleKeyPath) Key() *Model_SingleKey_KeyPath {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyPathAny) Key() *Model_SingleKey_KeyPathAny {
 	return &Model_SingleKey_KeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrderedPath represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrderedPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPathAny struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPath represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPathAny struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPath) Key() *Model_SingleKeyOrdered_KeyPath {
+	return &Model_SingleKeyOrdered_KeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPathAny) Key() *Model_SingleKeyOrdered_KeyPathAny {
+	return &Model_SingleKeyOrdered_KeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist-separate-package.path-txt
@@ -263,6 +263,74 @@ func (n *ModelAny) SingleKey(Key string) *Model_SingleKeyAny {
 	}
 }
 
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *Model) SingleKeyOrderedAny() *Model_SingleKeyOrderedAny {
+	return &Model_SingleKeyOrderedAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelAny) SingleKeyOrderedAny() *Model_SingleKeyOrderedAny {
+	return &Model_SingleKeyOrderedAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *Model) SingleKeyOrdered(Key string) *Model_SingleKeyOrdered {
+	return &Model_SingleKeyOrdered{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelAny) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedAny {
+	return &Model_SingleKeyOrderedAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKey represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKey struct {
 	*ygot.NodePath
@@ -401,6 +469,58 @@ func (n *Model_SingleKey) Key() *Model_SingleKey_Key {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyAny) Key() *Model_SingleKey_KeyAny {
 	return &Model_SingleKey_KeyAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrdered represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrdered struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrderedAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedAny struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_Key represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_Key struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyAny struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrdered) Key() *Model_SingleKeyOrdered_Key {
+	return &Model_SingleKeyOrdered_Key{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedAny) Key() *Model_SingleKeyOrdered_KeyAny {
+	return &Model_SingleKeyOrdered_KeyAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist.builder.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.builder.path-txt
@@ -164,6 +164,74 @@ func (n *ModelPathAny) SingleKey(Key string) *Model_SingleKeyPathAny {
 	}
 }
 
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPath) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPathAny) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPath) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPath {
+	return &Model_SingleKeyOrderedPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPathAny) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
@@ -302,6 +370,58 @@ func (n *Model_SingleKeyPath) Key() *Model_SingleKey_KeyPath {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyPathAny) Key() *Model_SingleKey_KeyPathAny {
 	return &Model_SingleKey_KeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrderedPath represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrderedPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPathAny struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPath represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPathAny struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPath) Key() *Model_SingleKeyOrdered_KeyPath {
+	return &Model_SingleKeyOrdered_KeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPathAny) Key() *Model_SingleKeyOrdered_KeyPathAny {
+	return &Model_SingleKeyOrdered_KeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist.nowildcard.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.nowildcard.path-txt
@@ -80,6 +80,23 @@ func (n *ModelPath) SingleKey(Key string) *Model_SingleKeyPath {
 	}
 }
 
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPath) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPath {
+	return &Model_SingleKeyOrderedPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
@@ -145,6 +162,32 @@ type Model_SingleKey_KeyPath struct {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyPath) Key() *Model_SingleKey_KeyPath {
 	return &Model_SingleKey_KeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrderedPath represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPath represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPath struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPath) Key() *Model_SingleKeyOrdered_KeyPath {
+	return &Model_SingleKeyOrdered_KeyPath{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.path-txt
@@ -262,6 +262,74 @@ func (n *ModelPathAny) SingleKey(Key string) *Model_SingleKeyPathAny {
 	}
 }
 
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPath) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPathAny) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": "*"},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPath) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPath {
+	return &Model_SingleKeyOrderedPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPathAny) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
@@ -400,6 +468,58 @@ func (n *Model_SingleKeyPath) Key() *Model_SingleKey_KeyPath {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyPathAny) Key() *Model_SingleKey_KeyPathAny {
 	return &Model_SingleKey_KeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrderedPath represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrderedPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPathAny struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPath represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPathAny struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPath) Key() *Model_SingleKeyOrdered_KeyPath {
+	return &Model_SingleKeyOrdered_KeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPathAny) Key() *Model_SingleKeyOrdered_KeyPathAny {
+	return &Model_SingleKeyOrdered_KeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},

--- a/ypathgen/testdata/structs/openconfig-withlist.simplifyallwc.path-txt
+++ b/ypathgen/testdata/structs/openconfig-withlist.simplifyallwc.path-txt
@@ -262,6 +262,74 @@ func (n *ModelPathAny) SingleKey(Key string) *Model_SingleKeyPathAny {
 	}
 }
 
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPath) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrderedAny (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key (wildcarded): string
+func (n *ModelPathAny) SingleKeyOrderedAny() *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPath) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPath {
+	return &Model_SingleKeyOrderedPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
+// SingleKeyOrdered (list): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "c/single-key-ordered"
+// Path from root: "/model/c/single-key-ordered"
+// Key: string
+func (n *ModelPathAny) SingleKeyOrdered(Key string) *Model_SingleKeyOrderedPathAny {
+	return &Model_SingleKeyOrderedPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"c", "single-key-ordered"},
+			map[string]interface{}{"key": Key},
+			n,
+		),
+	}
+}
+
 // Model_MultiKeyPath represents the /openconfig-withlist/model/b/multi-key YANG schema element.
 type Model_MultiKeyPath struct {
 	*ygot.NodePath
@@ -400,6 +468,58 @@ func (n *Model_SingleKeyPath) Key() *Model_SingleKey_KeyPath {
 // Path from root: "/model/a/single-key/state/key"
 func (n *Model_SingleKeyPathAny) Key() *Model_SingleKey_KeyPathAny {
 	return &Model_SingleKey_KeyPathAny{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Model_SingleKeyOrderedPath represents the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrderedPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered YANG schema element.
+type Model_SingleKeyOrderedPathAny struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPath represents the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPath struct {
+	*ygot.NodePath
+}
+
+// Model_SingleKeyOrdered_KeyPathAny represents the wildcard version of the /openconfig-withlist/model/c/single-key-ordered/state/key YANG schema element.
+type Model_SingleKeyOrdered_KeyPathAny struct {
+	*ygot.NodePath
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPath) Key() *Model_SingleKeyOrdered_KeyPath {
+	return &Model_SingleKeyOrdered_KeyPath{
+		NodePath: ygot.NewNodePath(
+			[]string{"state", "key"},
+			map[string]interface{}{},
+			n,
+		),
+	}
+}
+
+// Key (leaf): 
+// ----------------------------------------
+// Defining module: "openconfig-withlist"
+// Instantiating module: "openconfig-withlist"
+// Path from parent: "state/key"
+// Path from root: "/model/c/single-key-ordered/state/key"
+func (n *Model_SingleKeyOrderedPathAny) Key() *Model_SingleKeyOrdered_KeyPathAny {
+	return &Model_SingleKeyOrdered_KeyPathAny{
 		NodePath: ygot.NewNodePath(
 			[]string{"state", "key"},
 			map[string]interface{}{},


### PR DESCRIPTION
Flag is on by default to send a signal to downstream users to convert. The flag is used for transitioning existing code.

Tested generator manually. presubmit also has a test for it via integration_tests/schemaops and `go generate ./...`

* Added integration test
* Fixed a few typos