### PR TITLE
Make Schema Tree public

### DIFF
--- a/ygen/codegen.go
+++ b/ygen/codegen.go
@@ -195,7 +195,7 @@ type mappedYANGDefinitions struct {
 	enumEntries map[string]*yang.Entry
 	// schematree is a copy of the YANG schema tree, containing only leaf
 	// entries, such that schema paths can be referenced.
-	schematree *schemaTree
+	schematree *SchemaTree
 	// modules is the set of parsed YANG modules that are being processed as part of the
 	// code generatio, expressed as a slice of yang.Entry pointers.
 	modules []*yang.Entry
@@ -255,7 +255,7 @@ func mappedDefinitions(yangFiles, includePaths []string, opts IROptions) (*mappe
 	// Build the schematree for the modules provided - we build for all of the
 	// root elements, since we might need to reference a part of the schema that
 	// we are not outputting for leafref lookups.
-	st, err := buildSchemaTree(treeElems)
+	st, err := BuildSchemaTree(treeElems)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/ygen/directory.go
+++ b/ygen/directory.go
@@ -142,10 +142,10 @@ func GetOrderedPathDirectories(directory map[string]*Directory) []string {
 }
 
 // getOrderedDirDetails takes in a language-specific LangMapper, a map of
-// Directory objects containing the raw AST information, a schemaTree, and IR
+// Directory objects containing the raw AST information, a SchemaTree, and IR
 // generation options, and returns a map of ParsedDirectory objects that form
 // the primary component of ygen's IR output.
-func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory, schematree *schemaTree, opts IROptions) (map[string]*ParsedDirectory, error) {
+func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory, schematree *SchemaTree, opts IROptions) (map[string]*ParsedDirectory, error) {
 	dirDets := map[string]*ParsedDirectory{}
 	for _, dirPath := range GetOrderedPathDirectories(directory) {
 		dir := directory[dirPath]
@@ -237,7 +237,7 @@ func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory
 
 			var target *yang.Entry
 			if field.Type != nil && field.Type.Kind == yang.Yleafref {
-				if target, err = schematree.resolveLeafrefTarget(field.Type.Path, field); err != nil {
+				if target, err = schematree.ResolveLeafrefTarget(field.Type.Path, field); err != nil {
 					return nil, fmt.Errorf("unable to resolve leafref field: %v", err)
 				}
 			}

--- a/ygen/ir.go
+++ b/ygen/ir.go
@@ -103,7 +103,7 @@ type LangMapperBaseSetup interface {
 	// setSchemaTree is used to supply a copy of the YANG schema tree to
 	// the mapped such that leaves of type leafref can be resolved to
 	// their target leaves.
-	setSchemaTree(*schemaTree)
+	setSchemaTree(*SchemaTree)
 
 	// InjectEnumSet is intended to be called by unit tests in order to set up the
 	// LangMapperBase such that generated enumeration/identity names can be looked
@@ -128,7 +128,7 @@ type LangMapperBase struct {
 
 	// schematree is a copy of the YANG schema tree, containing only leaf
 	// entries, such that schema paths can be referenced.
-	schematree *schemaTree
+	schematree *SchemaTree
 }
 
 // setEnumSet is used to supply a set of enumerated values to the
@@ -150,7 +150,7 @@ func (s *LangMapperBase) setEnumSet(e *enumSet) {
 // In testing contexts outside of GenerateIR, however, the corresponding
 // exported Inject method needs to be called in order for certain built-in
 // methods of LangMapperBase to be available for use.
-func (s *LangMapperBase) setSchemaTree(st *schemaTree) {
+func (s *LangMapperBase) setSchemaTree(st *SchemaTree) {
 	s.schematree = st
 }
 
@@ -175,7 +175,7 @@ func (s *LangMapperBase) InjectEnumSet(entries map[string]*yang.Entry, compressP
 // set of yang.Entry pointers into a ctree structure.
 // It returns an error if there is duplication within the set of entries.
 func (s *LangMapperBase) InjectSchemaTree(entries []*yang.Entry) error {
-	schematree, err := buildSchemaTree(entries)
+	schematree, err := BuildSchemaTree(entries)
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (s *LangMapperBase) InjectSchemaTree(entries []*yang.Entry) error {
 // In testing contexts, this function requires InjectSchemaTree to be called
 // prior to being usable.
 func (b *LangMapperBase) ResolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
-	return b.schematree.resolveLeafrefTarget(path, contextEntry)
+	return b.schematree.ResolveLeafrefTarget(path, contextEntry)
 }
 
 // EnumeratedTypedefTypeName retrieves the name of an enumerated typedef (i.e.,

--- a/ygen/schematree.go
+++ b/ygen/schematree.go
@@ -24,19 +24,19 @@ import (
 	"github.com/openconfig/ygot/util"
 )
 
-// schemaTree contains a ctree.Tree that stores a copy of the YANG schema tree
+// SchemaTree contains a ctree.Tree that stores a copy of the YANG schema tree
 // containing only leaf entries, such that schema paths can be referenced.
-type schemaTree struct {
+type SchemaTree struct {
 	ctree.Tree
 }
 
-// buildSchemaTree maps a set of yang.Entry pointers into a ctree structure.
+// BuildSchemaTree maps a set of yang.Entry pointers into a ctree structure.
 // Only leaf or leaflist values are mapped, since these are the only entities
 // that can be referenced by XPATH expressions within a YANG schema.
 // It returns an error if there is duplication within the set of entries. The
 // paths that are used within the schema are represented as a slice of strings.
-func buildSchemaTree(entries []*yang.Entry) (*schemaTree, error) {
-	t := &schemaTree{}
+func BuildSchemaTree(entries []*yang.Entry) (*SchemaTree, error) {
+	t := &SchemaTree{}
 	for _, e := range entries {
 		pp := strings.Split(e.Path(), "/")
 		// We only want to find entities that are at the root of the
@@ -62,12 +62,12 @@ func buildSchemaTree(entries []*yang.Entry) (*schemaTree, error) {
 	return t, nil
 }
 
-// resolveLeafrefTarget takes an input path and context entry and
+// ResolveLeafrefTarget takes an input path and context entry and
 // determines the type of the leaf that is referred to by the path, such that
 // it can be mapped to a native language type. It returns the yang.YangType that
 // is associated with the target, and the target yang.Entry, such that the
 // caller can map this to the relevant language type.
-func (t *schemaTree) resolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
+func (t *SchemaTree) ResolveLeafrefTarget(path string, contextEntry *yang.Entry) (*yang.Entry, error) {
 	if t == nil {
 		// This should not be possible if the calling code generation is
 		// well structured and builds the schematree during parsing of YANG
@@ -95,7 +95,7 @@ func (t *schemaTree) resolveLeafrefTarget(path string, contextEntry *yang.Entry)
 
 // schemaTreeChildrenAdd adds the children of the supplied yang.Entry to the
 // supplied ctree.Tree recursively.
-func schemaTreeChildrenAdd(t *schemaTree, e *yang.Entry) error {
+func schemaTreeChildrenAdd(t *SchemaTree, e *yang.Entry) error {
 	for _, ch := range util.Children(e) {
 		chPath := strings.Split(ch.Path(), "/")
 		// chPath is of the form []string{"", "module", "entity", "child"}

--- a/ygen/schematree_test.go
+++ b/ygen/schematree_test.go
@@ -118,16 +118,16 @@ func TestBuildSchemaTree(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		got, err := buildSchemaTree(tt.inEntries)
+		got, err := BuildSchemaTree(tt.inEntries)
 		if err != nil {
-			t.Errorf("%s: buildSchemaTree(%v): got unexpected error building tree: %v", tt.name, tt.inEntries, err)
+			t.Errorf("%s: BuildSchemaTree(%v): got unexpected error building tree: %v", tt.name, tt.inEntries, err)
 			continue
 		}
 
 		for _, want := range tt.wantElements {
 			gotElement := got.GetLeafValue(want.path)
 			if diff := pretty.Compare(gotElement, want.value); diff != "" {
-				t.Errorf("%s: buildSchemaTree(%v): got incorrect value for element %v, diff(-got,+want)\n:%s", tt.name, tt.inEntries, want.path, diff)
+				t.Errorf("%s: BuildSchemaTree(%v): got incorrect value for element %v, diff(-got,+want)\n:%s", tt.name, tt.inEntries, want.path, diff)
 				continue
 			}
 		}
@@ -221,11 +221,11 @@ func TestResolveLeafrefTargetType(t *testing.T) {
 	for _, tt := range tests {
 		// Since we are outside of the build of a module, need to initialise
 		// the schematree.
-		st, err := buildSchemaTree(tt.inEntries)
+		st, err := BuildSchemaTree(tt.inEntries)
 		if err != nil {
-			t.Errorf("%s: buildSchemaTree(%v): got unexpected error: %v", tt.name, tt.inEntries, err)
+			t.Errorf("%s: BuildSchemaTree(%v): got unexpected error: %v", tt.name, tt.inEntries, err)
 		}
-		got, err := st.resolveLeafrefTarget(tt.inPath, tt.inContextEntry)
+		got, err := st.ResolveLeafrefTarget(tt.inPath, tt.inContextEntry)
 		if err != nil {
 			if !tt.wantErr {
 				t.Errorf("%s: resolveLeafrefTargetPath(%v, %v): got unexpected error: %v", tt.name, tt.inPath, tt.inContextEntry, err)


### PR DESCRIPTION
I would like to build the `SchemaTree` using yang Entries and then use the `ResolveLeafRefTarget` method to calculate the actual data type of a `leafref`.