### PR TITLE
Fix a bug in protoFromPathsInternal function in proto.go causing enca…

### DIFF
--- a/protomap/proto_test.go
+++ b/protomap/proto_test.go
@@ -1378,6 +1378,19 @@ func TestProtoFromPaths(t *testing.T) {
 			mustPath("/union"): "fish",
 		},
 		wantErrSubstring: `did not map path elem:{name:"union"}`,
+	}, {
+		desc:    "nested list with complex keys - preserve keys when trimming path",
+		inProto: &epb.Subinterface{},
+		inVals: map[*gpb.Path]any{
+			mustPath("config/description"): "subint-description",
+		},
+		inOpt: []UnmapOpt{
+			ProtobufMessagePrefix(mustPath("interfaces/interface/subinterfaces/subinterface")),
+			ValuePathPrefix(mustPath("interfaces/interface[name=eth0]/subinterfaces/subinterface[index=42]")),
+		},
+		wantProto: &epb.Subinterface{
+			Description: &wpb.StringValue{Value: "subint-description"},
+		},
 	}}
 
 	for _, tt := range tests {

--- a/util/gnmi.go
+++ b/util/gnmi.go
@@ -180,6 +180,9 @@ func TrimGNMIPathElemPrefix(path, prefix *gpb.Path) *gpb.Path {
 
 // GNMIPathToSchemaPath converts the path p into a schema path by removing all of the keys within the path.
 func GNMIPathToSchemaPath(p *gpb.Path) *gpb.Path {
+	if p == nil {
+		return nil
+	}
 	np := proto.Clone(p).(*gpb.Path)
 	for _, e := range np.Elem {
 		e.Key = nil
@@ -191,7 +194,7 @@ func GNMIPathToSchemaPath(p *gpb.Path) *gpb.Path {
 // Unlike TrimGNMIPathElemPrefix, this function compares paths as schema paths (without keys) to
 // determine the prefix relationship, which ensures correct handling when keys are present.
 func TrimGNMIPathElemPrefixKeyAware(path, prefix *gpb.Path) *gpb.Path {
-	if prefix == nil || len(prefix.Elem) == 0 || len(path.Elem) < len(prefix.Elem) {
+	if path == nil || prefix == nil || len(prefix.Elem) == 0 || len(path.Elem) < len(prefix.Elem) {
 		return path
 	}
 

--- a/util/gnmi.go
+++ b/util/gnmi.go
@@ -178,6 +178,31 @@ func TrimGNMIPathElemPrefix(path, prefix *gpb.Path) *gpb.Path {
 	return out
 }
 
+// GNMIPathToSchemaPath converts the path p into a schema path by removing all of the keys within the path.
+func GNMIPathToSchemaPath(p *gpb.Path) *gpb.Path {
+	np := proto.Clone(p).(*gpb.Path)
+	for _, e := range np.Elem {
+		e.Key = nil
+	}
+	return np
+}
+
+// TrimGNMIPathElemPrefixKeyAware trims the prefix from a path while properly handling keys.
+// Unlike TrimGNMIPathElemPrefix, this function compares paths as schema paths (without keys) to
+// determine the prefix relationship, which ensures correct handling when keys are present.
+func TrimGNMIPathElemPrefixKeyAware(path, prefix *gpb.Path) *gpb.Path {
+	if prefix == nil || len(prefix.Elem) == 0 || len(path.Elem) < len(prefix.Elem) {
+		return path
+	}
+
+	pathPrefix := &gpb.Path{Elem: path.Elem[:len(prefix.Elem)]}
+	if !proto.Equal(GNMIPathToSchemaPath(pathPrefix), GNMIPathToSchemaPath(prefix)) {
+		return path
+	}
+
+	return &gpb.Path{Elem: path.Elem[len(prefix.Elem):]}
+}
+
 // FindPathElemPrefix finds the longest common prefix of the paths specified.
 func FindPathElemPrefix(paths []*gpb.Path) *gpb.Path {
 	var prefix *gpb.Path


### PR DESCRIPTION
…psulation header details to be lost when mapping gNMI paths to protobuf fiedls.

Root cause: the issue stems from incorrect path construction when recursing into nested messages. Something like this will happen: "DEBUG: recursing into nested message gribi_aft.Afts.NextHop.EncapHeader.mpls, path: elem:{name:"afts"} elem:{name:"next-hops"} elem:{name:"next-hop"} elem:{name:"encap-headers"} elem:{name:"encap-header" key:{key:"index" value:"11"}} elem:{name:"afts"} elem:{name:"next-hops"} elem:{name:"next-hop"} elem:{name:"encap-headers"} elem:{name:"encap-header"} elem:{name:"mpls"}.

When findChilren uses these malformed paths to search for nested fields, it returns 0 children because no paths in the input map match this duplicated structure.