### PR TITLE
reject non-finite decimal64 values on unmarshal

### DIFF
--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -17,6 +17,7 @@ package ytypes
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -741,6 +742,9 @@ func sanitizeJSON(parent interface{}, schema *yang.Entry, fieldName string, valu
 		floatV, err := strconv.ParseFloat(value.(string), 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %v for schema %s: %v", value, schema.Name, err)
+		}
+		if math.IsInf(floatV, 0) || math.IsNaN(floatV) {
+			return nil, fmt.Errorf("error parsing %v for schema %s: decimal64 value must be finite", value, schema.Name)
 		}
 
 		return floatV, nil

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -1380,6 +1380,16 @@ func TestUnmarshalLeafJSONEncoding(t *testing.T) {
 			wantErr: `error parsing forty-two for schema decimal-leaf: strconv.ParseFloat: parsing "forty-two": invalid syntax`,
 		},
 		{
+			desc:    "decimal NaN",
+			json:    `{"decimal-leaf" : "NaN"}`,
+			wantErr: `error parsing NaN for schema decimal-leaf: decimal64 value must be finite`,
+		},
+		{
+			desc:    "decimal Inf",
+			json:    `{"decimal-leaf" : "Inf"}`,
+			wantErr: `error parsing Inf for schema decimal-leaf: decimal64 value must be finite`,
+		},
+		{
 			desc: "empty valid type",
 			json: `{"empty-leaf": [null]}`,
 			want: LeafContainerStruct{EmptyLeaf: true},

--- a/ytypes/util_test.go
+++ b/ytypes/util_test.go
@@ -683,6 +683,13 @@ func TestStringToKeyType(t *testing.T) {
 		in:               "I am a float?",
 		wantErrSubstring: "unable to convert",
 	}, {
+		name:             "invalid: non-finite float",
+		inSchema:         listSchema.Dir["decimal64Key"],
+		inParent:         &allKeysListStruct{},
+		inFieldName:      "Decimal64Key",
+		in:               "Inf",
+		wantErrSubstring: "value must be finite",
+	}, {
 		name:             "invalid: too big for int8",
 		inSchema:         listSchema.Dir["int8Key"],
 		inParent:         &allKeysListStruct{},

--- a/ytypes/util_types.go
+++ b/ytypes/util_types.go
@@ -17,6 +17,7 @@ package ytypes
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 
@@ -273,6 +274,9 @@ func stringToKeyType(schema *yang.Entry, parent interface{}, fieldName string, v
 		floatV, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return reflect.ValueOf(nil), fmt.Errorf("unable to convert %q to %v: %v", value, ykind, err)
+		}
+		if math.IsInf(floatV, 0) || math.IsNaN(floatV) {
+			return reflect.ValueOf(nil), fmt.Errorf("unable to convert %q to %v: value must be finite", value, ykind)
 		}
 		return reflect.ValueOf(floatV), nil
 	case yang.Yenum, yang.Yidentityref:


### PR DESCRIPTION
sanitizeJSON and stringToKeyType parse a decimal64 leaf/key from an untrusted JSON string with strconv.ParseFloat, which happily accepts NaN, Inf and Infinity, so Unmarshal stores a non-finite float64 for a leaf whose schema can never hold one. That value then cannot be round-tripped back out since encoding/json rejects NaN and Inf, and a stored NaN quietly breaks equality and diffing. Reject a non-finite result at both parse sites so the value is turned away where it enters rather than surfacing much later.