### PR TITLE
Add fields to IR and IROptions used by settting the path origin from the YANG module name or an specified name.

### DIFF
--- a/ygen/genir.go
+++ b/ygen/genir.go
@@ -53,6 +53,13 @@ type IROptions struct {
 	// to true.
 	// NOTE: This flag will be removed by v1 release.
 	AppendEnumSuffixForSimpleUnionEnums bool
+
+	// UseModuleNameAsPathOrigin specifies whether the YANG module name is
+	// set to the origin for generated gNMI paths when producing the IR.
+	UseModuleNameAsPathOrigin bool
+
+	// PathOriginName specifies the orign name for generated gNMI paths when producing the IR.
+	PathOriginName string
 }
 
 // GenerateIR creates the ygen intermediate representation for a set of
@@ -184,5 +191,7 @@ func GenerateIR(yangFiles, includePaths []string, langMapper LangMapper, opts IR
 		opts:          opts,
 		fakeroot:      rootEntry,
 		parsedModules: mdef.modules,
+		UseModuleNameAsPathOrigin: opts.UseModuleNameAsPathOrigin,
+		PathOriginName: opts.PathOriginName,		
 	}, nil
 }

--- a/ygen/ir.go
+++ b/ygen/ir.go
@@ -312,6 +312,9 @@ type IR struct {
 	// fakeroot stores the fake root's AST node for creating a serialized
 	// version of the AST if needed.
 	fakeroot *yang.Entry
+
+	UseModuleNameAsPathOrigin bool
+	PathOriginName string
 }
 
 // OrderedDirectoryPaths returns the absolute YANG paths of all ParsedDirectory


### PR DESCRIPTION
See [ygnmi PR154](https://github.com/openconfig/ygnmi/pull/154).

