### PR TITLE
Avoid panic when calling Elem on a nil map member.

### DIFF
--- a/ygot/struct_validation_map.go
+++ b/ygot/struct_validation_map.go
@@ -864,6 +864,10 @@ func copyMapField(dstField, srcField reflect.Value, accessPath string, opts ...M
 	errs.Separator = "\n"
 	for _, k := range srcField.MapKeys() {
 		v := srcField.MapIndex(k)
+		if v.IsNil() {
+			errs.Add(fmt.Errorf("map key %v, got nil value", k.Interface()))
+			continue
+		}
 		d := reflect.New(v.Elem().Type())
 		if _, ok := dstKeys[k.Interface()]; ok {
 			d = dstField.MapIndex(k)

--- a/ygot/struct_validation_map_test.go
+++ b/ygot/struct_validation_map_test.go
@@ -1617,6 +1617,15 @@ func TestCopyStruct(t *testing.T) {
 		wantDst: &copyTest{
 			StructMap: map[copyMapKey]*copyTest{},
 		},
+	}, {
+		name: "string map with explicit nil value",
+		inSrc: &copyTest{
+			StringMap: map[string]*copyTest{
+				"fish": nil,
+			},
+		},
+		inDst:   &copyTest{},
+		wantErr: true,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
 * (M) ygot/struct_validation_map(_test)?.go
   - if a map was received that had a nil value in it, this caused
     a panic to occur since `(reflect.Value).Elem()` does not handle
     these cases cleanly. Add a check whether the value is nil before
     calling Elem.
```
