### PR TITLE
gnmidiff: remove trie dependency

### DIFF
--- a/gnmidiff/prefix.go
+++ b/gnmidiff/prefix.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmidiff
+
+import (
+	"slices"
+	"strings"
+)
+
+// prefixSearch returns the subsequence of paths (a sorted list)
+// consisting of elements that have path + "/" as a prefix.
+func prefixSearch(paths []string, path string) []string {
+	// BinarySearchFunc finds the first index in paths where element is >= target + "/".
+	start, _ := slices.BinarySearchFunc(paths, path, func(element, target string) int {
+		L := len(target)
+		if len(element) < L {
+			return strings.Compare(element, target)
+		}
+		if sub := strings.Compare(element[:L], target); sub != 0 {
+			return sub
+		}
+		if len(element) == L || element[L] < '/' {
+			return -1
+		}
+		return 1
+	})
+
+	end := start
+	for end < len(paths) &&
+		len(paths[end]) > len(path) &&
+		paths[end][len(path)] == '/' &&
+		strings.HasPrefix(paths[end], path) {
+		end++
+	}
+	return paths[start:end]
+}

--- a/gnmidiff/prefix_bench_test.go
+++ b/gnmidiff/prefix_bench_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmidiff
+
+import (
+	"fmt"
+	"testing"
+
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+func BenchmarkDiffSetRequest(b *testing.B) {
+	reqA := &gpb.SetRequest{}
+	reqB := &gpb.SetRequest{}
+
+	for i := 0; i < 100; i++ {
+		ethName := fmt.Sprintf("eth%d", i)
+		pathStr := fmt.Sprintf("/interfaces/interface[name=%s]/config/description", ethName)
+		reqA.Update = append(reqA.Update, &gpb.Update{
+			Path: ygot.MustStringToPath(pathStr),
+			Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: fmt.Sprintf("desc-%d", i)}},
+		})
+		reqB.Update = append(reqB.Update, &gpb.Update{
+			Path: ygot.MustStringToPath(pathStr),
+			Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: fmt.Sprintf("desc-%d", i)}},
+		})
+	}
+	for i := 0; i < 50; i++ {
+		ethName := fmt.Sprintf("eth%d", i)
+		pathStr := fmt.Sprintf("/interfaces/interface[name=%s]", ethName)
+		reqA.Delete = append(reqA.Delete, ygot.MustStringToPath(pathStr))
+		reqB.Delete = append(reqB.Delete, ygot.MustStringToPath(pathStr))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := DiffSetRequest(reqA, reqB, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDiffSetRequestToNotifications(b *testing.B) {
+	req := &gpb.SetRequest{}
+	for i := 0; i < 50; i++ {
+		ethName := fmt.Sprintf("eth%d", i)
+		pathStr := fmt.Sprintf("/interfaces/interface[name=%s]", ethName)
+		req.Delete = append(req.Delete, ygot.MustStringToPath(pathStr))
+	}
+
+	notifs := []*gpb.Notification{
+		{
+			Update: []*gpb.Update{},
+		},
+	}
+	for i := 0; i < 100; i++ {
+		ethName := fmt.Sprintf("eth%d", i)
+		for j := 0; j < 5; j++ {
+			pathStr := fmt.Sprintf("/interfaces/interface[name=%s]/subinterfaces/subinterface[index=%d]/config/description", ethName, j)
+			notifs[0].Update = append(notifs[0].Update, &gpb.Update{
+				Path: ygot.MustStringToPath(pathStr),
+				Val:  &gpb.TypedValue{Value: &gpb.TypedValue_StringVal{StringVal: fmt.Sprintf("sub-desc-%d", j)}},
+			})
+		}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := DiffSetRequestToNotifications(req, notifs, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/gnmidiff/prefix_test.go
+++ b/gnmidiff/prefix_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmidiff
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestPrefixSearch(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		path  string
+		want  []string
+	}{
+		{
+			name:  "empty paths",
+			paths: nil,
+			path:  "/a",
+			want:  nil,
+		},
+		{
+			name:  "exact match only - no children",
+			paths: []string{"/a"},
+			path:  "/a",
+			want:  nil,
+		},
+		{
+			name:  "children matching prefix",
+			paths: []string{"/a", "/a/b", "/a/b/c"},
+			path:  "/a",
+			want:  []string{"/a/b", "/a/b/c"},
+		},
+		{
+			name:  "similar prefix with hyphen not matched",
+			paths: []string{"/a", "/a-b", "/a/b", "/a/c", "/b"},
+			path:  "/a",
+			want:  []string{"/a/b", "/a/c"},
+		},
+		{
+			name:  "key attributes containing hyphen",
+			paths: []string{"/interfaces/interface[name=eth0]", "/interfaces/interface[name=eth0-0]", "/interfaces/interface[name=eth0]/config"},
+			path:  "/interfaces/interface[name=eth0]",
+			want:  []string{"/interfaces/interface[name=eth0]/config"},
+		},
+		{
+			name:  "no matches in list",
+			paths: []string{"/a", "/b", "/c"},
+			path:  "/d",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		slices.Sort(tt.paths)
+		t.Run(tt.name, func(t *testing.T) {
+			got := prefixSearch(tt.paths, tt.path)
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("prefixSearch(%v, %q) returned diff (-want +got):\n%s", tt.paths, tt.path, diff)
+			}
+		})
+	}
+}

--- a/gnmidiff/set_to_get.go
+++ b/gnmidiff/set_to_get.go
@@ -2,9 +2,10 @@ package gnmidiff
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 
-	"github.com/derekparker/trie"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/ygot/ytypes"
 )
@@ -82,13 +83,11 @@ func DiffSetRequestToNotifications(setreq *gpb.SetRequest, notifs []*gpb.Notific
 		delete(updates, pathA)
 	}
 
-	t := trie.New()
-	for pathB, vB := range updates {
-		t.Add(pathB, vB)
-	}
+	updatePaths := slices.Collect(maps.Keys(updates))
+	slices.Sort(updatePaths)
 	for delPath := range setIntent.Deletes {
 		// TODO: handle wildcards in delete paths (if applicable).
-		for _, extraPath := range t.PrefixSearch(delPath + "/") {
+		for _, extraPath := range prefixSearch(updatePaths, delPath) {
 			diff.ExtraUpdates[extraPath] = updates[extraPath]
 		}
 	}

--- a/gnmidiff/setrequest.go
+++ b/gnmidiff/setrequest.go
@@ -17,10 +17,11 @@ package gnmidiff
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"strings"
 
-	"github.com/derekparker/trie"
 	"github.com/openconfig/ygot/ygot"
 	"github.com/openconfig/ygot/ytypes"
 
@@ -122,8 +123,8 @@ func minimalSetRequestIntent(req *gpb.SetRequest, schema *ytypes.Schema) (setReq
 		Deletes: map[string]struct{}{},
 		Updates: map[string]interface{}{},
 	}
-	// NOTE: This simple trie will not work if we intend to check conflicts with wildcard deletion paths.
-	t := trie.New()
+	// NOTE: This simple prefix match will not work if we intend to check conflicts with wildcard deletion paths.
+	deletePaths := make([]string, 0, len(req.Delete)+len(req.Replace))
 	for _, gPath := range req.Delete {
 		path, err := fullPathStr(prefix, gPath)
 		if err != nil {
@@ -133,7 +134,7 @@ func minimalSetRequestIntent(req *gpb.SetRequest, schema *ytypes.Schema) (setReq
 			return setRequestIntent{}, fmt.Errorf("gnmidiff: conflicting replaces in SetRequest: %v", path)
 		}
 		intent.Deletes[path] = struct{}{}
-		t.Add(path, nil)
+		deletePaths = append(deletePaths, path)
 	}
 	for _, upd := range req.Replace {
 		path, err := fullPathStr(prefix, upd.Path)
@@ -144,16 +145,17 @@ func minimalSetRequestIntent(req *gpb.SetRequest, schema *ytypes.Schema) (setReq
 			return setRequestIntent{}, fmt.Errorf("gnmidiff: conflicting replaces in SetRequest: %v", path)
 		}
 		intent.Deletes[path] = struct{}{}
-		t.Add(path, nil)
+		deletePaths = append(deletePaths, path)
 
 		if err := intent.populateUpdate(path, upd.GetVal(), schema, true); err != nil {
 			return setRequestIntent{}, err
 		}
 	}
 
+	slices.Sort(deletePaths)
 	// Do prefix match to check for conflicting replace paths.
-	for _, path := range t.Keys() {
-		if matches := t.PrefixSearch(path + "/"); len(matches) >= 1 {
+	for _, path := range deletePaths {
+		if matches := prefixSearch(deletePaths, path); len(matches) >= 1 {
 			return setRequestIntent{}, fmt.Errorf("gnmidiff: conflicting replaces in SetRequest: %v, %v", path, matches)
 		}
 	}
@@ -169,14 +171,11 @@ func minimalSetRequestIntent(req *gpb.SetRequest, schema *ytypes.Schema) (setReq
 		}
 	}
 
-	t = trie.New()
-	for path := range intent.Updates {
-		t.Add(path, nil)
-	}
-
 	// Do prefix match to check for conflicting update paths.
-	for _, path := range t.Keys() {
-		if matches := t.PrefixSearch(path + "/"); len(matches) >= 1 {
+	updatePaths := slices.Collect(maps.Keys(intent.Updates))
+	slices.Sort(updatePaths)
+	for _, path := range updatePaths {
+		if matches := prefixSearch(updatePaths, path); len(matches) >= 1 {
 			return setRequestIntent{}, fmt.Errorf("gnmidiff: bad SetRequest, there are leaf updates that have a prefix match: %v, %v", path, matches)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 toolchain go1.25.3
 
 require (
-	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d
 	github.com/golang/glog v1.2.5
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d h1:hUWoLdw5kvo2xCsqlsIBMvWUc1QCSsCYD2J2+Fg6YoU=
-github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d/go.mod h1:C7Es+DLenIpPc9J6IYw4jrK0h7S9bKj4DNl8+KxGEXU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
This change replaces the dependency on Derek Parker's trie
package with a naive (yet much faster) implementation.

Fixes #1088
