### PR TITLE
Fix nil pointer error when using skip_obsolete with list keys

### DIFF
--- a/gogen/codegen_test.go
+++ b/gogen/codegen_test.go
@@ -1123,6 +1123,20 @@ func TestSimpleStructs(t *testing.T) {
 			},
 		},
 		wantStructsCodeFile: filepath.Join(TestRoot, "testdata/structs/presence-container-example.formatted-txt"),
+	}, {
+		name:    "skip obsolete list keys test",
+		inFiles: []string{filepath.Join(datapath, "skip-obsolete-test.yang")},
+		inConfig: CodeGenerator{
+			IROptions: ygen.IROptions{
+				TransformationOptions: ygen.TransformationOpts{
+					SkipObsolete: true,
+				},
+			},
+			GoOptions: GoOpts{
+				GenerateSimpleUnions: true,
+			},
+		},
+		wantErrSubstring: "did not find type for key obsolete-key",
 	}}
 
 	for _, tt := range tests {

--- a/gogen/unordered_list.go
+++ b/gogen/unordered_list.go
@@ -546,7 +546,10 @@ func generateGetListKey(buf *bytes.Buffer, s *ygen.ParsedDirectory, nameMap map[
 	sort.Strings(kn)
 
 	for _, k := range kn {
-		h.Keys = append(h.Keys, nameMap[k])
+		// Skip keys that don't exist in nameMap (e.g., when skip_obsolete is enabled)
+		if fieldMap, ok := nameMap[k]; ok {
+			h.Keys = append(h.Keys, fieldMap)
+		}
 	}
 
 	return goKeyMapTemplate.Execute(buf, h)

--- a/testdata/modules/skip-obsolete-test.yang
+++ b/testdata/modules/skip-obsolete-test.yang
@@ -1,0 +1,29 @@
+module skip-obsolete-test {
+  prefix "sot";
+  namespace "urn:sot";
+
+  container top {
+    list interfaces {
+      key "name obsolete-key";
+      
+      leaf name {
+        type string;
+        description "Interface name";
+      }
+      
+      leaf obsolete-key {
+        type string;
+        status obsolete;
+        description "Obsolete key that should be skipped";
+      }
+      
+      leaf admin-status {
+        type enumeration {
+          enum up;
+          enum down;
+        }
+        description "Administrative status";
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes a bug where using `skip_obsolete` or `skip_deprecated` flags causes a nil pointer dereference during code generation for YANG lists with obsolete keys (https://github.com/openconfig/ygot/pull/1037).

```
ERROR Generating GoStruct Code: template: keyHelper:4:37: executing "keyHelper" at <$key.IsPtr>: nil pointer evaluating *gogen.yangFieldMap.IsPtr
```

When `skip_obsolete` is enabled, obsolete fields are filtered out during IR generation in `getOrderedDirDetails`, removing them from `ParsedDirectory.Fields`. However, `ParsedDirectory.ListKeys` retains all keys (including obsolete ones) since it's populated earlier in `buildDirectoryDefinitions` (before filtering occurs).

```go
func GenerateIR(yangFiles, includePaths []string, langMapper LangMapper, opts IROptions) (*IR, error) {
  // ...
  mdef, errs := mappedDefinitions(yangFiles, includePaths, opts)
  if errs != nil {
    return nil, errs
  }
  // ...
  directoryMap, errs := buildDirectoryDefinitions(langMapper, mdef.directoryEntries, opts)
  if errs != nil {
    return nil, errs
  }
  // ... 
  dirDets, err := getOrderedDirDetails(langMapper, directoryMap, mdef.schematree, opts)
  if err != nil {
    return nil, util.AppendErr(errs, err)
  }
  // ..
}
```

This creates a mismatch when `writeGoStruct` calls `generateGetListKey`.

```go
func writeGoStruct(targetStruct *ygen.ParsedDirectory, goStructElements map[string]*ygen.ParsedDirectory, generatedUnions map[string]bool, goOpts GoOpts) (GoStructCodeSnippet, []error) {
  // ...

  for _, fName := range targetStruct.OrderedFieldNames() {
    var fieldDef *goStructField

    field := targetStruct.Fields[fName]
    fieldName := goFieldNameMap[fName]
    definedNameMap[fName] = &yangFieldMap{YANGName: fName, GoName: fieldName}
    // ...
  }
  
  // ...
  if err := generateGetListKey(&methodBuf, targetStruct, definedNameMap); err != nil {
    errs = append(errs, err)
  }
  // ...
}
```

`generateGetListKey` iterates over all keys in `ListKeys` but tries to access obsolete keys in `nameMap`, causing nil pointer dereference. `nameMap`/`definedNameMap` is built from filtered `Fields`, so it only contains non-obsolete keys, while `ListKeys` contains all keys, including obsolete ones.

```go
func generateGetListKey(buf *bytes.Buffer, s *ygen.ParsedDirectory, nameMap map[string]*yangFieldMap) error {
  // ...

  kn := []string{}
  for k := range s.ListKeys {
    kn = append(kn, k)
  }
  sort.Strings(kn)

  for _, k := range kn {
    // Skip keys that don't exist in nameMap (e.g., when skip_obsolete is enabled)
    if fieldMap, ok := nameMap[k]; ok {
      h.Keys = append(h.Keys, fieldMap)
    }
  }
  // ...
}
```

To fix this, I added a safety check in `generateGetListKey` to skip keys that don't exist in `nameMap`:

```go
for _, k := range kn {
  // Skip keys that don't exist in nameMap (e.g., when skip_obsolete is enabled)
  if fieldMap, ok := nameMap[k]; ok {
    h.Keys = append(h.Keys, fieldMap)
  }
}
```