### PR TITLE
reject unterminated key predicates in extractKV

### DIFF
--- a/ygot/pathstrings.go
+++ b/ygot/pathstrings.go
@@ -294,6 +294,14 @@ func extractKV(in string) (string, map[string]string, error) {
 		inEscape = false
 	}
 
+	if inKey {
+		return "", nil, fmt.Errorf("received an unterminated key in element %s", in)
+	}
+
+	if inEscape {
+		return "", nil, fmt.Errorf("received a trailing escape character in element %s", in)
+	}
+
 	if len(keys) == 0 {
 		name = buf.String()
 	}

--- a/ygot/pathstrings_test.go
+++ b/ygot/pathstrings_test.go
@@ -358,6 +358,16 @@ func TestStringToPath(t *testing.T) {
 		wantSliceErr:      "received an unescaped [ in key of element bar",
 		wantStructuredErr: "received an unescaped [ in key of element bar",
 	}, {
+		name:              "unterminated key",
+		in:                `/foo/bar[baz=bat`,
+		wantSliceErr:      "received an unterminated key in element bar[baz=bat",
+		wantStructuredErr: "received an unterminated key in element bar[baz=bat",
+	}, {
+		name:              "unterminated key with escaped ]",
+		in:                `/foo/bar[baz=bat\]`,
+		wantSliceErr:      `received an unterminated key in element bar[baz=bat\]`,
+		wantStructuredErr: `received an unterminated key in element bar[baz=bat\]`,
+	}, {
 		name:              "element with unescaped ]",
 		in:                `/foo/bar]`,
 		wantSliceErr:      "received an unescaped ] when not in a key for element bar",
@@ -485,6 +495,18 @@ func TestPathToSchemaPath(t *testing.T) {
 			Element: []string{"interfaces", "interface[name=eth0]", "config", "description"},
 		},
 		want: "/interfaces/interface/config/description",
+	}, {
+		name: "element path with an unterminated predicate",
+		inPath: &gnmipb.Path{
+			Element: []string{"interfaces", "interface[name=eth0"},
+		},
+		wantErrSubstring: "received an unterminated key in element interface[name=eth0",
+	}, {
+		name: "element path with a trailing escape character",
+		inPath: &gnmipb.Path{
+			Element: []string{"interfaces", `interface\`},
+		},
+		wantErrSubstring: `received a trailing escape character in element interface\`,
 	}, {
 		name: "elem path with no keys",
 		inPath: &gnmipb.Path{


### PR DESCRIPTION
extractKV doesn't check whether it is still inside a [key=value] predicate when the input runs out, so an element with a dangling predicate is silently mis-parsed rather than rejected: the element name is discarded and the trailing key value takes its place. StringToStructuredPath(`/a/b[k=c`) returns /a/c with no error, and PathToSchemaPath on a deprecated Element of `a[b=c` returns /c, so code that string-checks a path before converting it can end up resolving a different node than the one it inspected. Same story for a trailing escape character, where the backslash is just dropped.

This errors on both cases at the end of extractKV, with test cases covering the string and Element forms.