### PR TITLE
escape backslash in key values in elemToString

### DIFF
--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -145,7 +145,8 @@ func elemToString(name string, kv map[string]string) (string, error) {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		v := strings.Replace(kv[k], `=`, `\=`, -1)
+		v := strings.Replace(kv[k], `\`, `\\`, -1)
+		v = strings.Replace(v, `=`, `\=`, -1)
 		v = strings.Replace(v, `]`, `\]`, -1)
 		name = fmt.Sprintf("%s[%s=%s]", name, k, v)
 	}

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -76,6 +76,12 @@ func TestPathToString(t *testing.T) {
 		}},
 		want: "/a[a=b]/b[c=d][e=f]/g",
 	}, {
+		name: "path with backslash in key value",
+		in: &gnmipb.Path{Elem: []*gnmipb.PathElem{
+			{Name: "a", Key: map[string]string{"k": `b\c`}},
+		}},
+		want: `/a[k=b\\c]`,
+	}, {
 		name: "structured path with empty element",
 		in: &gnmipb.Path{Elem: []*gnmipb.PathElem{
 			{Name: "a", Key: map[string]string{"a": "b"}},
@@ -218,7 +224,7 @@ func TestStringToPath(t *testing.T) {
 	}, {
 		name:                `name [name=[\\\]] example from specification`,
 		in:                  `/interfaces/interface[name=[\\\]]`,
-		wantStringSlicePath: &gnmipb.Path{Element: []string{"interfaces", `interface[name=[\\]]`}},
+		wantStringSlicePath: &gnmipb.Path{Element: []string{"interfaces", `interface[name=[\\\]]`}},
 		wantStructuredPath: &gnmipb.Path{
 			Elem: []*gnmipb.PathElem{
 				{Name: "interfaces"},


### PR DESCRIPTION
elemToString escapes = and ] in a PathElem key value but not the backslash that extractKV uses as its escape character, so the two disagree. A value like a\b serialized by PathToString re-parses to ab, and a trailing backslash lets one key absorb the next, so {k1:"a\", k2:"b"} round-trips to a single k1="a][k2=b]". Escape the backslash first so PathToString output round-trips through StringToStructuredPath.