### PR TITLE
Remove bottleneck in validation

### DIFF
--- a/ytypes/validate.go
+++ b/ytypes/validate.go
@@ -96,7 +96,7 @@ func Validate(schema *yang.Entry, value interface{}, opts ...ygot.ValidationOpti
 		}
 	}
 
-	util.DbgPrint("Validate with value %v, type %T, schema name %s", util.ValueStr(value), value, schema.Name)
+	util.DbgPrint("Validate with value %v, type %T, schema name %s", util.ValueStrDebug(value), value, schema.Name)
 
 	switch {
 	case schema.IsLeaf():


### PR DESCRIPTION
Even with debugLibrary not enabled ValueStr is calculated in this call, which causes significant bottlenecks in validation.

All other calls to DbgPrint already use ValueStrDebug to avoid formatting string output that won't ever be used.

In my test use case this changed performance from approximately 80s to 40ms.