### PR TITLE
reject out-of-range decimal64 precision in sanitizeGNMI

### DIFF
--- a/ytypes/leaf.go
+++ b/ytypes/leaf.go
@@ -835,6 +835,13 @@ func sanitizeGNMI(parent interface{}, schema *yang.Entry, fieldName string, tv *
 			if v.DecimalVal == nil {
 				return nil, fmt.Errorf("received DecimalVal is nil -- this is invalid")
 			}
+			// A YANG decimal64 has at most 18 fraction digits, so a larger
+			// precision is invalid. Reject it before the exponentiation below,
+			// which otherwise builds an unbounded big.Int from the untrusted
+			// Precision field.
+			if p := v.DecimalVal.Precision; p > 18 {
+				return nil, fmt.Errorf("decimal64 precision %d is out of range, must be at most 18", p)
+			}
 			prec := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(v.DecimalVal.Precision)), nil)
 			// Second return value indicates whether returned float64 value exactly
 			// represents the division. We don't want to fail unmarshalling as float64

--- a/ytypes/leaf_test.go
+++ b/ytypes/leaf_test.go
@@ -2096,6 +2096,17 @@ func TestUnmarshalLeafGNMIEncoding(t *testing.T) {
 			wantVal: &LeafContainerStruct{DecimalLeaf: ygot.Float64(0.42)},
 		},
 		{
+			desc:     "fail gNMI Decimal64 with out-of-range precision",
+			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
+			inVal: &gpb.TypedValue{
+				Value: &gpb.TypedValue_DecimalVal{
+					//lint:ignore SA1019 We still need to tolerate unmarshalling decimal_val and float_val.
+					DecimalVal: &gpb.Decimal64{Digits: 42, Precision: 19},
+				},
+			},
+			wantErr: "decimal64 precision 19 is out of range",
+		},
+		{
 			desc:     "fail gNMI nil Decimal64 value",
 			inSchema: typeToLeafSchema("decimal-leaf", yang.Ydecimal64),
 			inVal: &gpb.TypedValue{


### PR DESCRIPTION
sanitizeGNMI decodes a gNMI Decimal64 by raising 10 to the power of Precision, a uint32 read straight from the untrusted value with no upper bound. A YANG decimal64 has at most 18 fraction digits, so a message that sets a decimal64 leaf with a large Precision makes big.Int.Exp build a multi-gigabyte integer (Precision=20,000,000 already costs 2.3s and 227MB, and the uint32 max is far worse). Reject any Precision above 18 before the exponentiation, matching the nil check already right above it.