### PR TITLE
feat: support for diffing presence containers

### DIFF
--- a/gogen/genir_test.go
+++ b/gogen/genir_test.go
@@ -1301,6 +1301,7 @@ func TestGenerateIR(t *testing.T) {
 					DefiningModule:            "openconfig-complex",
 					TelemetryAtomic:           true,
 					CompressedTelemetryAtomic: false,
+					PresenceContainer:         true,
 				},
 				"/openconfig-complex/model": {
 					Name:       "Model",

--- a/gogen/gogen.go
+++ b/gogen/gogen.go
@@ -841,6 +841,12 @@ func (t *{{ .ParentReceiver }}) To_{{ .Name }}(i interface{}) ({{ .Name }}, erro
 	]", i, i)
 }
 `)
+	// presenceMethodTemplate provides a template to output a method
+	// indicating this is a presence container
+	presenceMethodTemplate = mustMakeTemplate("presenceMethodTemplate", `
+// IsPresence returns nothing, but indicates that the receiver is a presence container. 
+func (t *{{ .StructName }}) IsPresence() {}
+`)
 )
 
 // writeGoHeader outputs the package header, including the package name and
@@ -1403,6 +1409,14 @@ func writeGoStruct(targetStruct *ygen.ParsedDirectory, goStructElements map[stri
 
 	if err := generateBelongingModuleFunction(&methodBuf, structDef); err != nil {
 		errs = append(errs, err)
+	}
+
+	if goOpts.AddYangPresence {
+		if targetStruct.PresenceContainer {
+			if err := presenceMethodTemplate.Execute(&methodBuf, structDef); err != nil {
+				errs = append(errs, err)
+			}
+		}
 	}
 
 	return GoStructCodeSnippet{

--- a/gogen/gogen.go
+++ b/gogen/gogen.go
@@ -841,10 +841,11 @@ func (t *{{ .ParentReceiver }}) To_{{ .Name }}(i interface{}) ({{ .Name }}, erro
 	]", i, i)
 }
 `)
-	// presenceMethodTemplate provides a template to output a method
-	// indicating this is a presence container
+	// presenceMethodTemplate provides a template to output a marker method
+	// indicating that the generated struct represents a YANG presence
+	// container, such that it implements the ygot.PresenceContainer interface.
 	presenceMethodTemplate = mustMakeTemplate("presenceMethodTemplate", `
-// IsPresence returns nothing, but indicates that the receiver is a presence container. 
+// IsPresence returns nothing, but indicates that the receiver is a presence container.
 func (t *{{ .StructName }}) IsPresence() {}
 `)
 )
