### PR TITLE
Support skipping any-xml using -ignore_unsupported.

### DIFF
--- a/testdata/modules/openconfig-simple-with-unsupported.yang
+++ b/testdata/modules/openconfig-simple-with-unsupported.yang
@@ -17,6 +17,9 @@ module openconfig-simple {
     leaf four {
       type binary;
     }
+    anyxml xml-data {
+      description "updated stuff";
+    }
   }
 
   container parent {


### PR DESCRIPTION
Currently it fails because containers are being detected via the `default` case, so they're being classified as containers.