### PR TITLE
honor escapes inside keys in SplitPath

### DIFF
--- a/util/path.go
+++ b/util/path.go
@@ -401,6 +401,12 @@ func SplitPath(path string) []string {
 			inKey = true
 		case ch == ']' && !inEscape:
 			inKey = false
+		case ch == '\\' && !inEscape && inKey:
+			// Keep escapes inside keys intact for the key parser, but honor
+			// them here so an escaped ] does not prematurely end the key.
+			inEscape = true
+			buf.WriteRune(ch)
+			continue
 		case ch == '\\' && !inEscape && !inKey:
 			inEscape = true
 			continue

--- a/util/path_test.go
+++ b/util/path_test.go
@@ -1017,6 +1017,12 @@ func TestSplitPath(t *testing.T) {
 			want:                      []string{"a", `b[key1 = ../x/y key2 = "z"]`, "c"},
 			wantIgnoreLeadingTrailing: []string{"a", `b[key1 = ../x/y key2 = "z"]`, "c"},
 		},
+		{
+			desc:                      "escaped bracket then slash in key",
+			in:                        `a/b[k=x\]/y]/c`,
+			want:                      []string{"a", `b[k=x\]/y]`, "c"},
+			wantIgnoreLeadingTrailing: []string{"a", `b[k=x\]/y]`, "c"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
SplitPath treats / inside [...] as part of a key, but it ignored backslash escapes there, so an escaped ] cleared the in-key state and the next / was read as an element separator. PathToString escapes ] in key values but not /, so a key value containing ] followed by / no longer round-trips: StringToStructuredPath splits the element and errors, though extractKV parses it fine. Track escapes inside keys so the escaped ] keeps the key open, leaving the backslash for the key parser.