### PR TITLE
🐜: squash bug related to leaf-lists and shadow schemas.

### DIFF
--- a/util/reflect.go
+++ b/util/reflect.go
@@ -482,7 +482,7 @@ func ChildSchemaPreferShadow(schema *yang.Entry, f reflect.StructField) (*yang.E
 func childSchema(schema *yang.Entry, f reflect.StructField, preferShadowPath bool) (*yang.Entry, error) {
 	pathTag, _ := f.Tag.Lookup("path")
 	shadowPathTag, _ := f.Tag.Lookup("shadow-path")
-	DbgSchema("childSchema for schema %s, field %s, path tag %s, shadow-path tag\n", schema.Name, f.Name, pathTag, shadowPathTag)
+	DbgSchema("childSchema for schema %s, field %s, path tag %s, shadow-path tag %s\n", schema.Name, f.Name, pathTag, shadowPathTag)
 	p, err := relativeSchemaPath(f, preferShadowPath)
 	if err != nil {
 		return nil, err

--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -359,7 +359,7 @@ func unmarshalLeaf(inSchema *yang.Entry, parent interface{}, value interface{}, 
 
 	fieldName, _, err := schemaToStructFieldName(inSchema, parent, hasPreferShadowPath(opts))
 	if err != nil {
-		return err
+		return fmt.Errorf("unmarshal failed: %v", err)
 	}
 
 	schema, err := util.ResolveIfLeafRef(inSchema)

--- a/ytypes/schema_tests/set_test.go
+++ b/ytypes/schema_tests/set_test.go
@@ -15,8 +15,6 @@
 package validate
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -818,12 +816,4 @@ func TestSet(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestFish(t *testing.T) {
-	sch := mustSchema(opstateoc.Schema)
-	fmt.Printf("%+v\n", sch.SchemaTree["System_Dns"])
-
-	js, _ := json.MarshalIndent(sch.SchemaTree["System_Dns"], "", "  ")
-	fmt.Printf("%s\n", js)
 }

--- a/ytypes/util_schema.go
+++ b/ytypes/util_schema.go
@@ -324,6 +324,7 @@ func schemaToStructFieldName(schema *yang.Entry, parent interface{}, preferShado
 		if err != nil {
 			return "", nil, err
 		}
+
 		if hasRelativePath(schema, p) {
 			return fieldName, schema, nil
 		}


### PR DESCRIPTION
```
 * (M) util/reflect.go
   - Fix missing parameter to string output.
 * (M) ytypes/{leaf,node,node_test,schema_test,util_schema}.go
   - Two bugs fixed.
     1. In the case that one calls `SetNode` with something that was
        not a gNMI `TypedValue` and was not JSON, then we could panic
        when attempting to type cast it.
     2. If a schema was generated that uses path compression, and
        `SetNode` was called for a node that was compressed out, but
        `PreferShadowPaths` was not set AND this node was a leaf-list
        then rather than performing a no-op (the expected behaviour,
        since we asked to set a node that was not the 'preferred' thing
        to set), then we would bail with an error since the schema was
        not a leaf schema. Small fix, lots of testing to find the root
        cause here.
 * (M) ytypes/schema_test/set_test.go
   - Bug reproduction.
```
