### PR TITLE
reject non-object list elements in unmarshalList

### DIFF
--- a/ytypes/list.go
+++ b/ytypes/list.go
@@ -348,7 +348,10 @@ func unmarshalList(schema *yang.Entry, parent interface{}, jsonList interface{},
 	// in the new list element.
 	for _, le := range jl {
 		var err error
-		jt := le.(map[string]interface{})
+		jt, ok := le.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unmarshalList for schema %s: got list element type %T, expect map[string]interface{}", schema.Name, le)
+		}
 		newVal := reflect.New(listElementType.Elem())
 		util.DbgPrint("creating a new list element val of type %v", newVal.Type())
 		if err := unmarshalStruct(schema, newVal.Interface(), jt, enc, opts...); err != nil {

--- a/ytypes/list_test.go
+++ b/ytypes/list_test.go
@@ -496,6 +496,12 @@ func TestUnmarshalUnkeyedList(t *testing.T) {
 			json:    `{"struct-list" : { "leaf-field" : 42 } }`,
 			wantErr: `unmarshalList for schema struct-list: jsonList map[leaf-field:42] (map): got type map[string]interface {}, expect []interface{}`,
 		},
+		{
+			desc:    "list element is not an object",
+			schema:  containerWithLeafListSchema,
+			json:    `{"struct-list" : [ 42 ] }`,
+			wantErr: `unmarshalList for schema struct-list: got list element type float64, expect map[string]interface{}`,
+		},
 	}
 
 	var jsonTree interface{}


### PR DESCRIPTION
guard the per-element type assertion in unmarshalList so a schema list whose JSON array holds a scalar returns an error instead of panicking, matching the non-object handling unmarshalContainer already does.