### PR TITLE
Fix BuildEmptyTree for ordered maps

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -212,7 +212,8 @@ func initialiseTree(t reflect.Type, v reflect.Value) {
 		fVal := v.Field(i)
 		fType := t.Field(i)
 
-		if util.IsTypeStructPtr(fType.Type) {
+		_, isOrderedMap := fVal.Interface().(GoOrderedMap)
+		if !isOrderedMap && util.IsTypeStructPtr(fType.Type) {
 			// Only initialise nested struct pointers, since all struct fields within
 			// a GoStruct are expected to be pointers, and we do not want to initialise
 			// non-struct values. If the struct pointer is not nil, it is skipped.

--- a/ygot/struct_validation_map_exported_test.go
+++ b/ygot/struct_validation_map_exported_test.go
@@ -308,6 +308,25 @@ func TestEmitJSON(t *testing.T) {
 	}
 }
 
+func TestBuildEmptyTree(t *testing.T) {
+	tests := []struct {
+		name     string
+		inStruct ygot.GoStruct
+		want     ygot.GoStruct
+	}{{
+		name:     "device containing ordered map",
+		inStruct: &ctestschema.Device{},
+		want:     &ctestschema.Device{OtherData: &ctestschema.OtherData{}},
+	}}
+
+	for _, tt := range tests {
+		ygot.BuildEmptyTree(tt.inStruct)
+		if diff := cmp.Diff(tt.inStruct, tt.want); diff != "" {
+			t.Errorf("%s: did not get expected output, diff(-got,+want):\n%s", tt.name, diff)
+		}
+	}
+}
+
 func TestDeepCopyOrderedMap(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
OrderedMaps are map types, which are not supposed to be initialized by BuildEmptyTree.