@@ -1411,11 +1412,9 @@ func writeGoStruct(targetStruct *ygen.ParsedDirectory, goStructElements map[stri
 		errs = append(errs, err)
 	}
 
-	if goOpts.AddYangPresence {
-		if targetStruct.PresenceContainer {
-			if err := presenceMethodTemplate.Execute(&methodBuf, structDef); err != nil {
-				errs = append(errs, err)
-			}
+	if goOpts.AddYangPresence && targetStruct.PresenceContainer {
+		if err := presenceMethodTemplate.Execute(&methodBuf, structDef); err != nil {
+			errs = append(errs, err)
 		}
 	}
 

--- a/gogen/testdata/structs/presence-container-example.formatted-txt
+++ b/gogen/testdata/structs/presence-container-example.formatted-txt
@@ -154,7 +154,7 @@ func (*PresenceContainerExample_Parent_Child) ΛBelongingModule() string {
 	return "presence-container-example"
 }
 
-// IsPresence returns nothing, but indicates that the receiver is a presence container. 
+// IsPresence returns nothing, but indicates that the receiver is a presence container.
 func (t *PresenceContainerExample_Parent_Child) IsPresence() {}
 
 // PresenceContainerExample_Parent_Child_Config represents the /presence-container-example/parent/child/config YANG schema element.

--- a/gogen/testdata/structs/presence-container-example.formatted-txt
+++ b/gogen/testdata/structs/presence-container-example.formatted-txt
@@ -154,6 +154,9 @@ func (*PresenceContainerExample_Parent_Child) ΛBelongingModule() string {
 	return "presence-container-example"
 }
 
+// IsPresence returns nothing, but indicates that the receiver is a presence container. 
+func (t *PresenceContainerExample_Parent_Child) IsPresence() {}
+
 // PresenceContainerExample_Parent_Child_Config represents the /presence-container-example/parent/child/config YANG schema element.
 type PresenceContainerExample_Parent_Child_Config struct {
 	Four	Binary	`path:"four" module:"presence-container-example"`

--- a/protogen/genir_test.go
+++ b/protogen/genir_test.go
@@ -104,6 +104,7 @@ func protoIR(nestedDirectories bool) *ygen.IR {
 				DefiningModule:            "openconfig-complex",
 				TelemetryAtomic:           true,
 				CompressedTelemetryAtomic: false,
+				PresenceContainer:         true,
 			},
 			"/openconfig-complex/model": {
 				Name:       "Model",

--- a/ygen/directory.go
+++ b/ygen/directory.go
@@ -193,6 +193,16 @@ func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory
 			}
 		default:
 			pd.Type = Container
+			if len(dir.Entry.Extra["presence"]) > 0 {
+				if v := dir.Entry.Extra["presence"][0].(*yang.Value); v != nil {
+					pd.PresenceContainer = true
+				} else {
+					return nil, fmt.Errorf(
+						"unable to retrieve presence statement, expected non-nil *yang.Value, got %v",
+						dir.Entry.Extra["presence"][0],
+					)
+				}
+			}
 		}
 
 		for i, entry := 0, dir.Entry; ; i++ {

--- a/ygen/directory.go
+++ b/ygen/directory.go
@@ -193,15 +193,13 @@ func getOrderedDirDetails(langMapper LangMapper, directory map[string]*Directory
 			}
 		default:
 			pd.Type = Container
+			// TODO(https://github.com/openconfig/goyang/issues/286): update to use
+			// direct yang.Entry field once presence is natively supported in goyang.
 			if len(dir.Entry.Extra["presence"]) > 0 {
-				if v := dir.Entry.Extra["presence"][0].(*yang.Value); v != nil {
-					pd.PresenceContainer = true
-				} else {
-					return nil, fmt.Errorf(
-						"unable to retrieve presence statement, expected non-nil *yang.Value, got %v",
-						dir.Entry.Extra["presence"][0],
-					)
+				if v, ok := dir.Entry.Extra["presence"][0].(*yang.Value); !ok || v == nil {
+					return nil, fmt.Errorf("unable to retrieve presence statement, expected non-nil *yang.Value, got %v", dir.Entry.Extra["presence"][0])
 				}
+				pd.PresenceContainer = true
 			}
 		}
 

--- a/ygen/ir.go
+++ b/ygen/ir.go
@@ -468,6 +468,8 @@ type ParsedDirectory struct {
 	//
 	// https://github.com/openconfig/public/blob/master/release/models/openconfig-extensions.yang#L154
 	CompressedTelemetryAtomic bool
+	// PresenceContainer indicates that this container is a YANG presence container
+	PresenceContainer bool
 }
 
 // OrderedFieldNames returns the YANG name of all fields belonging to the

--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -444,7 +444,7 @@ type WithRespectPresenceContainers struct{}
 
 func (*WithRespectPresenceContainers) IsDiffOpt() {}
 
-// hasIgnoreAdditions returns the first IgnoreAdditions from an opts slice, or
+// hasRespectPresenceContainers returns the first WithRespectPresenceContainers from an opts slice, or
 // nil if there isn't one.
 func hasRespectPresenceContainers(opts []DiffOpt) *WithRespectPresenceContainers {
 	for _, o := range opts {

--- a/ygot/diff.go
+++ b/ygot/diff.go
@@ -339,10 +339,12 @@ func findSetLeaves(s GoStruct, orderedMapAsLeaf bool, opts ...DiffOpt) (map[*pat
 
 		outs := out.(map[*pathSpec]interface{})
 		if isYangPresence {
-			// If the current field is tagged as a presence container,
-			// we set it's value to `nil` instead of returning earlier.
-			// This is because empty presence containers has a meaning,
-			// unlike a normal container.
+			// The field is a presence container, so ival is a non-nil
+			// pointer to the container's struct. Its existence is
+			// meaningful in itself (unlike a normal container), so
+			// record the path with a nil value rather than the struct,
+			// which would otherwise be skipped above. Leaves within
+			// the container are still walked and recorded separately.
 			outs[vp] = nil
 		} else {
 			outs[vp] = ival
@@ -437,11 +439,18 @@ func hasIgnoreAdditions(opts []DiffOpt) *IgnoreAdditions {
 	return nil
 }
 
-// The RespectPresenceContainers DiffOpt indicates that presence containers
-// should be respected in the diff output.
-// This option was added to ensure we do not break backward compatibility.
+// WithRespectPresenceContainers is a DiffOpt that indicates that YANG presence
+// containers should be treated as values in the diff output. When set, a
+// presence container that exists in the modified struct but not the original
+// is emitted as an update with a nil value, and one that exists in the
+// original but not the modified struct is emitted as a delete of the
+// container path itself, in addition to any leaves within it.
+//
+// This is an opt-in behaviour to retain backwards compatibility with callers
+// that expect presence containers to be treated like ordinary containers.
 type WithRespectPresenceContainers struct{}
 
+// IsDiffOpt marks WithRespectPresenceContainers as a diff option.
 func (*WithRespectPresenceContainers) IsDiffOpt() {}
 
 // hasRespectPresenceContainers returns the first WithRespectPresenceContainers from an opts slice, or

--- a/ygot/render.go
+++ b/ygot/render.go
@@ -918,6 +918,11 @@ func marshalStructOrOrderedList(s any, enc gnmipb.Encoding, cfg *RFC7951JSONConf
 	if reflect.ValueOf(s).IsNil() {
 		return nil, nil
 	}
+	// A presence container might not be empty, but we should still
+	// treat it as such
+	if _, ok := s.(PresenceContainer); ok {
+		return nil, nil
+	}
 
 	var (
 		j     any

--- a/ygot/types.go
+++ b/ygot/types.go
@@ -19,6 +19,14 @@ import (
 	"reflect"
 )
 
+// PresenceContainer is an interface which can be implemented by Go structs that are
+// generated to represent a YANG presence container.
+type PresenceContainer interface {
+	// IsPresence is a marker method that indicates that the struct
+	// implements the PresenceContainer interface.
+	IsPresence()
+}
+
 // GoStruct is an interface which can be implemented by Go structs that are
 // generated to represent a YANG container or list member. It simply allows
 // handling code to ensure that it is interacting with a struct that will meet


### PR DESCRIPTION
Closes #936.

The implementation ended up being somewhat as described in #936, where we indicate that presence container has a `nil` value in the `findSetLeaves` function.   
In addition to this, we added a presence container interface, which is used in the `marshalStructOrOrderedList` to isolate the presence container which might have values, to act like an empty struct. 

The result is that we do not break any current tests (even without the diff option), but we decided to add a diff option, with the reasoning described in #936:

> Adding this as a non-optional, paired with `ygot.BuildEmptyTree` would also probably be breaking, as it would set all these presence containers?


We've confirmed this works in our setup. We're able to successfully configure all presence containers, even nested ones. 


Co-authored-by: Terje Lafton <terje@lafton.io>