### PR TITLE
Remove support for go 1.18.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18', '1.19', '1.20', '1.x']
+        go: ['1.19', '1.20', '1.21', '1.22', '1.x']
 
     steps:
       - name: Install protobuf


### PR DESCRIPTION
```
* (M) .github/workflows/go.yml
   - Remove testing support for go 1.18 -- these tests are failing
     based on dependencies. Our contract here is to support -3
     versions, so this is in-line with expecations of our consumers.
```

Fixes the failing CI @ HEAD.
