### PR TITLE
use strings.Join in PathToString to preserve key values

### DIFF
--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	stdpath "path"
 	"sort"
 	"strings"
 
@@ -43,7 +42,7 @@ const (
 // representing the path. Path is always treated as absolute.
 func PathToString(path *gnmipb.Path) (string, error) {
 	s, err := PathToStrings(path)
-	return "/" + stdpath.Join(s...), err
+	return "/" + strings.Join(s, "/"), err
 }
 
 // PathToSchemaPath returns the supplied Path as its corresponding schema path.
@@ -66,7 +65,7 @@ func PathToSchemaPath(path *gnmipb.Path) (string, error) {
 			sp = append(sp, elem)
 		}
 		s, err := elementsToString(sp)
-		return "/" + stdpath.Join(s...), err
+		return "/" + strings.Join(s, "/"), err
 	}
 
 	var p []string
@@ -76,7 +75,7 @@ func PathToSchemaPath(path *gnmipb.Path) (string, error) {
 		}
 		p = append(p, e.Name)
 	}
-	return "/" + stdpath.Join(p...), nil
+	return "/" + strings.Join(p, "/"), nil
 }
 
 // PathToStrings takes a gNMI Path and provides its string representation. For example,

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -99,6 +99,20 @@ func TestPathToString(t *testing.T) {
 			}},
 		},
 		want: "/one/two/three", // should have the element type, not elem.
+	}, {
+		name: "key value with repeated slash is preserved",
+		in: &gnmipb.Path{Elem: []*gnmipb.PathElem{
+			{Name: "a", Key: map[string]string{"k": "x//y"}},
+			{Name: "b"},
+		}},
+		want: "/a[k=x//y]/b",
+	}, {
+		name: "key value with dot segments is preserved",
+		in: &gnmipb.Path{Elem: []*gnmipb.PathElem{
+			{Name: "a", Key: map[string]string{"k": "p/../q"}},
+			{Name: "b"},
+		}},
+		want: "/a[k=p/../q]/b",
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Caught this round-tripping random gNMI paths back through StringToStructuredPath. PathToString and PathToSchemaPath join elements with path.Join, which runs path.Clean: it collapses // and resolves .. inside key values, so intf[name=a/../b]/state comes out as b]/state and x//y silently becomes x/y. Join with strings.Join so the serialized path is left alone.