### PR TITLE
Move to standard slices package

### DIFF
--- a/ygot/render.go
+++ b/ygot/render.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/openconfig/gnmi/errlist"
 	"github.com/openconfig/gnmi/value"
 	"github.com/openconfig/ygot/internal/yreflect"
 	"github.com/openconfig/ygot/util"
-	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 


### PR DESCRIPTION
It looks like bazel is having trouble with this when I try to convert lemming to Go 1.21.