### PR TITLE
Add support leaf-lists in paths->protobuf.

### DIFF
--- a/protomap/integration_tests/integration_test.go
+++ b/protomap/integration_tests/integration_test.go
@@ -224,6 +224,36 @@ func TestGRIBIAFTToStruct(t *testing.T) {
 				SrcIp: &wpb.StringValue{Value: "1.1.1.1"},
 			},
 		},
+	}, {
+		desc: "pushed mpls label stack",
+		inPaths: map[*gpb.Path]interface{}{
+			mustPath("state/pushed-mpls-label-stack"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{
+							mustValue(t, 20),
+							mustValue(t, 30),
+							mustValue(t, 40),
+							mustValue(t, 50),
+						},
+					},
+				},
+			},
+		},
+		inProto:  &gribi_aft.Afts_NextHop{},
+		inPrefix: mustPath("afts/next-hops/next-hop"),
+		wantProto: &gribi_aft.Afts_NextHop{
+			PushedMplsLabelStack: []*gribi_aft.Afts_NextHop_PushedMplsLabelStackUnion{{
+				PushedMplsLabelStackUint64: 20,
+			}, {
+				PushedMplsLabelStackUint64: 30,
+			}, {
+				PushedMplsLabelStackUint64: 40,
+			}, {
+				PushedMplsLabelStackUint64: 50,
+			}},
+		},
+		wantErr: true, // Currently this is unhandled but was causing a panic, check that it doesn't panic.
 	}}
 
 	for _, tt := range tests {

--- a/protomap/proto_test.go
+++ b/protomap/proto_test.go
@@ -826,6 +826,396 @@ func TestProtoFromPaths(t *testing.T) {
 			mustPath("/interfaces/interface[name=eth0][type=ETHERNET]/config/description"): "invalid",
 		},
 		wantErrSubstring: "received additional keys",
+	}, {
+		desc:    "leaf-list of non-union",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-string"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_StringVal{StringVal: "one"},
+						}, {
+							Value: &gpb.TypedValue_StringVal{StringVal: "two"},
+						}, {
+							Value: &gpb.TypedValue_StringVal{StringVal: "three"},
+						}},
+					},
+				},
+			},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistString: []*wpb.StringValue{{
+				Value: "one",
+			}, {
+				Value: "two",
+			}, {
+				Value: "three",
+			}},
+		},
+	}, {
+		desc:    "leaf-list of non-union, simple values",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-string"): []string{"hello", "world"},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistString: []*wpb.StringValue{{
+				Value: "hello",
+			}, {
+				Value: "world",
+			}},
+		},
+	}, {
+		desc:    "leaf-list - wrong type for repeated string",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-string"): "fish",
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list - zero length typed value",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-string"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "invalid leaf-list value",
+	}, {
+		desc:    "leaf-list - wrong field in typed value",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-string"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_StringVal{
+					StringVal: "fish",
+				},
+			},
+		},
+		wantErrSubstring: "invalid leaf-list value",
+	}, {
+		desc:    "leaf-list - wrong type for uint",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-uint"): []string{"one", "two"},
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list - wrong type for uint64",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-uint"): []string{"one", "two"},
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list - wrong type for bool",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bool"): []string{"one", "two"},
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list - wrong type for bytes",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bytes"): []string{"one", "two"},
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list of uint64",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-uint"): []uint64{1, 2, 3, 4},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistUint: []*wpb.UintValue{{
+				Value: 1,
+			}, {
+				Value: 2,
+			}, {
+				Value: 3,
+			}, {
+				Value: 4,
+			}},
+		},
+	}, {
+		desc:    "leaf-list of typed value uint64",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-uint"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_UintVal{UintVal: 1},
+						}, {
+							Value: &gpb.TypedValue_UintVal{UintVal: 2},
+						}, {
+							Value: &gpb.TypedValue_UintVal{UintVal: 3},
+						}},
+					},
+				},
+			},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistUint: []*wpb.UintValue{{
+				Value: 1,
+			}, {
+				Value: 2,
+			}, {
+				Value: 3,
+			}},
+		},
+	}, {
+		desc:    "leaf-list of int",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-int"): []int64{1, 2, 3, 4},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistInt: []*wpb.IntValue{{
+				Value: 1,
+			}, {
+				Value: 2,
+			}, {
+				Value: 3,
+			}, {
+				Value: 4,
+			}},
+		},
+	}, {
+		desc:    "leaf-list of typed value int",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-int"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_IntVal{IntVal: 1},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 2},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 3},
+						}},
+					},
+				},
+			},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistInt: []*wpb.IntValue{{
+				Value: 1,
+			}, {
+				Value: 2,
+			}, {
+				Value: 3,
+			}},
+		},
+	}, {
+		desc:    "leaf-list - wrong type for int",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-int"): "fish",
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list of bool",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bool"): []bool{true, false},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistBool: []*wpb.BoolValue{{
+				Value: true,
+			}, {
+				Value: false,
+			}},
+		},
+	}, {
+		desc:    "leaf-list of typed value bool",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bool"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+						}, {
+							Value: &gpb.TypedValue_BoolVal{BoolVal: false},
+						}},
+					},
+				},
+			},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistBool: []*wpb.BoolValue{{
+				Value: true,
+			}, {
+				Value: false,
+			}},
+		},
+	}, {
+		desc:    "leaf-list - int - wrong type typed value input",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			// int value containing bools.
+			mustPath("/leaflist-int"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+						}, {
+							Value: &gpb.TypedValue_BoolVal{BoolVal: false},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "wrong typed value",
+	}, {
+		desc:    "leaf-list - string - wrong type typed value input",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			// string value containing bools.
+			mustPath("/leaflist-string"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+						}, {
+							Value: &gpb.TypedValue_BoolVal{BoolVal: false},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "wrong typed value",
+	}, {
+		desc:    "leaf-list - uint - wrong type typed value input",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			// uint value containing bools.
+			mustPath("/leaflist-uint"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_BoolVal{BoolVal: true},
+						}, {
+							Value: &gpb.TypedValue_BoolVal{BoolVal: false},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "wrong typed value",
+	}, {
+		desc:    "leaf-list  - bool - wrong type typed value input",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bool"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_IntVal{IntVal: 1},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 2},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 3},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "wrong typed value",
+	}, {
+		desc:    "leaf-list of bytes",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bytes"): [][]byte{{1}, {2}},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistBytes: []*wpb.BytesValue{{
+				Value: []byte{1},
+			}, {
+				Value: []byte{2},
+			}},
+		},
+	}, {
+		desc:    "leaf-list of typed value bytes",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bytes"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_BytesVal{BytesVal: []byte{1}},
+						}, {
+							Value: &gpb.TypedValue_BytesVal{BytesVal: []byte{2}},
+						}},
+					},
+				},
+			},
+		},
+		wantProto: &epb.ExampleMessage{
+			LeaflistBytes: []*wpb.BytesValue{{
+				Value: []byte{1},
+			}, {
+				Value: []byte{2},
+			}},
+		},
+	}, {
+		desc:    "leaf-list - wrong type for bytes",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bytes"): "fish",
+		},
+		wantErrSubstring: "invalid type",
+	}, {
+		desc:    "leaf-list - wrong type of typed value for bytes",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-bytes"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_IntVal{IntVal: 1},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 2},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 3},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "wrong typed value",
+	}, {
+		desc:    "leaf-list - unhandled deprecated type",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-decimal64"): []float64{0.1, 0.2},
+		},
+		wantErrSubstring: "unhandled leaf-list value",
+	}, {
+		// TODO(robjs): implement handling for leaf-lists of unions.
+		desc:    "leaf-list - unions - currently unhandled",
+		inProto: &epb.ExampleMessage{},
+		inVals: map[*gpb.Path]any{
+			mustPath("/leaflist-union"): &gpb.TypedValue{
+				Value: &gpb.TypedValue_LeaflistVal{
+					LeaflistVal: &gpb.ScalarArray{
+						Element: []*gpb.TypedValue{{
+							Value: &gpb.TypedValue_StringVal{StringVal: "hello"},
+						}, {
+							Value: &gpb.TypedValue_IntVal{IntVal: 1},
+						}},
+					},
+				},
+			},
+		},
+		wantErrSubstring: "unhandled leaf-list of unions",
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
 * (M) protomap/integration_tests/integration_test.go
  - Add test case for a failure that was causing a panic,
    where a leaf-list of union values was being handed to
    PathsToProto. Currently not yet implemented, but test
    checks error handling works as expected.
 * (M) protomap/proto(_test)?.go
  - Add support and testing for mapping of leaf-lists of
    YANG inbuilt types to protobufs.
```
