### PR TITLE
Support subset merge for ordered maps

### DIFF
--- a/internal/yreflect/reflect_orderedmap.go
+++ b/internal/yreflect/reflect_orderedmap.go
@@ -141,3 +141,27 @@ func OrderedMapKeys(om goOrderedMap) ([]reflect.Value, error) {
 
 	return keySlice, nil
 }
+
+// GetOrderedMapElement calls the given ordered map's Get function given the
+// key value.
+//
+// - reflect.Value is the retrieved value at the key.
+// - bool is whether the value exists.
+// - error is whether an unexpected condition was detected.
+func GetOrderedMapElement(om goOrderedMap, k reflect.Value) (reflect.Value, bool, error) {
+	getMethod, err := MethodByName(reflect.ValueOf(om), "Get")
+	if err != nil {
+		return reflect.Value{}, false, err
+	}
+
+	ret := getMethod.Call([]reflect.Value{k})
+	if got, wantReturnN := len(ret), 1; got != wantReturnN {
+		return reflect.Value{}, false, fmt.Errorf("method Get() doesn't have expected number of return values, got %v, want %v", got, wantReturnN)
+	}
+	v := ret[0]
+	if gotKind := v.Type().Kind(); gotKind != reflect.Ptr {
+		return reflect.Value{}, false, fmt.Errorf("method Keys() did not return a ptr value, got %v", gotKind)
+	}
+
+	return v, !v.IsZero(), nil
+}

--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -941,8 +941,8 @@ func orderedMapKeysMergeable(dstOrderedMap, srcOrderedMap GoOrderedMap) error {
 		return err
 	}
 
-	si, di := 0, 0
-	for ; si != len(srcKeys) && di != len(dstKeys); di++ {
+	si := 0
+	for di := 0; si != len(srcKeys) && di != len(dstKeys); di++ {
 		// Map keys must be comparable
 		if srcKeys[si].Interface() == dstKeys[di].Interface() {
 			si++


### PR DESCRIPTION
when merging A <- B, and B is subset of A and the ordering of elements don't contradict, allow merging to occur.